### PR TITLE
Draft: worldmock: reuse port to process to both Listen and Dial to fix e2e tests

### DIFF
--- a/test/worldmock/worldmock.go
+++ b/test/worldmock/worldmock.go
@@ -6,10 +6,11 @@ import (
 	"os"
 
 	"github.com/jackc/pgproto3/v2"
+	"github.com/wal-g/tracelog"
+
 	"github.com/pg-sharding/spqr/pkg/config"
 	"github.com/pg-sharding/spqr/pkg/conn"
 	"github.com/pg-sharding/spqr/router/pkg/client"
-	"github.com/wal-g/tracelog"
 )
 
 type WorldMock struct {
@@ -20,8 +21,7 @@ func (w *WorldMock) Run() error {
 
 	ctx := context.Background()
 
-
-	listener, err := net.Listen("tcp6", "[::1]:5433")
+	listener, err := net.Listen("tcp", w.addr)
 	if err != nil {
 		tracelog.ErrorLogger.PrintError(err)
 		return err
@@ -96,7 +96,7 @@ func (w *WorldMock) serv(netconn net.Conn) error {
 		switch v := msg.(type) {
 		case *pgproto3.Parse:
 			tracelog.InfoLogger.Printf("received prep stmt %v %v", v.Name, v.Query)
-			break;
+			break
 		case *pgproto3.Query:
 
 			tracelog.InfoLogger.Printf("received message %v", v.String)

--- a/test/worldmock/worldmock.go
+++ b/test/worldmock/worldmock.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/jackc/pgproto3/v2"
+	reuse "github.com/libp2p/go-reuseport"
 	"github.com/wal-g/tracelog"
 
 	"github.com/pg-sharding/spqr/pkg/config"
@@ -21,7 +22,7 @@ func (w *WorldMock) Run() error {
 
 	ctx := context.Background()
 
-	listener, err := net.Listen("tcp", w.addr)
+	listener, err := reuse.Listen("tcp", w.addr)
 	if err != nil {
 		tracelog.ErrorLogger.PrintError(err)
 		return err


### PR DESCRIPTION
Fix e2e tests:
- reuse port to process to both Listen and Dial
- use the `tcp` network by default
- use configurable address
- format code