### PR TITLE
Refactor QDB interfaces, add comments to code

### DIFF
--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -24,7 +24,7 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
-		db, err := qdb.NewQDB(qdbImpl)
+		db, err := qdb.NewXQDB(qdbImpl)
 		if err != nil {
 			return err
 		}

--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -801,7 +801,7 @@ func (qc *qdbCoordinator) Move(ctx context.Context, req *kr.MoveKeyRange) error 
 	/* physical changes on shards */
 	err = datatransfers.MoveKeys(ctx, keyRange.ShardID, req.ShardId, *keyRange, shardingRules, qc.db)
 	if err != nil {
-		spqrlog.Zero.Error().Msg("failed to move rows")
+		spqrlog.Zero.Error().Err(err).Msg("failed to move rows")
 		return err
 	}
 

--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -221,9 +221,6 @@ func (qc *qdbCoordinator) watchRouters(ctx context.Context) {
 				switch resp.Status {
 				case routerproto.RouterStatus_CLOSED:
 					spqrlog.Zero.Debug().Msg("router is closed")
-					if err := qc.db.LockRouter(ctx, r.ID); err != nil {
-						return err
-					}
 					if err := qc.SyncRouterMetadata(ctx, internalR); err != nil {
 						return err
 					}

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/go-sql-driver/mysql v1.7.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-memdb v1.3.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/pkg/coord/local/clocal.go
+++ b/pkg/coord/local/clocal.go
@@ -31,7 +31,7 @@ type LocalCoordinator struct {
 	DataShardCfgs  map[string]*config.Shard
 	WorldShardCfgs map[string]*config.Shard
 
-	/* not extended qdb, as router dont need to track installation topology */
+	// not extended QDB, since the router does not need to track the installation topology
 	qdb qdb.QDB
 }
 

--- a/pkg/coord/local/clocal.go
+++ b/pkg/coord/local/clocal.go
@@ -31,6 +31,7 @@ type LocalCoordinator struct {
 	DataShardCfgs  map[string]*config.Shard
 	WorldShardCfgs map[string]*config.Shard
 
+	/* not extended qdb, as router dont need to track installation topology */
 	qdb qdb.QDB
 }
 

--- a/pkg/datatransfers/data_transfers_test.go
+++ b/pkg/datatransfers/data_transfers_test.go
@@ -27,9 +27,9 @@ func TestCommitPositive(t *testing.T) {
 	m2.EXPECT().Exec(context.TODO(), "PREPARE TRANSACTION 'sh1-krid'").Return(pgconn.CommandTag{}, nil)
 	m2.EXPECT().Exec(context.TODO(), "COMMIT PREPARED 'sh1-krid'").Return(pgconn.CommandTag{}, nil)
 
-	db, err := qdb.NewQDB("mem")
+	db, err := qdb.NewXQDB("mem")
 	assert.NoError(err)
-	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, &db)
+	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, db)
 	assert.NoError(err)
 
 	tx, err := db.GetTransferTx(context.TODO(), "krid")
@@ -51,9 +51,9 @@ func TestFailToCommitFirstTx(t *testing.T) {
 	m2 := mock.NewMockTx(ctrl)
 	m2.EXPECT().Exec(context.TODO(), "PREPARE TRANSACTION 'sh1-krid'").Return(pgconn.CommandTag{}, nil)
 
-	db, err := qdb.NewQDB("mem")
+	db, err := qdb.NewXQDB("mem")
 	assert.NoError(err)
-	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, &db)
+	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, db)
 	assert.Error(err)
 
 	tx, err := db.GetTransferTx(context.TODO(), "krid")
@@ -74,9 +74,9 @@ func TestFailToCommitSecondTx(t *testing.T) {
 	m2.EXPECT().Exec(context.TODO(), "PREPARE TRANSACTION 'sh1-krid'").Return(pgconn.CommandTag{}, nil)
 	m2.EXPECT().Exec(context.TODO(), "COMMIT PREPARED 'sh1-krid'").Return(pgconn.CommandTag{}, fmt.Errorf(""))
 
-	db, err := qdb.NewQDB("mem")
+	db, err := qdb.NewXQDB("mem")
 	assert.NoError(err)
-	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, &db)
+	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, db)
 	assert.Error(err)
 
 	tx, err := db.GetTransferTx(context.TODO(), "krid")
@@ -94,9 +94,9 @@ func TestFailToPrepareFirstTx(t *testing.T) {
 
 	m2 := mock.NewMockTx(ctrl)
 
-	db, err := qdb.NewQDB("mem")
+	db, err := qdb.NewXQDB("mem")
 	assert.NoError(err)
-	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, &db)
+	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, db)
 	assert.Error(err)
 
 	_, err = db.GetTransferTx(context.TODO(), "krid")
