### PR TITLE
Group columns by its relations name, to properly route queries

### DIFF
--- a/qdb/ops/ops.go
+++ b/qdb/ops/ops.go
@@ -44,40 +44,44 @@ func AddKeyRangeWithChecks(ctx context.Context, qdb qdb.QrouterDB, keyRange *qdb
 
 var RuleIntersec = fmt.Errorf("sharding rule intersects with existing one")
 
-func CheckShardingRule(ctx context.Context, qdb qdb.QrouterDB, colnames []string) error {
+func MatchShardingRule(ctx context.Context, qdb qdb.QrouterDB, relationName string, shardingEntries []string) (*qdb.ShardingRule, error) {
 	rules, err := qdb.ListShardingRules(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	spqrlog.Logger.Printf(spqrlog.DEBUG5, "checking with %d rules", len(rules))
+	spqrlog.Logger.Printf(spqrlog.DEBUG5, "checking relation %s with %d sharding rules", relationName, len(rules))
 
-	checkSet := make(map[string]struct{}, len(colnames))
+	/*
+	* Create set to search column names in `shardingEntries`
+	 */
+	checkSet := make(map[string]struct{}, len(shardingEntries))
 
-	for _, k := range colnames {
+	for _, k := range shardingEntries {
 		checkSet[k] = struct{}{}
 	}
 
 	for _, rule := range rules {
-		spqrlog.Logger.Printf(spqrlog.DEBUG5, "checking %+v against %+v", rule.Entries[0].Column, colnames)
-		if len(rule.Entries) != len(colnames) {
+		spqrlog.Logger.Printf(spqrlog.DEBUG5, "checking %+v against %+v", rule.Entries[0].Column, shardingEntries)
+		if len(rule.Entries) != len(shardingEntries) {
 			continue
 		}
 
-		fullMatch := true
+		allColumnsMatched := true
 
 		for _, v := range rule.Entries {
 			if _, ok := checkSet[v.Column]; !ok {
-				fullMatch = false
+				allColumnsMatched = false
 				break
 			}
 		}
 
-		if fullMatch {
-			return RuleIntersec
+		/* In this rule, we successfully matched all columns */
+		if allColumnsMatched {
+			return rule, RuleIntersec
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func ModifyKeyRangeWithChecks(ctx context.Context, qdb qdb.QrouterDB, keyRange *qdb.KeyRange) error {

--- a/qdb/ops/ops.go
+++ b/qdb/ops/ops.go
@@ -61,8 +61,9 @@ func MatchShardingRule(ctx context.Context, qdb qdb.QrouterDB, relationName stri
 	}
 
 	for _, rule := range rules {
-		spqrlog.Logger.Printf(spqrlog.DEBUG5, "checking %+v against %+v", rule.Entries[0].Column, shardingEntries)
-		if len(rule.Entries) != len(shardingEntries) {
+		spqrlog.Logger.Printf(spqrlog.DEBUG5, "checking %+v against %+v", rule.Entries, shardingEntries)
+		// Simple optimisation
+		if len(rule.Entries) > len(shardingEntries) {
 			continue
 		}
 

--- a/router/pkg/qrouter/proxy_routing.go
+++ b/router/pkg/qrouter/proxy_routing.go
@@ -327,6 +327,8 @@ func (qr *ProxyQrouter) matchShards(ctx context.Context, qstmt *pgquery.RawStmt,
 			}
 		}
 
+		spqrlog.Logger.Printf(spqrlog.DEBUG5, "deparsed columns %+v and offset indexes %+v", cols, colindxs)
+
 		if rule, err := ops.MatchShardingRule(ctx, qr.qdb, "", cols); err == nil {
 			return nil, ShardingKeysMissing
 		} else {

--- a/test/regress/tests/router/expected/shard_routing.out
+++ b/test/regress/tests/router/expected/shard_routing.out
@@ -101,6 +101,40 @@ NOTICE: send query to shard(s) : sh2
  -211212 | 2121221 |   23
 (5 rows)
 
+-- check that aliases works
+SELECT * FROM xxtt1 a WHERE a.w_id >= 1;
+NOTICE: send query to shard(s) : sh1
+  i  |   j    | w_id 
+-----+--------+------
+     |        |    1
+     |        |   15
+   1 |        |    1
+  15 |        |   15
+   1 |        |    1
+ -12 |        |   15
+   1 |        |    1
+ -12 |        |   15
+ -12 |      1 |    1
+ -12 | 123123 |   15
+(10 rows)
+
+SELECT * FROM xxtt1 a WHERE a.w_id >= 20;
+NOTICE: send query to shard(s) : sh1
+ i | j | w_id 
+---+---+------
+(0 rows)
+
+SELECT * FROM xxtt1 a WHERE a.w_id >= 21;
+NOTICE: send query to shard(s) : sh2
+    i    |    j    | w_id 
+---------+---------+------
+         |         |   21
+      21 |         |   21
+      12 |         |   21
+ 2121221 |         |   21
+ -211212 | 2121221 |   23
+(5 rows)
+
 DROP TABLE xx;
 NOTICE: send query to shard(s) : sh1,sh2
 DROP TABLE xxtt1;

--- a/test/regress/tests/router/sql/shard_routing.sql
+++ b/test/regress/tests/router/sql/shard_routing.sql
@@ -37,6 +37,11 @@ SELECT * FROM xxtt1 WHERE w_id >= 1;
 SELECT * FROM xxtt1 WHERE w_id >= 20;
 SELECT * FROM xxtt1 WHERE w_id >= 21;
 
+-- check that aliases works
+SELECT * FROM xxtt1 a WHERE a.w_id >= 1;
+SELECT * FROM xxtt1 a WHERE a.w_id >= 20;
+SELECT * FROM xxtt1 a WHERE a.w_id >= 21;
+
 DROP TABLE xx;
 DROP TABLE xxtt1;
 


### PR DESCRIPTION
All columns in query should be considered in context of its table,
to distinguish composite join/select queries routing schemas
For example,

SELECT * FROM a join b WHERE a.c1 = <val> and b.c2 = <val>
      and

SELECT * FROM a join b WHERE a.c1 = <val> and a.c2 = <val>

can be routed with different rules

Also, this test now works, as we remember each table alias in parse-time:
```
postgres=# select * from t1 a where i <= 30;
 i
----
 22
(1 row)

postgres=# select * from t1 a where a.i <= 30;
ERROR:  too complex query to parse
```
