### PR TITLE
FYI: experiment with postgres regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ build_images:
 test: build_images
 	docker-compose up --remove-orphans --exit-code-from client --build router coordinator world1 shard1 shard2 qdb01 client 
 
+make installcheck: build_images
+	docker-compose -f test/installcheck/docker-compose.yml up --remove-orphans --exit-code-from installcheck --build router shard installcheck
+
 stress: build_images
 	docker-compose up -d --remove-orphans --build router coordinator world1 shard1 shard2 qdb01
 	docker-compose build client

--- a/docker/router/Dockerfile
+++ b/docker/router/Dockerfile
@@ -1,3 +1,3 @@
 FROM spqr_spqrbase
 
-ENTRYPOINT /spqr/spqr-router run -c /spqr/docker/router/cfg.yaml
+ENTRYPOINT /spqr/spqr-router run -c ${SPQR_CONFIG=/spqr/docker/router/cfg.yaml}

--- a/test/installcheck/Dockerfile
+++ b/test/installcheck/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+COPY --from=networld/grpcurl /grpcurl /usr/bin/
+WORKDIR /build
+RUN apt-get update && apt-get install -y --no-install-recommends wget vim git build-essential ca-certificates \
+    libreadline-dev zlib1g-dev bison flex postgresql postgresql-contrib
+RUN git clone -b REL_13_STABLE --single-branch https://github.com/postgres/postgres.git
+
+WORKDIR /build/postgres
+RUN ./configure && make
+RUN mkdir -p /usr/local/pgsql/bin/ && ln -s /usr/bin/psql /usr/local/pgsql/bin/psql
+
+ENV LANG=C.UTF-8 PGHOST=installcheck_router_1 PGPORT=6432 PGSSLMODE=disable BUILDKIT_PROGRESS=plain
+RUN chmod -R go+rwX /build
+USER postgres
+CMD ["make", "installcheck"]

--- a/test/installcheck/docker-compose.yml
+++ b/test/installcheck/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3'
+
+services:
+    shard:
+        image: postgres:13-alpine
+        environment:
+          - POSTGRES_USER=postgres
+          - POSTGRES_DB=regression
+          - POSTGRES_HOST_AUTH_METHOD=trust
+        hostname: installcheck_shard_1
+        ports:
+            - "5432:5432"
+    router:
+        build:
+            dockerfile: ./docker/router/Dockerfile
+            context: ../../
+        ports:
+            - "6432:6432"
+        environment:
+          - SPQR_CONFIG=/spqr/test/installcheck/router.yaml
+        hostname: installcheck_router_1
+        depends_on:
+          - "shard"
+    installcheck:
+        build:
+            context: .
+        hostname: installcheck_installcheck
+        depends_on:
+          - "router"

--- a/test/installcheck/router.yaml
+++ b/test/installcheck/router.yaml
@@ -1,0 +1,34 @@
+host: 'installcheck_router_1'
+router_port: '6432'
+admin_console_port: '7432'
+grpc_api_port: '7000'
+router_mode: PROXY
+frontend_rules:
+  - db: regression
+    usr: postgres
+    pool_mode: SESSION
+    auth_rule:
+      auth_method: ok
+  - db: postgres
+    usr: postgres
+    pool_mode: SESSION
+    auth_rule:
+      auth_method: ok
+world_shard_fallback: true
+shards:
+  sh1:
+    db: regression
+    usr: postgres
+    pwd: 12345678
+    type: DATA
+    hosts:
+      - 'installcheck_shard_1:5432'
+backend_rules:
+  - db: regression
+    usr: postgres
+    pool_discard: true
+    pool_rollback: true
+  - db: postgres
+    usr: postgres
+    pool_discard: true
+    pool_rollback: true


### PR DESCRIPTION
My idea was to up one-shard SPQR installation and run Postgresql regression tests against the router. I ran into several problems:

