### PR TITLE
fix lock/unlock key range wrong namespace in qdb

### DIFF
--- a/docker/tests/bin/move.sh
+++ b/docker/tests/bin/move.sh
@@ -39,17 +39,7 @@ psql "host=spqr_router_1_1 sslmode=disable user=user1 dbname=db1 port=6432" -c "
 	exit 1
 }
 
-psql "host=spqr_coordinator sslmode=disable user=user1 dbname=db1 port=7002" -c "LOCK KEY RANGE krid2;" || {
-	echo "ERROR: tests failed"
-	exit 1
-}
-
 psql "host=spqr_coordinator sslmode=disable user=user1 dbname=db1 port=7002" -c "MOVE KEY RANGE krid2 to sh1;" || {
-	echo "ERROR: tests failed"
-	exit 1
-}
-
-psql "host=spqr_coordinator sslmode=disable user=user1 dbname=db1 port=7002" -c "UNLOCK KEY RANGE krid2;" || {
 	echo "ERROR: tests failed"
 	exit 1
 }

--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -364,7 +364,7 @@ func (q *EtcdQDB) LockKeyRange(ctx context.Context, id string) (*KeyRange, error
 		}
 		defer unlockMutex(mu, ctx)
 
-		resp, err := q.cli.Get(ctx, keyLockPath(keyRangeID))
+		resp, err := q.cli.Get(ctx, keyLockPath(keyRangeNodePath(keyRangeID)))
 		if err != nil {
 			return nil, err
 		}
@@ -428,7 +428,7 @@ func (q *EtcdQDB) UnlockKeyRange(ctx context.Context, id string) error {
 		}
 		defer unlockMutex(mu, ctx)
 
-		resp, err := q.cli.Get(ctx, keyLockPath(keyRangeID))
+		resp, err := q.cli.Get(ctx, keyLockPath(keyRangeNodePath(keyRangeID)))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Lock/Unlock doesn't really work in coordinator, because it checks the wrong locked key range namespace in qdb. So it locks key range anyway, because we never put anything in lock/{krid}, and it never unlocks, because there is nothing in lock/keyranges/{krid}
removed `lock key range ...` from e2e test because it's done in `move key range ...` itself, so no need any preparation
```
root@spqr_client:/go# psql -h spqr_coordinator -p 7002 -U user1 -d db1
psql (13.11 (Debian 13.11-1.pgdg120+1), server 0.0.0)
Type "help" for help.

db1=> 
    CREATE SHARDING RULE r1 COLUMN id;
    CREATE KEY RANGE krid1 FROM 0 TO 11 ROUTE TO sh1;
    CREATE KEY RANGE krid2 FROM 11 TO 31 ROUTE TO sh2;
                          add sharding rule                           
----------------------------------------------------------------------
 created sharding rule r1 for table (*) with columns [id, hash: x->x]
(1 row)

         add key range          
--------------------------------
 created key range from 0 to 11
(1 row)

          add key range          
---------------------------------
 created key range from 11 to 31
(1 row)

db1=> split key range krid3 from krid1 by 5;
      split key range       
----------------------------
 split key range krid1 by 5
(1 row)

db1=> exit
root@spqr_client:/go# exit
exit
ERROR: 127
make: *** [Makefile:54: run] Error 127
diphantxm@diphantxm-nux:~/go/src/spqr$ docker exec spqr_qdb_0_1 etcdctl get --prefix ""
/keyranges/krid1
{"from":"MA==","to":"NQ==","shard_id":"sh1","key_range_id":"krid1"}
/keyranges/krid2
{"from":"MTE=","to":"MzE=","shard_id":"sh2","key_range_id":"krid2"}
/keyranges/krid3
{"from":"NQ==","to":"MTE=","shard_id":"sh1","key_range_id":"krid3"}
/sharding_rules/r1
{"id":"r1","table":"","columns":[{"column":"id","hash":""}]}
lock/keyranges/krid1
locked
```