### PR TITLE
Add routing on insert from select statements

### DIFF
--- a/qdb/memqdb.go
+++ b/qdb/memqdb.go
@@ -11,11 +11,11 @@ import (
 type MemQDB struct {
 	mu sync.RWMutex
 
-	freq    map[string]bool
-	krs     map[string]*KeyRange
-	locks   map[string]*sync.RWMutex
-	shards  map[string]*Shard
-	shrules map[string]*ShardingRule
+	freq       map[string]bool
+	krs        map[string]*KeyRange
+	locks      map[string]*sync.RWMutex
+	shards     map[string]*Shard
+	shrules    map[string]*ShardingRule
 	dataspaces map[string]*Dataspace
 }
 
@@ -23,20 +23,18 @@ var _ QDB = &MemQDB{}
 
 func NewMemQDB() (*MemQDB, error) {
 	return &MemQDB{
-		freq:    map[string]bool{},
-		krs:     map[string]*KeyRange{},
-		locks:   map[string]*sync.RWMutex{},
-		shards:  map[string]*Shard{},
-		shrules: map[string]*ShardingRule{},
+		freq:       map[string]bool{},
+		krs:        map[string]*KeyRange{},
+		locks:      map[string]*sync.RWMutex{},
+		shards:     map[string]*Shard{},
+		shrules:    map[string]*ShardingRule{},
 		dataspaces: map[string]*Dataspace{},
 	}, nil
 }
 
-
 // ==============================================================================
 //                               SHARDING RULES
 // ==============================================================================
-
 
 func (q *MemQDB) AddShardingRule(ctx context.Context, rule *ShardingRule) error {
 	spqrlog.Logger.Printf(spqrlog.DEBUG1, "add sharding rule %v", rule.Entries[0].Column)
@@ -159,7 +157,7 @@ func (q *MemQDB) DropKeyRangeAll(ctx context.Context) error {
 		l.Unlock()
 	}
 
-	return nil 
+	return nil
 }
 
 func (q *MemQDB) ListKeyRanges(_ context.Context) ([]*KeyRange, error) {
@@ -228,8 +226,7 @@ func (q *MemQDB) ShareKeyRange(id string) error {
 	spqrlog.Logger.Printf(spqrlog.LOG, "memqdb: sharing key with key %v", id)
 
 	q.locks[id].RLock()
-	q.locks[id].RUnlock()
-
+	defer q.locks[id].RUnlock()
 
 	return nil
 }

--- a/test/regress/tests/router/expected/shard_routing.out
+++ b/test/regress/tests/router/expected/shard_routing.out
@@ -135,6 +135,17 @@ NOTICE: send query to shard(s) : sh2
  -211212 | 2121221 |   23
 (5 rows)
 
+-- check that `INSERT FROM SELECT` works
+INSERT INTO xx SELECT * FROM xx a WHERE a.w_id = 20;
+NOTICE: send query to shard(s) : sh1
+SELECT * FROM xx WHERE w_id >= 20;
+NOTICE: send query to shard(s) : sh1
+ w_id 
+------
+   20
+   20
+(2 rows)
+
 DROP TABLE xx;
 NOTICE: send query to shard(s) : sh1,sh2
 DROP TABLE xxtt1;

--- a/test/regress/tests/router/sql/shard_routing.sql
+++ b/test/regress/tests/router/sql/shard_routing.sql
@@ -42,6 +42,10 @@ SELECT * FROM xxtt1 a WHERE a.w_id >= 1;
 SELECT * FROM xxtt1 a WHERE a.w_id >= 20;
 SELECT * FROM xxtt1 a WHERE a.w_id >= 21;
 
+-- check that `INSERT FROM SELECT` works
+INSERT INTO xx SELECT * FROM xx a WHERE a.w_id = 20;
+SELECT * FROM xx WHERE w_id >= 20;
+
 DROP TABLE xx;
 DROP TABLE xxtt1;
 


### PR DESCRIPTION
Add logic for `INSERT FROM SELECT` routing e.g.

```
postgres=# select * from t1;
 i
----
  1
 10
  1
 10
 22
(5 rows)

postgres=# insert into t1 select * from t1 where i = 10 returning *;
 i
----
 10
 10
(2 rows)

INSERT 0 2
postgres=# ^C
```

now works