### PR TITLE
add checks to move key range

### DIFF
--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -718,7 +718,7 @@ func (qc *qdbCoordinator) Unite(ctx context.Context, uniteKeyRange *kr.UniteKeyR
 	}
 	if !kr.CmpRangesEqual(krLeft.UpperBound, krRight.LowerBound) {
 		if !kr.CmpRangesEqual(krLeft.LowerBound, krRight.UpperBound) {
-			return fmt.Errorf("failed to unite not adjacent key ranges")
+			return fmt.Errorf("failed to unite non-adjacent key ranges")
 		}
 		krLeft, krRight = krRight, krLeft
 	}
@@ -784,6 +784,20 @@ func (qc *qdbCoordinator) Move(ctx context.Context, req *kr.MoveKeyRange) error 
 		Str("shard-id", req.ShardId).
 		Msg("qdb coordinator move key range")
 
+	keyRange, err := qc.db.GetKeyRange(ctx, req.Krid)
+	if err != nil {
+		return err
+	}
+	shardingRules, err := qc.ListShardingRules(ctx)
+	if err != nil {
+		return err
+	}
+
+	// no need to move data to the same shard
+	if keyRange.ShardID == req.ShardId {
+		return nil
+	}
+
 	moveId, err := qc.RecordKeyRangeMove(ctx,
 		&qdb.MoveKeyRange{
 			MoveId:     uuid.New().String(),
@@ -813,15 +827,6 @@ func (qc *qdbCoordinator) Move(ctx context.Context, req *kr.MoveKeyRange) error 
 			spqrlog.Zero.Error().Err(err).Msg("")
 		}
 	}()
-
-	//move between shards
-	keyRange, _ := qc.db.GetKeyRange(ctx, req.Krid)
-	shardingRules, _ := qc.ListShardingRules(ctx)
-
-	// no need to move data to the same shard
-	if keyRange.ShardID == req.ShardId {
-		return nil
-	}
 
 	/* physical changes on shards */
 	err = datatransfers.MoveKeys(ctx, keyRange.ShardID, req.ShardId, *keyRange, shardingRules, qc.db)

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -313,7 +313,7 @@ Feature: Coordinator test
     """
     Then SQL error on host "coordinator" should match regexp
     """
-    failed to unite not adjacent key ranges
+    failed to unite non-adjacent key ranges
     """
 
   Scenario: Unite in reverse order works

--- a/test/feature/features/move.feature
+++ b/test/feature/features/move.feature
@@ -164,7 +164,7 @@ Feature: Move test
   Scenario: Move to non-existent shard fails
     When I run SQL on host "coordinator"
     """
-    MOVE KEY RANGE krid1 TO sh3
+    MOVE KEY RANGE krid1 TO non-existent
     """
     Then command return code should be "1"
     And SQL error on host "coordinator" should match regexp

--- a/test/feature/features/move.feature
+++ b/test/feature/features/move.feature
@@ -1,6 +1,5 @@
 Feature: Move test
-
-  Scenario: MOVE KEY RANGE works
+  Background:
     Given cluster is up and running
     When I execute SQL on host "coordinator"
     """
@@ -9,6 +8,8 @@ Feature: Move test
     ADD KEY RANGE krid2 FROM 11 TO 20 ROUTE TO sh2;
     """
     Then command return code should be "0"
+
+  Scenario: MOVE KEY RANGE works
     When I run SQL on host "shard1"
     """
     CREATE TABLE xMove(w_id INT, s TEXT);
@@ -63,14 +64,7 @@ Feature: Move test
     001
     """
 
-    Scenario: MOVE KEY RANGE works with many rows
-    Given cluster is up and running
-    When I execute SQL on host "coordinator"
-    """
-    ADD SHARDING RULE r1 COLUMNS w_id;
-    ADD KEY RANGE krid1 FROM 1 TO 10 ROUTE TO sh1;
-    """
-    Then command return code should be "0"
+  Scenario: MOVE KEY RANGE works with many rows
     When I run SQL on host "shard1"
     """
     CREATE TABLE xMove(w_id INT, s TEXT);
@@ -110,14 +104,7 @@ Feature: Move test
     .*001(.|\n)*002(.|\n)*003(.|\n)*004(.|\n)*005
     """
 
-    Scenario: MOVE KEY RANGE works with many tables
-    Given cluster is up and running
-    When I execute SQL on host "coordinator"
-    """
-    ADD SHARDING RULE r1 COLUMNS w_id;
-    ADD KEY RANGE krid1 FROM 1 TO 10 ROUTE TO sh1;
-    """
-    Then command return code should be "0"
+  Scenario: MOVE KEY RANGE works with many tables
     When I run SQL on host "shard1"
     """
     CREATE TABLE xMove(w_id INT, s TEXT);
@@ -172,4 +159,26 @@ Feature: Move test
     And SQL result should not match regexp
     """
     002
+    """
+
+  Scenario: Move to non-existent shard fails
+    When I run SQL on host "coordinator"
+    """
+    MOVE KEY RANGE krid1 TO sh3
+    """
+    Then command return code should be "1"
+    And SQL error on host "coordinator" should match regexp
+    """
+    failed to connect
+    """
+
+  Scenario: Move non-existent key range fails
+    When I run SQL on host "coordinator"
+    """
+    MOVE KEY RANGE krid3 TO sh2
+    """
+    Then command return code should be "1"
+    And SQL error on host "coordinator" should match regexp
+    """
+    failed to fetch key range with id /keyranges/krid3
     """


### PR DESCRIPTION
* Check if key range exists
* Add tests for non-existent key range scenario and non-existent shard scenario
* Fixed typo

If we encounter an error when moving data from shard to shard, record in qdb will be marked as completed anyway. As stated in #282, we need these records to "decide key-range configuration more efficiently and precise", but actually there was no data movement. It may lead us to wrong decision. What you think?