### PR TITLE
Enhance router TLS-related log messages.

### DIFF
--- a/config-example/router.yaml
+++ b/config-example/router.yaml
@@ -25,13 +25,14 @@ backend_rules:
     db: db1
     pool_discard: true
     pool_rollback: true
+    auth_rule:
+      password: strong
 
 shards:
   sh1:
     tls:
-      key_file: /etc/odyssey/ssl/server.key
+      root_cert_file: /path/to/root.ca
       sslmode: disable
-      cert_file: /etc/odyssey/ssl/server.crt
     db: db1
     usr: user1
     pwd: 12345678
@@ -40,9 +41,8 @@ shards:
       - '192.168.233.2:6432'
   sh2:
     tls:
-      key_file: /etc/odyssey/ssl/server.key
+      root_cert_file: /path/to/root.ca
       sslmode: disable
-      cert_file: /etc/odyssey/ssl/server.crt
     db: db1
     usr: user1
     pwd: 12345678
@@ -51,9 +51,8 @@ shards:
       - '192.168.233.3:6432'
   w1:
     tls:
-      key_file: /etc/odyssey/ssl/server.key
+      root_cert_file: /path/to/root.ca
       sslmode: disable
-      cert_file: /etc/odyssey/ssl/server.crt
     db: db1
     usr: user1
     pwd: 12345678

--- a/config-example/router.yaml
+++ b/config-example/router.yaml
@@ -43,9 +43,6 @@ shards:
     tls:
       root_cert_file: /path/to/root.ca
       sslmode: disable
-    db: db1
-    usr: user1
-    pwd: 12345678
     type: DATA
     hosts:
       - '192.168.233.3:6432'

--- a/pkg/conn/auth.go
+++ b/pkg/conn/auth.go
@@ -14,7 +14,7 @@ import (
 )
 
 func AuthBackend(shard DBInstance, berule *config.BackendRule, msg pgproto3.BackendMessage) error {
-	spqrlog.Logger.Printf(spqrlog.DEBUG2, "Auth type proc %T\n", msg)
+	spqrlog.Logger.Printf(spqrlog.DEBUG2, "backend shard %p: auth type proc %T\n", shard, msg)
 
 	switch v := msg.(type) {
 	case *pgproto3.AuthenticationOk:

--- a/pkg/conn/instance.go
+++ b/pkg/conn/instance.go
@@ -74,8 +74,6 @@ func (pgi *PostgreSQLInstance) Receive() (pgproto3.BackendMessage, error) {
 }
 
 func NewInstanceConn(host string, tlsconfig *tls.Config) (DBInstance, error) {
-	spqrlog.Logger.Printf(spqrlog.DEBUG3, "init new postgresql instance connection to %v", host)
-
 	netconn, err := net.Dial("tcp", host)
 	if err != nil {
 		return nil, err
@@ -93,6 +91,8 @@ func NewInstanceConn(host string, tlsconfig *tls.Config) (DBInstance, error) {
 			return nil, err
 		}
 	}
+
+	spqrlog.Logger.Printf(spqrlog.LOG, "%p acquire new connection to %v with tls %v", instance, host, tlsconfig != nil)
 
 	instance.frontend = pgproto3.NewFrontend(pgproto3.NewChunkReader(instance.conn), instance.conn)
 	return instance, nil
@@ -157,6 +157,7 @@ func (pgi *PostgreSQLInstance) ReqBackendSsl(tlsconfig *tls.Config) error {
 	}
 
 	pgi.conn = tls.Client(pgi.conn, tlsconfig)
+	spqrlog.Logger.Printf(spqrlog.DEBUG5, "initaited backend connection with TLS (%p)", pgi)
 	return nil
 }
 

--- a/router/pkg/datashard/conn_pool.go
+++ b/router/pkg/datashard/conn_pool.go
@@ -196,7 +196,7 @@ func checkRw(sh Shard) (bool, error) {
 }
 
 func (s *InstancePoolImpl) Connection(key kr.ShardKey, rule *config.BackendRule) (Shard, error) {
-	spqrlog.Logger.Printf(spqrlog.DEBUG1, "acquiring new instance conntion to shard %s", key.Name)
+	spqrlog.Logger.Printf(spqrlog.DEBUG1, "instance pool %p: acquiring new instance conntion to shard %s", s, key.Name)
 
 	hosts := s.shardMapping[key.Name].Hosts
 	rand.Shuffle(len(hosts), func(i, j int) {
@@ -266,14 +266,12 @@ func (s *InstancePoolImpl) Put(shkey kr.ShardKey, sh Shard) error {
 
 func NewConnPool(mapping map[string]*config.Shard) DBPool {
 	allocator := func(shardKey kr.ShardKey, host string, rule *config.BackendRule) (Shard, error) {
-		spqrlog.Logger.Printf(spqrlog.LOG, "acquire new connection to %v", host)
 		shard := mapping[shardKey.Name]
 
 		tlsconfig, err := shard.TLS.Init(shard.Hosts[0])
 		if err != nil {
 			return nil, err
 		}
-
 		pgi, err := conn.NewInstanceConn(host, tlsconfig)
 		if err != nil {
 			return nil, err

--- a/router/pkg/datashard/datashard.go
+++ b/router/pkg/datashard/datashard.go
@@ -160,7 +160,7 @@ func (sh *Conn) Auth(sm *pgproto3.StartupMessage) error {
 		case pgproto3.AuthenticationResponseMessage:
 			err := conn.AuthBackend(sh.dedicated, sh.beRule, v)
 			if err != nil {
-				spqrlog.Logger.Errorf("failed to perform backend auth %w", err)
+				spqrlog.Logger.Errorf("failed to perform backend auth %v", err)
 				return err
 			}
 		case *pgproto3.ErrorResponse:

--- a/router/pkg/rulerouter/relay.go
+++ b/router/pkg/rulerouter/relay.go
@@ -310,7 +310,7 @@ func (rst *RelayStateImpl) Connect(shardRoutes []*qrouter.DataShardRoute) error 
 	}
 
 	query := rst.Cl.ConstructClientParams()
-	spqrlog.Logger.Printf(spqrlog.DEBUG1, "setting user params %s", query.String)
+	spqrlog.Logger.Printf(spqrlog.DEBUG1, "setting params for client %p: %s", rst.Cl, query.String)
 	_, _, err = rst.Cl.ProcQuery(query, true, false)
 	return err
 }


### PR DESCRIPTION
Include client and/or shard ids to TLS-related log messages. Also, fix config-exmpales/router.yaml to show that only root ca path is required to connect to backends (shard) while server_key file is not