### PR TITLE
fix key range intersection checks

### DIFF
--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -812,6 +812,11 @@ func (qc *qdbCoordinator) Move(ctx context.Context, req *kr.MoveKeyRange) error 
 	//move between shards
 	keyRange, _ := qc.db.GetKeyRange(ctx, req.Krid)
 	shardingRules, _ := qc.ListShardingRules(ctx)
+
+	if keyRange.ShardID == req.ShardId {
+		return nil
+	}
+
 	/* physical changes on shards */
 	err = datatransfers.MoveKeys(ctx, keyRange.ShardID, req.ShardId, *keyRange, shardingRules, qc.db)
 	if err != nil {

--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -579,6 +579,9 @@ func (qc *qdbCoordinator) Split(ctx context.Context, req *kr.SplitKeyRange) erro
 		}
 	}()
 
+	if kr.CmpRangesEqual(req.Bound, krOld.LowerBound) || kr.CmpRangesEqual(req.Bound, krOld.UpperBound) {
+		return fmt.Errorf("failed to split because bound equals lower or upper bound of the key range")
+	}
 	if kr.CmpRangesLess(req.Bound, krOld.LowerBound) || !kr.CmpRangesLess(req.Bound, krOld.UpperBound) {
 		return fmt.Errorf("failed to split because bound is out of key range")
 	}

--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -580,6 +580,9 @@ func (qc *qdbCoordinator) Split(ctx context.Context, req *kr.SplitKeyRange) erro
 	if kr.CmpRangesLess(req.Bound, krOld.LowerBound) || !kr.CmpRangesLess(req.Bound, krOld.UpperBound) {
 		return fmt.Errorf("failed to split because bound is out of key range")
 	}
+	if _, err := qc.db.GetKeyRange(ctx, req.Krid); err == nil {
+		return fmt.Errorf("key range %v already present in qdb", req.Krid)
+	}
 
 	krNew := kr.KeyRangeFromDB(
 		&qdb.KeyRange{

--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -818,8 +818,7 @@ func (qc *qdbCoordinator) Move(ctx context.Context, req *kr.MoveKeyRange) error 
 	keyRange, _ := qc.db.GetKeyRange(ctx, req.Krid)
 	shardingRules, _ := qc.ListShardingRules(ctx)
 
-	// no need to move data to the same
-	// so pretend work is done
+	// no need to move data to the same shard
 	if keyRange.ShardID == req.ShardId {
 		return nil
 	}

--- a/qdb/ops/ops.go
+++ b/qdb/ops/ops.go
@@ -51,8 +51,9 @@ func AddKeyRangeWithChecks(ctx context.Context, qdb qdb.QDB, keyRange *kr.KeyRan
 	}
 
 	for _, v := range existsKrids {
-		if kr.CmpRangesLess(keyRange.LowerBound, v.LowerBound) && kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) ||
-			kr.CmpRangesLess(keyRange.LowerBound, v.UpperBound) && kr.CmpRangesLess(v.UpperBound, keyRange.UpperBound) {
+		if kr.CmpRangesLessEqual(keyRange.LowerBound, v.LowerBound) && kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) ||
+			kr.CmpRangesLess(keyRange.LowerBound, v.UpperBound) && kr.CmpRangesLess(v.UpperBound, keyRange.UpperBound) ||
+			kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) && kr.CmpRangesLess(keyRange.UpperBound, v.UpperBound) {
 			return fmt.Errorf("key range %v intersects with %v present in qdb", keyRange.ID, v.KeyRangeID)
 		}
 	}
@@ -124,8 +125,9 @@ func ModifyKeyRangeWithChecks(ctx context.Context, qdb qdb.QDB, keyRange *kr.Key
 			// update req
 			continue
 		}
-		if kr.CmpRangesLess(keyRange.LowerBound, v.LowerBound) && kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) ||
-			kr.CmpRangesLess(keyRange.LowerBound, v.UpperBound) && kr.CmpRangesLess(v.UpperBound, keyRange.UpperBound) {
+		if kr.CmpRangesLessEqual(keyRange.LowerBound, v.LowerBound) && kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) ||
+			kr.CmpRangesLess(keyRange.LowerBound, v.UpperBound) && kr.CmpRangesLess(v.UpperBound, keyRange.UpperBound) ||
+			kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) && kr.CmpRangesLess(keyRange.UpperBound, v.UpperBound) {
 			return fmt.Errorf("key range %v intersects with %v present in qdb", keyRange.ID, v.KeyRangeID)
 		}
 	}

