### PR TITLE
fix coordinator crash when moving key range twice

### DIFF
--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -841,7 +841,8 @@ func (qc *qdbCoordinator) Move(ctx context.Context, req *kr.MoveKeyRange) error 
 	if err := qc.traverseRouters(ctx, func(cc *grpc.ClientConn) error {
 		cl := routerproto.NewKeyRangeServiceClient(cc)
 		moveResp, err := cl.MoveKeyRange(ctx, &routerproto.MoveKeyRangeRequest{
-			KeyRange: krmv.ToProto(),
+			KeyRange:  krmv.ToProto(),
+			ToShardId: krmv.ShardID,
 		})
 		spqrlog.Zero.Debug().
 			Interface("response", moveResp).

--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -937,7 +937,7 @@ func (q *EtcdQDB) UpdateKeyRangeMoveStatus(ctx context.Context, moveId string, s
 	if err != nil {
 		return err
 	}
-	if len(resp.Kvs[0].Value) != 1 {
+	if len(resp.Kvs) != 1 {
 		return fmt.Errorf("failed to update move key range operation by id %s", moveId)
 	}
 	var moveKr MoveKeyRange


### PR DESCRIPTION
Why do we mark status of MoveKeyRange as completed in qdb instead of just removing it? Completed operations just pollute qdb, don't they?