### PR TITLE
Support sync messages in multi-shard setup

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -28,6 +28,7 @@ type Client interface {
 	ID() string
 
 	ReplyErrMsg(errmsg string) error
+	ReplyRFQ() error
 	ReplyNotice(message string) error
 	ReplyDebugNotice(msg string) error
 	ReplyDebugNoticef(fmt string, args ...interface{}) error

--- a/pkg/config/router.go
+++ b/pkg/config/router.go
@@ -43,9 +43,14 @@ type Router struct {
 	RouterMode       string            `json:"router_mode" toml:"router_mode" yaml:"router_mode"`
 	JaegerUrl        string            `json:"jaeger_url" toml:"jaeger_url" yaml:"jaeger_url"`
 	FrontendRules    []*FrontendRule   `json:"frontend_rules" toml:"frontend_rules" yaml:"frontend_rules"`
+	Qr               QRouter   `json:"query_routing" toml:"query_routing" yaml:"query_routing"`
 	FrontendTLS      *TLSConfig        `json:"frontend_tls" yaml:"frontend_tls" toml:"frontend_tls"`
 	BackendRules     []*BackendRule    `json:"backend_rules" toml:"backend_rules" yaml:"backend_rules"`
 	ShardMapping     map[string]*Shard `json:"shards" toml:"shards" yaml:"shards"`
+}
+
+type QRouter struct {
+	MulticastUnroutableInsertStatement bool `json:"multicast_unroutable_insert_statement" toml:"multicast_unroutable_insert_statement" yaml:"multicast_unroutable_insert_statement"`
 }
 
 type BackendRule struct {

--- a/router/pkg/client/client.go
+++ b/router/pkg/client/client.go
@@ -831,6 +831,21 @@ func (cl *PsqlClient) ReplyErrMsg(errmsg string) error {
 	return nil
 }
 
+func (cl *PsqlClient) ReplyRFQ() error {
+	for _, msg := range []pgproto3.BackendMessage{
+		&pgproto3.ReadyForQuery{
+			TxStatus: byte(conn.TXIDLE),
+		},
+	} {
+		if err := cl.Send(msg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+
 func (cl *PsqlClient) Shutdown() error {
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.ErrorResponse{

--- a/router/pkg/frontend.go
+++ b/router/pkg/frontend.go
@@ -220,7 +220,7 @@ func Frontend(qr qrouter.QueryRouter, cl client.RouterClient, cmngr rulerouter.P
 			case *pgproto3.Terminate:
 				return nil
 			case *pgproto3.Sync:
-				return rst.ProcessMessage(q, true, true, cmngr)
+				return rst.Sync(true, true, cmngr)
 			case *pgproto3.Parse:
 				hash := murmur3.Sum64([]byte(q.Query))
 				spqrlog.Logger.Printf(spqrlog.DEBUG1, "name %v, query %v, hash %d", q.Name, q.Query, hash)

--- a/router/pkg/instance.go
+++ b/router/pkg/instance.go
@@ -54,7 +54,7 @@ func NewRouter(ctx context.Context, rcfg *config.Router) (*InstanceImpl, error) 
 	qtype := config.RouterMode(rcfg.RouterMode)
 	spqrlog.Logger.Printf(spqrlog.DEBUG1, "creating QueryRouter with type %s", qtype)
 
-	qr, err := qrouter.NewQrouter(qtype, rcfg.ShardMapping)
+	qr, err := qrouter.NewQrouter(qtype, rcfg.ShardMapping, &rcfg.Qr)
 	if err != nil {
 		return nil, err
 	}

--- a/router/pkg/qrouter/proxy.go
+++ b/router/pkg/qrouter/proxy.go
@@ -34,6 +34,8 @@ type ProxyQrouter struct {
 	DataShardCfgs  map[string]*config.Shard
 	WorldShardCfgs map[string]*config.Shard
 
+	cfg *config.QRouter
+
 	initialized *atomic.Bool
 
 	qdb qdb.QrouterDB
@@ -160,7 +162,8 @@ func (qr *ProxyQrouter) WorldShards() []string {
 
 	return ret
 }
-func NewProxyRouter(shardMapping map[string]*config.Shard) (*ProxyQrouter, error) {
+
+func NewProxyRouter(shardMapping map[string]*config.Shard, qcfg *config.QRouter) (*ProxyQrouter, error) {
 	db, err := mem.NewQrouterDBMem()
 	if err != nil {
 		return nil, err
@@ -171,6 +174,7 @@ func NewProxyRouter(shardMapping map[string]*config.Shard) (*ProxyQrouter, error
 		WorldShardCfgs: map[string]*config.Shard{},
 		qdb:            db,
 		initialized:    atomic.NewBool(false),
+		cfg: qcfg,
 	}
 
 	for name, shardCfg := range shardMapping {

--- a/router/pkg/qrouter/proxy_routing.go
+++ b/router/pkg/qrouter/proxy_routing.go
@@ -359,9 +359,11 @@ func (qr *ProxyQrouter) Route(ctx context.Context, parsedStmt *pgquery.ParseResu
 	case *pgquery.Node_InsertStmt:
 		routes, err := qr.matchShards(ctx, stmt)
 		if err != nil {
-			switch err {
-			case ShardingKeysMissing:
-				return MultiMatchState{}, nil
+			if qr.cfg.MulticastUnroutableInsertStatement {
+				switch err {
+				case ShardingKeysMissing:
+					return MultiMatchState{}, nil
+				}
 			}
 			return nil, err
 		}

--- a/router/pkg/qrouter/qrouter.go
+++ b/router/pkg/qrouter/qrouter.go
@@ -69,12 +69,12 @@ type QueryRouter interface {
 	Subscribe(krid string, keyRangeStatus *qdb.KeyRangeStatus, noitfyio chan<- interface{}) error
 }
 
-func NewQrouter(qtype config.RouterMode, shardMapping map[string]*config.Shard) (QueryRouter, error) {
+func NewQrouter(qtype config.RouterMode, shardMapping map[string]*config.Shard, qcfg *config.QRouter) (QueryRouter, error) {
 	switch qtype {
 	case config.LocalMode:
 		return NewLocalQrouter(shardMapping)
 	case config.ProxyMode:
-		return NewProxyRouter(shardMapping)
+		return NewProxyRouter(shardMapping, qcfg)
 	default:
 		return nil, errors.Errorf("unknown qrouter type: %v", qtype)
 	}


### PR DESCRIPTION
Process sync message correctly in cases when there is no active backend connections to any shard, instead of replying with error 'too complex to parse'. This fixed the case when sync message is issued right after parse message, or similar, in which router fill fail to 'route' sync to shard, because this is un-routabale messafe.