--- a/qdb/ops/ops.go
+++ b/qdb/ops/ops.go
@@ -36,10 +36,9 @@ func AddShardingRuleWithChecks(ctx context.Context, qdb qdb.QDB, rule *shrule.Sh
 }
 
 func AddKeyRangeWithChecks(ctx context.Context, qdb qdb.QDB, keyRange *kr.KeyRange) error {
-	// TODO: do real validate
-	//if err := validateShard(ctx, qdb, keyRange.ShardID); err != nil {
-	//	return err
-	//}
+	if _, err := qdb.GetShard(ctx, keyRange.ShardID); err != nil {
+		return err
+	}
 
 	if _, err := qdb.GetKeyRange(ctx, keyRange.ID); err == nil {
 		return fmt.Errorf("key range %v already present in qdb", keyRange.ID)
@@ -51,10 +50,8 @@ func AddKeyRangeWithChecks(ctx context.Context, qdb qdb.QDB, keyRange *kr.KeyRan
 	}
 
 	for _, v := range existsKrids {
-		if kr.CmpRangesLessEqual(keyRange.LowerBound, v.LowerBound) && kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) ||
-			kr.CmpRangesLess(keyRange.LowerBound, v.UpperBound) && kr.CmpRangesLess(v.UpperBound, keyRange.UpperBound) ||
-			kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) && kr.CmpRangesLess(keyRange.UpperBound, v.UpperBound) {
-			return fmt.Errorf("key range %v intersects with %v present in qdb", keyRange.ID, v.KeyRangeID)
+		if doIntersect(keyRange, v) {
+			return fmt.Errorf("key range %v intersects with key range %v in QDB", keyRange.ID, v.KeyRangeID)
 		}
 	}
 
@@ -125,12 +122,25 @@ func ModifyKeyRangeWithChecks(ctx context.Context, qdb qdb.QDB, keyRange *kr.Key
 			// update req
 			continue
 		}
-		if kr.CmpRangesLessEqual(keyRange.LowerBound, v.LowerBound) && kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) ||
-			kr.CmpRangesLess(keyRange.LowerBound, v.UpperBound) && kr.CmpRangesLess(v.UpperBound, keyRange.UpperBound) ||
-			kr.CmpRangesLess(v.LowerBound, keyRange.UpperBound) && kr.CmpRangesLess(keyRange.UpperBound, v.UpperBound) {
-			return fmt.Errorf("key range %v intersects with %v present in qdb", keyRange.ID, v.KeyRangeID)
+		if doIntersect(keyRange, v) {
+			return fmt.Errorf("key range %v intersects with key range %v in QDB", keyRange.ID, v.KeyRangeID)
 		}
 	}
 
 	return qdb.UpdateKeyRange(ctx, keyRange.ToDB())
+}
+
+// This method checks if two key ranges intersect
+func doIntersect(l *kr.KeyRange, r *qdb.KeyRange) bool {
+	// l0     r0      l1      r1
+	// |------|-------|--------
+	//
+	// r0     l0      r1      l1
+	// -------|-------|-------|
+	//
+	// r0     l0      r1      l1
+	// |------|-------|--------
+	return kr.CmpRangesLessEqual(l.LowerBound, r.LowerBound) && kr.CmpRangesLess(r.LowerBound, l.UpperBound) ||
+		kr.CmpRangesLess(l.LowerBound, r.UpperBound) && kr.CmpRangesLess(r.UpperBound, l.UpperBound) ||
+		kr.CmpRangesLess(r.LowerBound, l.UpperBound) && kr.CmpRangesLess(l.UpperBound, r.UpperBound)
 }