@@ -114,9 +114,9 @@ func TestFailToPrepareSecondTx(t *testing.T) {
 	m2 := mock.NewMockTx(ctrl)
 	m2.EXPECT().Exec(context.TODO(), "PREPARE TRANSACTION 'sh1-krid'").Return(pgconn.CommandTag{}, fmt.Errorf(""))
 
-	db, err := qdb.NewQDB("mem")
+	db, err := qdb.NewXQDB("mem")
 	assert.NoError(err)
-	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, &db)
+	err = commitTransactions(context.TODO(), "sh1", "sh2", "krid", m1, m2, db)
 	assert.Error(err)
 
 	_, err = db.GetTransferTx(context.TODO(), "krid")

--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -869,9 +869,12 @@ func (q *EtcdQDB) UpdateKeyRangeMoveStatus(ctx context.Context, moveId string, s
 		Str("id", moveId).
 		Msg("etcdqdb: get sharding rule")
 
-	resp, err := q.cli.Get(ctx, shardingRuleNodePath(moveId), clientv3.WithPrefix())
+	resp, err := q.cli.Get(ctx, keyRangeMovesNodePath(moveId), clientv3.WithPrefix())
 	if err != nil {
 		return err
+	}
+	if len(resp.Kvs[0].Value) != 1 {
+		return fmt.Errorf("failed to update move key range operation by id %s", moveId)
 	}
 	var moveKr MoveKeyRange
 	if err := json.Unmarshal(resp.Kvs[0].Value, &moveKr); err != nil {

--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -48,6 +48,7 @@ const (
 	keyspace               = "key_space"
 	keyRangesNamespace     = "/keyranges"
 	dataspaceNamespace     = "/dataspaces"
+	keyRangeMovesNamespace = "/krmoves"
 	routersNamespace       = "/routers"
 	shardingRulesNamespace = "/sharding_rules"
 	shardsNamespace        = "/shards"
@@ -75,6 +76,10 @@ func shardNodePath(key string) string {
 
 func dataspaceNodePath(key string) string {
 	return path.Join(dataspaceNamespace, key)
+}
+
+func keyRangeMovesNodePath(key string) string {
+	return path.Join(keyRangeMovesNamespace, key)
 }
 
 // ==============================================================================
@@ -803,4 +808,89 @@ func (q *EtcdQDB) ListDataspaces(ctx context.Context) ([]*Dataspace, error) {
 		Interface("response", resp).
 		Msg("etcdqdb: list dataspaces")
 	return rules, nil
+}
+
+// ==============================================================================
+//                              KEY RANGE MOVES
+// ==============================================================================
+
+func (q *EtcdQDB) ListKeyRangeMoves(ctx context.Context) ([]*MoveKeyRange, error) {
+	spqrlog.Zero.Debug().Msg("etcdqdb: list move key range operations")
+
+	namespacePrefix := keyRangeMovesNamespace + "/"
+	resp, err := q.cli.Get(ctx, namespacePrefix, clientv3.WithPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	moves := make([]*MoveKeyRange, 0, len(resp.Kvs))
+
+	for _, kv := range resp.Kvs {
+		// A sharding rule supports no more than one column for a while.
+		var rule *MoveKeyRange
+		err := json.Unmarshal(kv.Value, &rule)
+		if err != nil {
+			return nil, err
+		}
+
+		moves = append(moves, rule)
+	}
+
+	spqrlog.Zero.Debug().
+		Interface("response", resp).
+		Msg("etcdqdb: list move key range oeprations")
+	return moves, nil
+}
+
+func (q *EtcdQDB) RecordKeyRangeMove(ctx context.Context, m *MoveKeyRange) error {
+	spqrlog.Zero.Debug().
+		Str("id", m.MoveId).
+		Msg("etcdqdb: add move key range operation")
+
+	rawMoveKeyRange, err := json.Marshal(m)
+
+	if err != nil {
+		return err
+	}
+	resp, err := q.cli.Put(ctx, keyRangeMovesNodePath(m.MoveId), string(rawMoveKeyRange))
+	if err != nil {
+		return err
+	}
+
+	spqrlog.Zero.Debug().
+		Interface("response", resp).
+		Msg("etcdqdb: add move key range operation")
+
+	return nil
+}
+
+func (q *EtcdQDB) UpdateKeyRangeMoveStatus(ctx context.Context, moveId string, s MoveKeyRangeStatus) error {
+	spqrlog.Zero.Debug().
+		Str("id", moveId).
+		Msg("etcdqdb: get sharding rule")
+
+	resp, err := q.cli.Get(ctx, shardingRuleNodePath(moveId), clientv3.WithPrefix())
+	if err != nil {
+		return err
+	}
+	var moveKr MoveKeyRange
+	if err := json.Unmarshal(resp.Kvs[0].Value, &moveKr); err != nil {
+		return err
+	}
+	moveKr.Status = s
+	rawMoveKeyRange, err := json.Marshal(moveKr)
+
+	if err != nil {
+		return err
+	}
+	respModify, err := q.cli.Put(ctx, keyRangeMovesNodePath(moveKr.MoveId), string(rawMoveKeyRange))
+	if err != nil {
+		return err
+	}
+
+	spqrlog.Zero.Debug().
+		Interface("response", respModify).
+		Msg("etcdqdb: update status of move key range operation")
+
+	return nil
 }

--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -176,7 +176,8 @@ func (q *EtcdQDB) ListShardingRules(ctx context.Context) ([]*ShardingRule, error
 	rules := make([]*ShardingRule, 0, len(resp.Kvs))
 
 	for _, kv := range resp.Kvs {
-		// A sharding rule supports no more than one column for a while.
+		// XXX: multi-column routing schemas
+		// A sharding rule currently supports only one column
 		var rule *ShardingRule
 		if err := json.Unmarshal(kv.Value, &rule); err != nil {
 			return nil, err
@@ -790,7 +791,6 @@ func (q *EtcdQDB) ListDataspaces(ctx context.Context) ([]*Dataspace, error) {
 	rules := make([]*Dataspace, 0, len(resp.Kvs))
 
 	for _, kv := range resp.Kvs {
-		// A sharding rule supports no more than one column for a while.
 		var rule *Dataspace
 		err := json.Unmarshal(kv.Value, &rule)
 		if err != nil {
@@ -826,7 +826,8 @@ func (q *EtcdQDB) ListKeyRangeMoves(ctx context.Context) ([]*MoveKeyRange, error
 	moves := make([]*MoveKeyRange, 0, len(resp.Kvs))
 
 	for _, kv := range resp.Kvs {
-		// A sharding rule supports no more than one column for a while.
+		// XXX: multi-column routing schemas
+		// A sharding rule currently supports only one column
 		var rule *MoveKeyRange
 		err := json.Unmarshal(kv.Value, &rule)
 		if err != nil {

--- a/qdb/memqdb.go
+++ b/qdb/memqdb.go
@@ -497,6 +497,18 @@ func (q *MemQDB) OpenRouter(ctx context.Context, id string) error {
 	return ExecuteCommands(q.DumpState, NewUpdateCommand(q.Routers, id, q.Routers[id]))
 }
 
+func (q *MemQDB) CloseRouter(ctx context.Context, id string) error {
+	spqrlog.Zero.Debug().
+		Str("router", id).
+		Msg("memqdb: open router")
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.Routers[id].State = CLOSED
+
+	return ExecuteCommands(q.DumpState, NewUpdateCommand(q.Routers, id, q.Routers[id]))
+}
+
 func (q *MemQDB) ListRouters(ctx context.Context) ([]*Router, error) {
 	spqrlog.Zero.Debug().Msg("memqdb: list routers")
 	q.mu.RLock()
@@ -513,10 +525,6 @@ func (q *MemQDB) ListRouters(ctx context.Context) ([]*Router, error) {
 	})
 
 	return ret, nil
-}
-
-func (q *MemQDB) LockRouter(ctx context.Context, id string) error {
-	return nil
 }
 
 // ==============================================================================

--- a/qdb/memqdb.go
+++ b/qdb/memqdb.go
@@ -12,6 +12,7 @@ import (
 )
 
 type MemQDB struct {
+	ShardingSchemaKeeper
 	// TODO create more mutex per map if needed
 	mu           sync.RWMutex
 	muDeletedKrs sync.RWMutex

--- a/qdb/memqdb_test.go
+++ b/qdb/memqdb_test.go
@@ -79,7 +79,6 @@ func TestMemqdbRacing(t *testing.T) {
 		func() { _ = memqdb.DropShardingRule(ctx, mockShardingRule.ID) },
 		func() { _, _ = memqdb.DropShardingRuleAll(ctx) },
 		func() { _ = memqdb.RemoveTransferTx(ctx, mockDataTransferTransaction.FromShardId) },
-		func() { _ = memqdb.LockRouter(ctx, mockRouter.ID) },
 		func() {
 			_, _ = memqdb.LockKeyRange(ctx, mockKeyRange.KeyRangeID)
 			_ = memqdb.UnlockKeyRange(ctx, mockKeyRange.KeyRangeID)

--- a/qdb/models.go
+++ b/qdb/models.go
@@ -11,6 +11,20 @@ type KeyRange struct {
 	ShardID    string `json:"shard_id"`
 	KeyRangeID string `json:"key_range_id"`
 }
+type MoveKeyRangeStatus string
+
+const (
+	MoveKeyRangePlanned  = MoveKeyRangeStatus("PLANNED")
+	MoveKeyRangeStarted  = MoveKeyRangeStatus("STARTED")
+	MoveKeyRangeComplete = MoveKeyRangeStatus("COMPLETE")
+)
+
+type MoveKeyRange struct {
+	MoveId     string             `json:"move_id"`
+	ShardId    string             `json:"shard_id"`
+	KeyRangeID string             `json:"key_range_id"`
+	Status     MoveKeyRangeStatus `json:"status"`
+}
 
 type KeyRangeStatus string
 

--- a/qdb/qdb.go
+++ b/qdb/qdb.go
@@ -18,10 +18,18 @@ type ShardingSchemaKeeper interface {
 
 type TopolodyKeeper interface {
 	AddRouter(ctx context.Context, r *Router) error
-	OpenRouter(ctx context.Context, rID string) error
 	DeleteRouter(ctx context.Context, rID string) error
 	ListRouters(ctx context.Context) ([]*Router, error)
-	LockRouter(ctx context.Context, id string) error
+
+	// OpenRouter: change state of router to online
+	// Making it usable to use for query executiong.
+	// "Online" mode.
+	OpenRouter(ctx context.Context, rID string) error
+
+	// CloseRouter: change state of router to offline
+	// Making it unusable to use for query executiong.
+	// "Offline" mode.
+	CloseRouter(ctx context.Context, rID string) error
 }
 
 // Keep track of the status of the two-phase data move transaction.

--- a/qdb/qdb.go
+++ b/qdb/qdb.go
@@ -13,7 +13,7 @@ type ShardingSchemaKeeper interface {
 	/* list all key-range moves in progress */
 	ListKeyRangeMoves(ctx context.Context) ([]*MoveKeyRange, error)
 	/* mark key range move as completed */
-	UpdateKeyRangeMoveStatus(ctx context.Context, moveId string) error
+	UpdateKeyRangeMoveStatus(ctx context.Context, moveId string, s MoveKeyRangeStatus) error
 }
 
 type TopolodyKeeper interface {

--- a/qdb/qdb.go
+++ b/qdb/qdb.go
@@ -9,11 +9,11 @@ import (
 
 type ShardingSchemaKeeper interface {
 	/* persist start of key range move in distributed storage */
-	RecordKeyRangeMove() error
+	RecordKeyRangeMove(ctx context.Context, m *MoveKeyRange) error
 	/* list all key-range moves in progress */
-	ListKeyRangeMoves() error
+	ListKeyRangeMoves(ctx context.Context) ([]*MoveKeyRange, error)
 	/* mark key range move as completed */
-	CompleteKeyRangeMove() error
+	UpdateKeyRangeMoveStatus(ctx context.Context, moveId string) error
 }
 
 type TopolodyKeeper interface {
@@ -71,7 +71,7 @@ type XQDB interface {
 	// router topology
 	TopolodyKeeper
 	// data move state
-	//ShardingSchemaKeeper TODO: impl
+	ShardingSchemaKeeper
 	DistributedXactKepper
 }
 

--- a/qdb/qdb.go
+++ b/qdb/qdb.go
@@ -24,17 +24,17 @@ type TopolodyKeeper interface {
 	LockRouter(ctx context.Context, id string) error
 }
 
-/* keep status of two-phase data move transaction */
+// Keep track of the status of the two-phase data move transaction.
 type DistributedXactKepper interface {
 	RecordTransferTx(ctx context.Context, key string, info *DataTransferTransaction) error
 	GetTransferTx(ctx context.Context, key string) (*DataTransferTransaction, error)
 	RemoveTransferTx(ctx context.Context, key string) error
 }
 
-/* this is generic interface for both coordinator and router to use
-* Router should use memory-based version of this interface, to cache
-* state of routing schema, while coordinator should use etcd-based
-* impelementation to keep distributed state in sync.
+/* This is a generic interface to be used by both the coordinator and the router.
+* The router should use a memory-based version of this interface to cache
+* the state of the routing schema, while the coordinator should use an etcd-based
+* implementation to keep the distributed state in sync.
  */
 type QDB interface {
 	AddShardingRule(ctx context.Context, rule *ShardingRule) error
@@ -65,6 +65,7 @@ type QDB interface {
 }
 
 // Extended QDB
+// The coordinator should use an etcd-based implementation to keep the distributed state in sync.
 type XQDB interface {
 	// routing schema
 	QDB

--- a/test/feature/spqr_test.go
+++ b/test/feature/spqr_test.go
@@ -55,7 +55,7 @@ type testContext struct {
 	sqlUserQueryError sync.Map // host -> error
 	commandRetcode    int
 	commandOutput     string
-	qdb               qdb.QDB
+	qdb               qdb.XQDB
 	t                 *testing.T
 }
 


### PR DESCRIPTION
Split qdb interface into smaller ones.
Qdb is interface for key range and sharding rule operations. However, we also need extended QDB interface to keep routers of spqr installation, key-range move operation status etc. 