### PR TITLE
fix(router): compare the number of columns when adding sharding rule

### DIFF
--- a/router/pkg/qrouter/proxy.go
+++ b/router/pkg/qrouter/proxy.go
@@ -215,7 +215,7 @@ func (qr *ProxyRouter) ListKeyRanges(ctx context.Context) ([]*kr.KeyRange, error
 }
 
 func (qr *ProxyRouter) AddShardingRule(ctx context.Context, rule *shrule.ShardingRule) error {
-	if len(rule.Columns()) != 0 {
+	if len(rule.Columns()) != 1 {
 		return xerrors.New("only single column sharding rules are supported for now")
 	}
 


### PR DESCRIPTION
Fix the bug on comparing the length of columns slice when adding sharding rule for proxy router