### PR TITLE
Handle `sslmode` correctly

### DIFF
--- a/balancer/app/app.go
+++ b/balancer/app/app.go
@@ -81,13 +81,13 @@ func (app *App) ProcBalancer(ctx context.Context) error {
 	return nil
 }
 
-func (app *App) ServeAdminConsole(ctx context.Context, clientTLSConfig config.TLSConfig) error {
-	clientTLS, err := clientTLSConfig.Init()
+func (app *App) ServeAdminConsole(ctx context.Context, bconfig *config.Balancer) error {
+	clientTLS, err := bconfig.TLS.Init(bconfig.Host)
 	if err != nil {
 		return fmt.Errorf("init frontend TLS: %w", err)
 	}
 
-	address := net.JoinHostPort(config.BalancerConfig().Host, config.BalancerConfig().AdminConsolePort)
+	address := net.JoinHostPort(bconfig.Host, bconfig.AdminConsolePort)
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return err

--- a/cmd/balancer/main.go
+++ b/cmd/balancer/main.go
@@ -51,7 +51,7 @@ var rootCmd = &cobra.Command{
 
 		wg.Add(1)
 		go func(wg *sync.WaitGroup) {
-			err := app.ServeAdminConsole(ctx, bCfg.TLS)
+			err := app.ServeAdminConsole(ctx, &bCfg)
 			spqrlog.Logger.FatalOnError(err)
 			wg.Done()
 		}(wg)

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -2,42 +2,118 @@ package config
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"errors"
 	"fmt"
+	"os"
 
-	"github.com/wal-g/tracelog"
+	"github.com/pg-sharding/spqr/pkg/spqrlog"
 )
 
 // https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
-
-const (
-	SSLMODEDISABLE    = "disable"
-	SSLMODEALLOW      = "allow"
-	SSLMODEPREFER     = "prefer"
-	SSLMODEREQUIRE    = "require"
-	SSLMODEVERIFYCA   = "verify-ca"
-	SSLMODEVERIFYFULL = "verify-full"
-)
-
 type TLSConfig struct {
-	SslMode  string `json:"sslmode" toml:"sslmode" yaml:"sslmode"`
-	KeyFile  string `json:"key_file" toml:"key_file" yaml:"key_file"`
-	CertFile string `json:"cert_file" toml:"cert_file" yaml:"cert_file"`
+	SslMode      string `json:"sslmode" toml:"sslmode" yaml:"sslmode"`
+	KeyFile      string `json:"key_file" toml:"key_file" yaml:"key_file"`
+	CertFile     string `json:"cert_file" toml:"cert_file" yaml:"cert_file"`
+	RootCertFile string `json:"root_cert_file" toml:"root_cert_file" yaml:"root_cert_file"`
 }
 
-func (c *TLSConfig) IsSSLModeDisable() bool {
-	return c == nil || c.SslMode == SSLMODEDISABLE || (c.CertFile == "" && c.KeyFile == "" || c.SslMode == "")
-}
+// ConfigTLS creates tls.Init from SPQR config.
+// Almost full copy of https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L610.
+func (c *TLSConfig) Init(host string) (*tls.Config, error) {
+	// Match libpq default behavior
+	if c == nil || c.SslMode == "" {
+		c = &TLSConfig{SslMode: "disable"}
+	}
 
-func (c *TLSConfig) Init() (*tls.Config, error) {
-	if c.IsSSLModeDisable() {
-		tracelog.InfoLogger.Printf("skip loading tls certs")
+	if (c.CertFile != "" && c.KeyFile == "") || (c.CertFile == "" && c.KeyFile != "") {
+		return nil, errors.New(`both "cert_file" and "key_file" are required`)
+	}
+
+	tlsConfig := &tls.Config{}
+
+	switch c.SslMode {
+	case "disable":
 		return nil, nil
+	case "allow", "prefer":
+		tlsConfig.InsecureSkipVerify = true
+	case "require":
+		// According to PostgreSQL documentation, if a root CA file exists,
+		// the behavior of sslmode=require should be the same as that of verify-ca
+		//
+		// See https://www.postgresql.org/docs/12/libpq-ssl.html
+		if c.RootCertFile != "" {
+			goto nextCase
+		}
+		tlsConfig.InsecureSkipVerify = true
+		break
+	nextCase:
+		fallthrough
+	case "verify-ca":
+		// Don't perform the default certificate verification because it
+		// will verify the hostname. Instead, verify the server's
+		// certificate chain ourselves in VerifyPeerCertificate and
+		// ignore the server name. This emulates libpq's verify-ca
+		// behavior.
+		//
+		// See https://github.com/golang/go/issues/21971#issuecomment-332693931
+		// and https://pkg.go.dev/crypto/tls?tab=doc#example-Config-VerifyPeerCertificate
+		// for more info.
+		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.VerifyPeerCertificate = func(certificates [][]byte, _ [][]*x509.Certificate) error {
+			certs := make([]*x509.Certificate, len(certificates))
+			for i, asn1Data := range certificates {
+				cert, err := x509.ParseCertificate(asn1Data)
+				if err != nil {
+					return errors.New("failed to parse certificate from server: " + err.Error())
+				}
+				certs[i] = cert
+			}
+
+			// Leave DNSName empty to skip hostname verification.
+			opts := x509.VerifyOptions{
+				Roots:         tlsConfig.RootCAs,
+				Intermediates: x509.NewCertPool(),
+			}
+			// Skip the first cert because it's the leaf. All others
+			// are intermediates.
+			for _, cert := range certs[1:] {
+				opts.Intermediates.AddCert(cert)
+			}
+			_, err := certs[0].Verify(opts)
+			return err
+		}
+	case "verify-full":
+		tlsConfig.ServerName = host
+	default:
+		return nil, errors.New("sslmode is invalid")
 	}
 
-	tracelog.InfoLogger.Printf("loading tls cert file %s, key file %s", c.CertFile, c.KeyFile)
-	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load tls conf: %w", err)
+	if c.RootCertFile != "" {
+		caCertPool := x509.NewCertPool()
+
+		caPath := c.RootCertFile
+		caCert, err := os.ReadFile(caPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read CA file: %w", err)
+		}
+
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, errors.New("unable to add CA to cert pool")
+		}
+
+		tlsConfig.RootCAs = caCertPool
+		tlsConfig.ClientCAs = caCertPool
 	}
-	return &tls.Config{Certificates: []tls.Certificate{cert}, InsecureSkipVerify: true}, nil
+
+	if c.CertFile != "" && c.KeyFile != "" {
+		spqrlog.Logger.Printf(spqrlog.DEBUG2, "loading tls cert file %s, key file %s", c.CertFile, c.KeyFile)
+		cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("unable to X509 key pair: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsConfig, nil
 }

--- a/router/pkg/datashard/conn_pool.go
+++ b/router/pkg/datashard/conn_pool.go
@@ -267,8 +267,9 @@ func (s *InstancePoolImpl) Put(shkey kr.ShardKey, sh Shard) error {
 func NewConnPool(mapping map[string]*config.Shard) DBPool {
 	allocator := func(shardKey kr.ShardKey, host string, rule *config.BackendRule) (Shard, error) {
 		spqrlog.Logger.Printf(spqrlog.LOG, "acquire new connection to %v", host)
+		shard := mapping[shardKey.Name]
 
-		tlsconfig, err := mapping[shardKey.Name].TLS.Init()
+		tlsconfig, err := shard.TLS.Init(shard.Hosts[0])
 		if err != nil {
 			return nil, err
 		}

--- a/router/pkg/instance.go
+++ b/router/pkg/instance.go
@@ -60,7 +60,7 @@ func NewRouter(ctx context.Context, rcfg *config.Router) (*InstanceImpl, error) 
 	}
 
 	// frontend
-	frTLS, err := rcfg.FrontendTLS.Init()
+	frTLS, err := rcfg.FrontendTLS.Init(rcfg.Host)
 	if err != nil {
 		return nil, fmt.Errorf("init frontend TLS: %w", err)
 	}


### PR DESCRIPTION
It was impossible for the router to connect to shards using a root certificate.
It works: 
```
root@denchick-spqr01h:/spqr# psql "host=localhost sslmode=disable user=sbtest dbname=sbtest port=6432"
psql (14.5 (Ubuntu 14.5-201-yandex.52547.2fabebd33c))
Type "help" for help.

sbtest=> select * from articles;
NOTICE: send query to shard(s) : shard01,shard02
 id 
----
(0 rows)
```

SPQR logs:

```
root@denchick-spqr01h:/spqr# ./spqr-router -c router.yaml run
2022/11/07 06:36:45 Running config: {
  "log_level": "",
  "host": "localhost",
  "router_port": "6432",
  "admin_console_port": "7432",
  "grpc_api_port": "7000",
  "world_shard_fallback": false,
  "show_notice_messages": true,
  "auto_conf": "",
  "init_sql": "init.sql",
  "under_coordinator": false,
  "router_mode": "PROXY",
  "jaeger_url": "",
  "frontend_rules": [
    {
      "db": "sbtest",
      "usr": "sbtest",
      "auth_rule": {
        "auth_method": "ok",
        "password": ""
      },
      "pool_mode": "TRANSACTION",
      "pool_discard": false,
      "pool_rollback": false,
      "pool_prepared_statement": false,
      "pool_default": false
    }
  ],
  "frontend_tls": null,
  "backend_rules": [
    {
      "db": "sbtest",
      "usr": "sbtest",
      "auth_rule": {
        "auth_method": "md5",
        "password": "password"
      },
      "pool_default": false
    }
  ],
  "shards": {
    "shard01": {
      "target_session_attrs": "",
      "hosts": [
        "sas-xhxplfw3lnnqbf5c.db.yandex.net:6432"
      ],
      "type": "DATA",
      "tls": {
        "sslmode": "require",
        "key_file": "",
        "cert_file": "",
        "root_cert_file": "/spqr/root.crt"
      }
    },
    "shard02": {
      "target_session_attrs": "",
      "hosts": [
        "sas-v0df2vny5r5x5u77.db.yandex.net:6432"
      ],
      "type": "DATA",
      "tls": {
        "sslmode": "require",
        "key_file": "",
        "cert_file": "",
        "root_cert_file": "/spqr/root.crt"
      }
    }
  }
}
LOG: 2022/11/07 06:36:45.348305 adding node shard01
LOG: 2022/11/07 06:36:45.348322 adding node shard02
LOG: 2022/11/07 06:36:45.348354 init.sql found
INFO: 2022/11/07 06:36:45.348412 executing init sql
INFO: 2022/11/07 06:36:45.348418 query: SHOW shards;
INFO: 2022/11/07 06:36:45.348453 query: ADD SHARDING RULE rule1 COLUMNS id;
INFO: 2022/11/07 06:36:45.348483 query: ADD KEY RANGE krid1 FROM 1 TO 1073741823  ROUTE TO shard01;
INFO: 2022/11/07 06:36:45.348511 query: ADD KEY RANGE krid2 FROM 1073741824 TO 2147483647  ROUTE TO shard02;
INFO: 2022/11/07 06:36:45.348529 query: SHOW sharding_rules;
INFO: 2022/11/07 06:36:45.348545 query: SHOW key_ranges;
INFO: 2022/11/07 06:36:45.348563 Successfully init 6 queries from init.sql
INFO: 2022/11/07 06:36:45.349055 SPQR Administative Console is ready on localhost:7432
INFO: 2022/11/07 06:36:45.349087 SPQR GRPC API is ready on localhost:7000
INFO: 2022/11/07 06:36:45.349106 SPQR Router is ready on localhost:6432 by postgresql proto
LOG: 2022/11/07 06:36:46.736241 init client connection with ssl: false
LOG: 2022/11/07 06:36:46.736598 Processing auth for sbtest sbtest
LOG: 2022/11/07 06:36:46.736642 acquire conn to shard02
LOG: 2022/11/07 06:36:46.736650 acquire new connection to sas-v0df2vny5r5x5u77.db.yandex.net:6432
LOG: 2022/11/07 06:36:46.746281 client auth OK
LOG: 2022/11/07 06:36:46.746296 pre route ok
INFO: 2022/11/07 06:36:46.746306 process frontend for route sbtest sbtest
LOG: 2022/11/07 06:36:53.972523 acquire conn to shard01
LOG: 2022/11/07 06:36:53.972541 acquire new connection to sas-xhxplfw3lnnqbf5c.db.yandex.net:6432
LOG: 2022/11/07 06:36:53.977892 acquire conn to shard02
LOG: 2022/11/07 06:36:53.977908 got cached connection from pool
LOG: 2022/11/07 06:36:53.982652 multishard server: enter rfq await mode
LOG: 2022/11/07 06:36:53.982691 end of tx unrouting from [{shard01 true} {shard02 true}]
LOG: 2022/11/07 06:36:53.982698 unrouting from datashard shard01
LOG: 2022/11/07 06:36:53.982703 unrouting from datashard shard02
LOG: 2022/11/07 06:37:00.541583 acquire conn to shard01
LOG: 2022/11/07 06:37:00.541602 acquire new connection to sas-xhxplfw3lnnqbf5c.db.yandex.net:6432
LOG: 2022/11/07 06:37:00.546895 end of tx unrouting from [{shard01 false}]
LOG: 2022/11/07 06:37:00.546905 unrouting from datashard shard01
```