- There are indeed a lot of tests.
- Before every test, I should set up sharding rules cause there are a lot of test tables.
- SPQR does not support yet a lot of queries that should be run on every shard. 

```
➜  installcheck git:(postgres-regression-tests) ✗ docker-compose up installcheck
installcheck_shard_1 is up-to-date
installcheck_router_1 is up-to-date
Starting installcheck_installcheck_1 ... done
Attaching to installcheck_installcheck_1
installcheck_1  | make -C ./src/backend generated-headers
installcheck_1  | make[1]: Entering directory '/build/postgres/src/backend'
installcheck_1  | make -C catalog distprep generated-header-symlinks
installcheck_1  | make[2]: Entering directory '/build/postgres/src/backend/catalog'
installcheck_1  | make[2]: Nothing to be done for 'distprep'.
installcheck_1  | make[2]: Nothing to be done for 'generated-header-symlinks'.
installcheck_1  | make[2]: Leaving directory '/build/postgres/src/backend/catalog'
installcheck_1  | make -C utils distprep generated-header-symlinks
installcheck_1  | make[2]: Entering directory '/build/postgres/src/backend/utils'
installcheck_1  | make[2]: Nothing to be done for 'distprep'.
installcheck_1  | make[2]: Nothing to be done for 'generated-header-symlinks'.
installcheck_1  | make[2]: Leaving directory '/build/postgres/src/backend/utils'
installcheck_1  | make[1]: Leaving directory '/build/postgres/src/backend'
installcheck_1  | make -C src/test/regress installcheck
installcheck_1  | make[1]: Entering directory '/build/postgres/src/test/regress'
installcheck_1  | make -C ../../../src/port all
installcheck_1  | make[2]: Entering directory '/build/postgres/src/port'
installcheck_1  | make[2]: Nothing to be done for 'all'.
installcheck_1  | make[2]: Leaving directory '/build/postgres/src/port'
installcheck_1  | make -C ../../../src/common all
installcheck_1  | make[2]: Entering directory '/build/postgres/src/common'
installcheck_1  | make[2]: Nothing to be done for 'all'.
installcheck_1  | make[2]: Leaving directory '/build/postgres/src/common'
installcheck_1  | make -C ../../../contrib/spi
installcheck_1  | make[2]: Entering directory '/build/postgres/contrib/spi'
installcheck_1  | make[2]: Nothing to be done for 'all'.
installcheck_1  | make[2]: Leaving directory '/build/postgres/contrib/spi'
installcheck_1  | rm -rf ./testtablespace
installcheck_1  | mkdir ./testtablespace
installcheck_1  | ../../../src/test/regress/pg_regress --inputdir=. --bindir='/usr/local/pgsql/bin'    --dlpath=. --max-concurrent-tests=20  --schedule=./serial_schedule 
installcheck_1  | (using postmaster on installcheck_router_1, port 6432)
installcheck_1  | ============== dropping database "regression"         ==============
installcheck_1  | DROP DATABASE
installcheck_1  | ============== creating database "regression"         ==============
installcheck_1  | CREATE DATABASE
installcheck_1  | ERROR:  too complex query to parse
installcheck_1  | command failed: "/usr/local/pgsql/bin/psql" -X -c "ALTER DATABASE \"regression\" SET lc_messages TO 'C';ALTER DATABASE \"regression\" SET lc_monetary TO 'C';ALTER DATABASE \"regression\" SET lc_numeric TO 'C';ALTER DATABASE \"regression\" SET lc_time TO 'C';ALTER DATABASE \"regression\" SET bytea_output TO 'hex';ALTER DATABASE \"regression\" SET timezone_abbreviations TO 'Default';" "regression"
installcheck_1  | make[1]: *** [GNUmakefile:138: installcheck] Error 2
installcheck_1  | make[1]: Leaving directory '/build/postgres/src/test/regress'
installcheck_1  | make: *** [GNUmakefile:69: installcheck] Error 2
installcheck_installcheck_1 exited with code 2
```