### PR TITLE
Add target-session-attrs option to shard config

### DIFF
--- a/config-example/1shardproxy.toml
+++ b/config-example/1shardproxy.toml
@@ -32,7 +32,6 @@ usr = "opgejrqr"
 pwd = "RJj7-J717NALMmU4As0umiYwYn7wgAOk"
 type = "DATA"
 hosts = [ "dumbo.db.elephantsql.com:5432" ]
-
   [shards.sh1.tls]
   sslmode = "disable"
   cert_file = "/etc/odyssey/ssl/server.crt"

--- a/config-example/2shardproxy.yaml
+++ b/config-example/2shardproxy.yaml
@@ -59,5 +59,7 @@ shards:
     usr: user1
     pwd: 12345678
     type: DATA
+    target_session_attrs: "read-write"
     hosts:
       - 'localhost:5551'
+      - 'localhost:5432'

--- a/config-example/localrouter.yaml
+++ b/config-example/localrouter.yaml
@@ -1,4 +1,4 @@
-log_level: DEBUG2
+log_level: DEBUG5
 
 host: '::1'
 router_port: '6432'
@@ -46,5 +46,7 @@ shards:
     usr: user1
     pwd: 12345678
     type: DATA
+    target_session_attrs: "read-write"
     hosts:
-      - 'localhost:5550'
+      - 'localhost:5551'
+      - 'localhost:5432'

--- a/pkg/config/router.go
+++ b/pkg/config/router.go
@@ -64,13 +64,20 @@ type FrontendRule struct {
 	PoolDefault           bool     `json:"pool_default" yaml:"pool_default" toml:"pool_default"`
 }
 
+const (
+	TargetSessionAttrsRW  = "read-write"
+	TargetSessionAttrsRO  = "read-only"
+	TargetSessionAttrsAny = "any"
+)
+
 type Shard struct {
-	DB    string     `json:"db" toml:"db" yaml:"db"`
-	Usr   string     `json:"usr" toml:"usr" yaml:"usr"`
-	Pwd   string     `json:"pwd" toml:"pwd" yaml:"pwd"`
-	Hosts []string   `json:"hosts" toml:"hosts" yaml:"hosts"`
-	Type  ShardType  `json:"type" toml:"type" yaml:"type"`
-	TLS   *TLSConfig `json:"tls" yaml:"tls" toml:"tls"`
+	DB                 string     `json:"db" toml:"db" yaml:"db"`
+	Usr                string     `json:"usr" toml:"usr" yaml:"usr"`
+	Pwd                string     `json:"pwd" toml:"pwd" yaml:"pwd"`
+	TargetSessionAttrs string     `json:"target_session_attrs" toml:"target_session_attrs" yaml:"target_session_attrs"`
+	Hosts              []string   `json:"hosts" toml:"hosts" yaml:"hosts"`
+	Type               ShardType  `json:"type" toml:"type" yaml:"type"`
+	TLS                *TLSConfig `json:"tls" yaml:"tls" toml:"tls"`
 }
 
 var cfgRouter Router

--- a/router/pkg/instance.go
+++ b/router/pkg/instance.go
@@ -45,7 +45,6 @@ func (r *InstanceImpl) Initialized() bool {
 var _ Router = &InstanceImpl{}
 
 func NewRouter(ctx context.Context) (*InstanceImpl, error) {
-
 	// qrouter init
 	qtype := config.RouterMode(config.RouterConfig().RouterMode)
 	spqrlog.Logger.Printf(spqrlog.DEBUG1, "creating QueryRouter with type %s", qtype)

--- a/router/pkg/qrouter/local.go
+++ b/router/pkg/qrouter/local.go
@@ -46,6 +46,14 @@ func NewLocalQrouter(shardMapping map[string]*config.Shard) (*LocalQrouter, erro
 	return l, nil
 }
 
+func (l *LocalQrouter) Initialize() bool {
+	return true
+}
+
+func (l *LocalQrouter) Initialized() bool {
+	return true
+}
+
 func (l *LocalQrouter) AddDataShard(_ context.Context, ds *datashards.DataShard) error {
 	spqrlog.Logger.Printf(spqrlog.DEBUG5, "adding node %s", ds.ID)
 	l.ds = ds


### PR DESCRIPTION
Implement target session attrs option and policies
for backend connections. Now ew can specify in shard`s
config to match replica/primary hosts while acquiring
new connections