### PR TITLE
fix: add a mock router to avoid panic in the coordinator client process

### DIFF
--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -5,6 +5,10 @@ import (
 	"net"
 
 	"github.com/jackc/pgproto3/v2"
+	"github.com/wal-g/tracelog"
+	"golang.org/x/xerrors"
+	"google.golang.org/grpc"
+
 	"github.com/pg-sharding/spqr/coordinator"
 	"github.com/pg-sharding/spqr/pkg/config"
 	"github.com/pg-sharding/spqr/pkg/conn"
@@ -14,11 +18,10 @@ import (
 	"github.com/pg-sharding/spqr/router/grpcclient"
 	router "github.com/pg-sharding/spqr/router/pkg"
 	psqlclient "github.com/pg-sharding/spqr/router/pkg/client"
+	"github.com/pg-sharding/spqr/router/pkg/datashard"
+	"github.com/pg-sharding/spqr/router/pkg/route"
 	routerproto "github.com/pg-sharding/spqr/router/protos"
 	spqrparser "github.com/pg-sharding/spqr/yacc/console"
-	"github.com/wal-g/tracelog"
-	"golang.org/x/xerrors"
-	"google.golang.org/grpc"
 )
 
 type routerConn struct {
@@ -168,7 +171,10 @@ func (qc *qdbCoordinator) ProcClient(ctx context.Context, nconn net.Conn) error 
 		return err
 	}
 
-	if err := cl.Auth(nil); err != nil {
+	r := route.NewRoute(nil, nil, nil)
+	r.SetParams(datashard.ParameterSet{})
+
+	if err := cl.Auth(r); err != nil {
 		return err
 	}
 	tracelog.InfoLogger.Printf("client auth OK")


### PR DESCRIPTION
Fixed panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
spqr-coordinator-1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x8cd99e]
spqr-coordinator-1  | 
spqr-coordinator-1  | goroutine 67 [running]:
spqr-coordinator-1  | github.com/pg-sharding/spqr/router/pkg/route.(*Route).Params(0x0)
spqr-coordinator-1  | 	/home/go/src/github.com/pg-sharding/spqr/router/pkg/route/route.go:59 +0x5e
spqr-coordinator-1  | github.com/pg-sharding/spqr/router/pkg/client.(*PsqlClient).Auth(0xc0005b8db8, 0xda0f26?)
spqr-coordinator-1  | 	/home/go/src/github.com/pg-sharding/spqr/router/pkg/client/client.go:511 +0x30a
spqr-coordinator-1  | github.com/pg-sharding/spqr/coordinator/provider.(*qdbCoordinator).ProcClient(0xc00007e140?, {0xeb1430, 0xc000038040}, {0xeb3d70, 0xc0003a0000})
spqr-coordinator-1  | 	/home/go/src/github.com/pg-sharding/spqr/coordinator/provider/coordinator.go:351 +0x306
spqr-coordinator-1  | github.com/pg-sharding/spqr/coordinator/app.(*App).ServePsql(0xc000592020, 0x0?)
spqr-coordinator-1  | 	/home/go/src/github.com/pg-sharding/spqr/coordinator/app/app.go:63 +0x1ea
spqr-coordinator-1  | github.com/pg-sharding/spqr/coordinator/app.(*App).Run.func2(0x0?)
spqr-coordinator-1  | 	/home/go/src/github.com/pg-sharding/spqr/coordinator/app/app.go:40 +0x35
spqr-coordinator-1  | created by github.com/pg-sharding/spqr/coordinator/app.(*App).Run
spqr-coordinator-1  | 	/home/go/src/github.com/pg-sharding/spqr/coordinator/app/app.go:39 +0x18d
```