--- a/qdb/ops/ops.go
+++ b/qdb/ops/ops.go
@@ -138,9 +138,9 @@ func doIntersect(l *kr.KeyRange, r *qdb.KeyRange) bool {
 	// r0     l0      r1      l1
 	// -------|-------|-------|
 	//
-	// r0     l0      r1      l1
-	// |------|-------|--------
+	// l0     r0      l1      r1
+	// -------|-------|-------|
 	return kr.CmpRangesLessEqual(l.LowerBound, r.LowerBound) && kr.CmpRangesLess(r.LowerBound, l.UpperBound) ||
-		kr.CmpRangesLess(l.LowerBound, r.UpperBound) && kr.CmpRangesLess(r.UpperBound, l.UpperBound) ||
-		kr.CmpRangesLess(r.LowerBound, l.UpperBound) && kr.CmpRangesLess(l.UpperBound, r.UpperBound)
+		kr.CmpRangesLess(l.LowerBound, r.UpperBound) && kr.CmpRangesLessEqual(r.UpperBound, l.UpperBound) ||
+		kr.CmpRangesLess(r.LowerBound, l.UpperBound) && kr.CmpRangesLessEqual(l.UpperBound, r.UpperBound)
 }

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -429,3 +429,49 @@ Feature: Coordinator test
       "Upper bound":"40"
     }]
     """
+
+  Scenario: Add intersecting key range fails
+    #
+    # Create test key range
+    #
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid3 FROM 100 TO 110 ROUTE TO sh1
+    """
+    Then command return code should be "0"
+
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid4 FROM 90 TO 105 ROUTE TO sh1
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    key range krid4 intersects with krid3 present in qdb
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid4 FROM 105 TO 115 ROUTE TO sh1
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    key range krid4 intersects with krid3 present in qdb
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid4 FROM 102 TO 108 ROUTE TO sh1
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    key range krid4 intersects with krid3 present in qdb
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid4 FROM 90 TO 120 ROUTE TO sh1
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    key range krid4 intersects with krid3 present in qdb
+    """

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -343,7 +343,7 @@ Feature: Coordinator test
     """
 
     #
-    # Check we cannot split by right end of open interval
+    # Check we cannot split by lower or upper bound
     #
     When I run SQL on host "coordinator"
     """
@@ -351,7 +351,16 @@ Feature: Coordinator test
     """
     Then SQL error on host "coordinator" should match regexp
     """
-    bound is out of key range
+    failed to split because bound equals lower or upper bound of the key range
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    SPLIT KEY RANGE krid3 FROM krid2 BY 11
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    failed to split because bound equals lower or upper bound of the key range
     """
 
   Scenario: Router is down

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -446,7 +446,7 @@ Feature: Coordinator test
     """
     Then SQL error on host "coordinator" should match regexp
     """
-    key range krid4 intersects with krid3 present in qdb
+    key range krid4 intersects with key range krid3 in QDB
     """
 
     When I run SQL on host "coordinator"
@@ -455,7 +455,7 @@ Feature: Coordinator test
     """
     Then SQL error on host "coordinator" should match regexp
     """
-    key range krid4 intersects with krid3 present in qdb
+    key range krid4 intersects with key range krid3 in QDB
     """
 
     When I run SQL on host "coordinator"
@@ -464,7 +464,7 @@ Feature: Coordinator test
     """
     Then SQL error on host "coordinator" should match regexp
     """
-    key range krid4 intersects with krid3 present in qdb
+    key range krid4 intersects with key range krid3 in QDB
     """
 
     When I run SQL on host "coordinator"
@@ -473,5 +473,5 @@ Feature: Coordinator test
     """
     Then SQL error on host "coordinator" should match regexp
     """
-    key range krid4 intersects with krid3 present in qdb
+    key range krid4 intersects with key range krid3 in QDB
     """

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -475,3 +475,39 @@ Feature: Coordinator test
     """
     key range krid4 intersects with key range krid3 in QDB
     """
+
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid4 FROM 105 TO 110 ROUTE TO sh1
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    key range krid4 intersects with key range krid3 in QDB
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid4 FROM 70 TO 110 ROUTE TO sh1
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    key range krid4 intersects with key range krid3 in QDB
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid4 FROM 100 TO 120 ROUTE TO sh1
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    key range krid4 intersects with key range krid3 in QDB
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    ADD KEY RANGE krid4 FROM 100 TO 105 ROUTE TO sh1
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    key range krid4 intersects with key range krid3 in QDB
+    """


### PR DESCRIPTION
* added feature tests for adding intersecting key range
* fix adding existing krid by splitting
* fix moving key range to the same shardID

If you move key range to the same shardID, it will return an error with the following message: `ERROR:  ERROR: transaction identifier "sh2-krid4" is already in use (SQLSTATE 42710)`. So I thought it's kinda pointless to move to the same shard and added another check.

Also when adding a new key range, one case of ranges intersection was uncovered - when you add a key range that's inside another existing key range. Thus this key range is added, but they actually intersect.