### PR TITLE
Parallelize scenarios

### DIFF
--- a/.github/scenario_balancer.py
+++ b/.github/scenario_balancer.py
@@ -1,0 +1,17 @@
+N = 16
+import sys
+import os
+
+l = [[int(line.split()[0]), line.split()[1]] for line in sys.stdin.readlines()]
+buckets = [[0, []] for _ in range(N)]
+for w, p in l:
+    b = min(buckets, key=lambda b: b[0])
+    b[0] += w
+    b[1].append(p)
+matrix = []
+for _, ps in buckets:
+    if len(ps) == 0:
+        continue
+    tests = ';'.join([os.path.basename(p) for p in ps])
+    matrix.append('GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE="{}" make feature_test_ci'.format(tests))
+print(matrix)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,13 +65,6 @@ jobs:
     outputs:
       output1: ${{ steps.step1.outputs.features }}
     steps:
-      - name: Install Latest Docker
-        run: |
-          for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
-          sudo apt-get update
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Check Docker Version
         run: docker --version
 
@@ -114,13 +107,6 @@ jobs:
       # do not cancel all tests if one failed
       fail-fast: false
     steps:
-      - name: Install Latest Docker
-        run: |
-          for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
-          sudo apt-get update
-          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Check Docker Version
         run: docker --version
       - name: Check out code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,7 +72,7 @@ jobs:
       - id: step1
         run: |
           make split_feature_test
-          array=$(for x in $(ls test/feature/generatedFeatures); do echo $x; done | python3 -c "import sys; print(['GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE={} make feature_test'.format(test.strip()) for test in sys.stdin.readlines()])")
+          array=$(for x in $(ls test/feature/generatedFeatures); do echo $x; done | python3 -c "import sys; print(['GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE={} make feature_test_ci'.format(test.strip()) for test in sys.stdin.readlines()])")
           echo "features=$(echo "{\"command\": $array}")" >> $GITHUB_OUTPUT
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
@@ -101,7 +101,7 @@ jobs:
         run: docker --version
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Download spqr build
+      - name: Download generatedFeatures
         uses: actions/download-artifact@v3
         with:
           name: generated_tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,19 +51,11 @@ jobs:
       - name: regress tests
         run: make regress
 
-  feature:
-    name: feature
+  feature_prepare:
+    name: feature_prepare
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        command:
-          - 'GODOG_FEATURE=base.feature make feature_test'
-          - 'GODOG_FEATURE=coordinator.feature make feature_test'
-          - 'GODOG_FEATURE=memqdb.feature make feature_test'
-          - 'GODOG_FEATURE=move_recover.feature make feature_test'
-          - 'GODOG_FEATURE=move.feature make feature_test'
-      # do not cancel all tests if one failed
-      fail-fast: false
+    outputs:
+      output1: ${{ steps.step1.outputs.features }}
     steps:
       - name: Install Latest Docker
         run: |
@@ -77,6 +69,42 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v2
+      - id: step1
+        run: |
+          make split_feature_test
+          array=$(for x in $(ls test/feature/generatedFeatures); do echo $x; done | python3 -c "import sys; print(['GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE={} make feature_test'.format(test.strip()) for test in sys.stdin.readlines()])")
+          echo "features=$(echo "{\"command\": $array}")" >> $GITHUB_OUTPUT
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: generated_tests
+          path: |
+            ./test/feature/generatedFeatures
 
+  feature:
+    name: feature
+    runs-on: ubuntu-latest
+    needs: feature_prepare
+    strategy:
+      matrix: ${{ fromJson(needs.feature_prepare.outputs.output1) }}
+      # do not cancel all tests if one failed
+      fail-fast: false
+    steps:
+      - name: Install Latest Docker
+        run: |
+          for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
+          sudo apt-get update
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+      - name: Check Docker Version
+        run: docker --version
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Download spqr build
+        uses: actions/download-artifact@v3
+        with:
+          name: generated_tests
+          path: ./test/feature/generatedFeatures
       - name: feature tests
         run: ${{ matrix.command }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -70,26 +70,7 @@ jobs:
       - id: step1
         run: |
           make split_feature_test
-          cat << EOD > balancer.py
-          N = 14
-          import sys
-          import os
-
-          l = [[int(line.split()[0]), line.split()[1]] for line in sys.stdin.readlines()]
-          buckets = [[0, []] for _ in range(N)]
-          for w, p in l:
-              b = min(buckets, key=lambda b: b[0])
-              b[0] += w
-              b[1].append(p)
-          matrix = []
-          for _, ps in buckets:
-              if len(ps) == 0:
-                  continue
-              tests = ';'.join([os.path.basename(p) for p in ps])
-              matrix.append('GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE="{}" make feature_test_ci'.format(tests))
-          print(matrix)
-          EOD
-          array=$(find test/feature/generatedFeatures -type f -exec wc -l {} \; | sort -rn | awk 'NR!=1 {printf $0"\n"}' | python3 balancer.py)
+          array=$(find test/feature/generatedFeatures -type f -exec wc -l {} \; | sort -rn | awk 'NR!=1 {printf $0"\n"}' | python3 .github/scenario_balancer.py)
           echo "features=$(echo "{\"command\": $array}")" >> $GITHUB_OUTPUT
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,7 +74,26 @@ jobs:
       - id: step1
         run: |
           make split_feature_test
-          array=$(for x in $(find test/feature/generatedFeatures -type f -exec wc -l {} + | sort -rn | awk 'NR!=1 {printf $2"\n"}' | xargs basename -a); do echo $x; done | python3 -c "import sys; print(['GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE={} make feature_test_ci'.format(test.strip()) for test in sys.stdin.readlines()])")
+          cat << EOD > balancer.py
+          N = 14
+          import sys
+          import os
+
+          l = [[int(line.split()[0]), line.split()[1]] for line in sys.stdin.readlines()]
+          buckets = [[0, []] for _ in range(N)]
+          for w, p in l:
+              b = min(buckets, key=lambda b: b[0])
+              b[0] += w
+              b[1].append(p)
+          matrix = []
+          for _, ps in buckets:
+              if len(ps) == 0:
+                  continue
+              tests = ';'.join([os.path.basename(p) for p in ps])
+              matrix.append('GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE="{}" make feature_test_ci'.format(tests))
+          print(matrix)
+          EOD
+          array=$(find test/feature/generatedFeatures -type f -exec wc -l {} \; | sort -rn | awk 'NR!=1 {printf $0"\n"}' | python3 balancer.py)
           echo "features=$(echo "{\"command\": $array}")" >> $GITHUB_OUTPUT
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,11 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  CACHE_FOLDER: ~/docker-images-${{ github.sha }}
-  CACHE_FILE_SPQR: ~/docker-images-${{ github.sha }}/spqr-base-image.tgz
   IMAGE_SHARD: spqr-shard-image
-  IMAGE_SPQR: spqr-base-image
-  IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
   SHARD_CACHE_KEY: sha256sum-of-docker-shard
   CACHE_FILE_SHARD: ~/spqr-shard-image-shard-cache-key.tgz
 
@@ -110,13 +106,6 @@ jobs:
           echo "CACHE_FILE_SHARD=$CACHE_FILE_SHARD" >> $GITHUB_ENV
 
       #  use cache to pass docker images to the test jobs
-      - name: Docker images caching
-        id: cache-images
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.CACHE_FILE_SPQR }}
-          key: ${{ env.IMAGES_CACHE_KEY }}
       - name: Docker shard image caching
         id: cache-shard-image
         uses: actions/cache@v3
@@ -129,9 +118,7 @@ jobs:
       - name: Build shard image
         if: steps.cache-shard-image.outputs.cache-hit != 'true'
         run: make save_shard_image
-      - name: Build images
-        if: steps.cache-images.outputs.cache-hit != 'true'
-        run: make save_image
+
 
   feature:
     name: feature
@@ -168,13 +155,6 @@ jobs:
           path: ./test/feature/generatedFeatures
 
       # load docker images
-      - name: Load docker images
-        id: cache-images
-        uses: actions/cache@v3
-        with:
-          path: |
-            ${{ env.CACHE_FILE_SPQR }}
-          key: ${{ env.IMAGES_CACHE_KEY }}
       - name: Load shard image
         id: cache-shard-image
         uses: actions/cache@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,14 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  CACHE_FOLDER: ~/docker-images-${{ github.sha }}
+  CACHE_FILE_SHARD: ~/docker-images-${{ github.sha }}/spqr-shard-image.tgz
+  CACHE_FILE_SPQR: ~/docker-images-${{ github.sha }}/spqr-base-image.tgz
+  IMAGE_SHARD: spqr-shard-image
+  IMAGE_SPQR: spqr-base-image
+  IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
+
 jobs:
 
   unit:
@@ -81,6 +89,22 @@ jobs:
           path: |
             ./test/feature/generatedFeatures
 
+
+      #  use cache to pass docker images to the test jobs
+      - name: Docker images caching
+        id: cache-images
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.CACHE_FILE_SHARD }}
+            ${{ env.CACHE_FILE_SPQR }}
+          key: ${{ env.IMAGES_CACHE_KEY }}
+
+      # build images
+      - name: Build images
+        if: steps.cache-images.outputs.cache-hit != 'true'
+        run: make save_image
+
   feature:
     name: feature
     runs-on: ubuntu-latest
@@ -106,5 +130,16 @@ jobs:
         with:
           name: generated_tests
           path: ./test/feature/generatedFeatures
+
+      # load docker images
+      - name: Load docker images
+        id: cache-images
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.CACHE_FILE_SHARD }}
+            ${{ env.CACHE_FILE_SPQR }}
+          key: ${{ env.IMAGES_CACHE_KEY }}
+
       - name: feature tests
         run: ${{ matrix.command }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,11 +8,12 @@ on:
 
 env:
   CACHE_FOLDER: ~/docker-images-${{ github.sha }}
-  CACHE_FILE_SHARD: ~/docker-images-${{ github.sha }}/spqr-shard-image.tgz
   CACHE_FILE_SPQR: ~/docker-images-${{ github.sha }}/spqr-base-image.tgz
   IMAGE_SHARD: spqr-shard-image
   IMAGE_SPQR: spqr-base-image
   IMAGES_CACHE_KEY: docker-images-${{ github.sha }}
+  SHARD_CACHE_KEY: sha256sum-of-docker-shard
+  CACHE_FILE_SHARD: ~/spqr-shard-image-shard-cache-key.tgz
 
 jobs:
 
@@ -73,7 +74,7 @@ jobs:
       - id: step1
         run: |
           make split_feature_test
-          array=$(for x in $(ls test/feature/generatedFeatures); do echo $x; done | python3 -c "import sys; print(['GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE={} make feature_test_ci'.format(test.strip()) for test in sys.stdin.readlines()])")
+          array=$(for x in $(find test/feature/generatedFeatures -type f -exec wc -l {} + | sort -rn | awk 'NR!=1 {printf $2"\n"}' | xargs basename -a); do echo $x; done | python3 -c "import sys; print(['GODOG_FEATURE_DIR=generatedFeatures GODOG_FEATURE={} make feature_test_ci'.format(test.strip()) for test in sys.stdin.readlines()])")
           echo "features=$(echo "{\"command\": $array}")" >> $GITHUB_OUTPUT
       - name: Archive production artifacts
         uses: actions/upload-artifact@v3
@@ -82,6 +83,12 @@ jobs:
           path: |
             ./test/feature/generatedFeatures
 
+      - name: Update env
+        run: |
+          SHARD_CACHE_KEY="spqr-shard-image-$(find docker/shard/ -type f -exec sha256sum '{}' \; | sha256sum | awk '{printf $1}')"
+          CACHE_FILE_SHARD="~/$SHARD_CACHE_KEY.tgz"
+          echo "SHARD_CACHE_KEY=$SHARD_CACHE_KEY" >> $GITHUB_ENV
+          echo "CACHE_FILE_SHARD=$CACHE_FILE_SHARD" >> $GITHUB_ENV
 
       #  use cache to pass docker images to the test jobs
       - name: Docker images caching
@@ -89,11 +96,20 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.CACHE_FILE_SHARD }}
             ${{ env.CACHE_FILE_SPQR }}
           key: ${{ env.IMAGES_CACHE_KEY }}
+      - name: Docker shard image caching
+        id: cache-shard-image
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.CACHE_FILE_SHARD }}
+          key: ${{ env.SHARD_CACHE_KEY }}
 
       # build images
+      - name: Build shard image
+        if: steps.cache-shard-image.outputs.cache-hit != 'true'
+        run: make save_shard_image
       - name: Build images
         if: steps.cache-images.outputs.cache-hit != 'true'
         run: make save_image
@@ -107,10 +123,25 @@ jobs:
       # do not cancel all tests if one failed
       fail-fast: false
     steps:
+      - name: Install Latest Docker
+        run: |
+          for pkg in docker.io docker-doc docker-compose podman-docker containerd runc; do sudo apt-get remove $pkg; done
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+          sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu  $(lsb_release -cs)  stable"
+          sudo apt-get update
+          sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
       - name: Check Docker Version
         run: docker --version
       - name: Check out code
         uses: actions/checkout@v2
+
+      - name: Update env
+        run: |
+          SHARD_CACHE_KEY="spqr-shard-image-$(find docker/shard/ -type f -exec sha256sum '{}' \; | sha256sum | awk '{printf $1}')"
+          CACHE_FILE_SHARD="~/$SHARD_CACHE_KEY.tgz"
+          echo "SHARD_CACHE_KEY=$SHARD_CACHE_KEY" >> $GITHUB_ENV
+          echo "CACHE_FILE_SHARD=$CACHE_FILE_SHARD" >> $GITHUB_ENV
+
       - name: Download generatedFeatures
         uses: actions/download-artifact@v3
         with:
@@ -123,9 +154,15 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.CACHE_FILE_SHARD }}
             ${{ env.CACHE_FILE_SPQR }}
           key: ${{ env.IMAGES_CACHE_KEY }}
+      - name: Load shard image
+        id: cache-shard-image
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.CACHE_FILE_SHARD }}
+          key: ${{ env.SHARD_CACHE_KEY }}
 
       - name: feature tests
         run: ${{ matrix.command }}

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,12 @@ split_feature_test:
 clean_feature_test:
 	rm -rf test/feature/generatedFeatures
 
+feature_test_ci: build_images
+	go build ./test/feature/...
+	rm -rf ./test/feature/logs
+	mkdir ./test/feature/logs
+	(cd test/feature; go test -timeout 150m)
+
 feature_test: build_images
 	make split_feature_test
 	go build ./test/feature/...

--- a/Makefile
+++ b/Makefile
@@ -43,14 +43,6 @@ build: build_balancer build_coordinator build_coorctl build_router build_mover b
 build_images:
 	docker-compose build spqr-base-image spqr-shard-image
 
-save_image:
-	mkdir -p ${CACHE_FOLDER}
-	sudo rm -rf ${CACHE_FOLDER}/*
-	
-	docker-compose build ${IMAGE_SPQR};\
-	docker save ${IMAGE_SPQR} | gzip -c > ${CACHE_FILE_SPQR};\
-	ls ${CACHE_FOLDER}
-
 save_shard_image:
 	sudo rm -f spqr-shard-image-*
 	docker-compose build ${IMAGE_SHARD};\
@@ -103,14 +95,13 @@ clean_feature_test:
 	rm -rf test/feature/generatedFeatures
 
 feature_test_ci:
-	@if [ "x" = "${CACHE_FILE_SHARD}x" ] || [ "x" = "${CACHE_FILE_SPQR}x" ]; then\
+	@if [ "x" = "${CACHE_FILE_SHARD}x" ]; then\
 		echo "Rebuild";\
-		make build_images;\
+		docker-compose build spqr-shard-image;\
 	else\
 		docker load -i ${CACHE_FILE_SHARD};\
-		docker load -i ${CACHE_FILE_SPQR};\
 	fi
-
+	docker-compose build spqr-base-image
 	go build ./test/feature/...
 	mkdir ./test/feature/logs
 	(cd test/feature; go test -timeout 150m)

--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,18 @@ build: build_balancer build_coordinator build_coorctl build_router build_mover b
 build_images:
 	docker-compose build spqr-base-image spqr-shard-image
 
-save_image: build_images
+save_image:
 	mkdir -p ${CACHE_FOLDER}
 	sudo rm -rf ${CACHE_FOLDER}/*
-	docker save ${IMAGE_SHARD} | gzip -c > ${CACHE_FILE_SHARD}
-	docker save ${IMAGE_SPQR} | gzip -c > ${CACHE_FILE_SPQR}
+	
+	docker-compose build ${IMAGE_SPQR};\
+	docker save ${IMAGE_SPQR} | gzip -c > ${CACHE_FILE_SPQR};\
 	ls ${CACHE_FOLDER}
+
+save_shard_image:
+	sudo rm -f spqr-shard-image-*
+	docker-compose build ${IMAGE_SHARD};\
+	docker save ${IMAGE_SHARD} | gzip -c > ${CACHE_FILE_SHARD};\
 
 clean:
 	rm -f spqr-router spqr-coordinator spqr-mover spqr-worldmock spqr-balancer
@@ -106,7 +112,6 @@ feature_test_ci:
 	fi
 
 	go build ./test/feature/...
-	rm -rf ./test/feature/logs
 	mkdir ./test/feature/logs
 	(cd test/feature; go test -timeout 150m)
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ save_shard_image:
 
 clean:
 	rm -f spqr-router spqr-coordinator spqr-mover spqr-worldmock spqr-balancer
+	make clean_feature_test
 
 ######################## RUN ########################
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,3 +67,7 @@ services:
             context: .
         hostname: spqr_client
         container_name: spqr_client
+    slicer:
+        build:
+            dockerfile: ./docker/slicer/Dockerfile
+            context: .

--- a/docker/slicer/DocStringSupport.patch
+++ b/docker/slicer/DocStringSupport.patch
@@ -1,0 +1,96 @@
+diff --git a/lib/cucumber-slicer.js b/lib/cucumber-slicer.js
+index 791b40d..6a1357d 100644
+--- a/lib/cucumber-slicer.js
++++ b/lib/cucumber-slicer.js
+@@ -5,11 +5,14 @@ const { extractScenarios,
+         getScenariosOfType,
+         getFeatureTop } = require('./features');
+ 
++function escapeString(str) {
++  return str.replace(/[^a-zA-Z0-9 ]/g, '').replaceAll(' ', '_')
++}
+ 
+ function writeSingleScenarioFile(dir, parsed, scenario) {
+   let output = getFeatureTop(parsed);
+   output += extractScenarios(scenario);
+-  return writeFeatureFile(dir, parsed, output);
++  return writeFeatureFile(dir, parsed, output, escapeString(parsed.feature.name) + '__' + escapeString(scenario[0].name));
+ }
+ 
+ function writeWholeFeatureFile(dir, parsedFeature) {
+@@ -17,7 +20,7 @@ function writeWholeFeatureFile(dir, parsedFeature) {
+   let scenarios = getScenariosOfType(parsedFeature, 'Scenario');
+   scenarios = scenarios.concat(getScenariosOfType(parsedFeature, 'ScenarioOutline'));
+   output += extractScenarios(scenarios);
+-  return writeFeatureFile(dir, parsedFeature, output);
++  return writeFeatureFile(dir, parsedFeature, output, escapeString(parsed.feature.name));
+ }
+ 
+ function splitFeatureFile(parsed, dir) {
+diff --git a/lib/feature-files.js b/lib/feature-files.js
+index 63b0f9b..8f0643f 100644
+--- a/lib/feature-files.js
++++ b/lib/feature-files.js
+@@ -1,8 +1,7 @@
+ const fs = require('fs');
+ const path = require('path');
+-const uuid = require('uuid/v4');
+ 
+-function writeFeatureFile(dir, parsed, content) {
++function writeFeatureFile(dir, parsed, content, filename) {
+   if (!fs.existsSync(dir)) {
+     fs.mkdirSync(dir);
+   }
+@@ -11,9 +10,9 @@ function writeFeatureFile(dir, parsed, content) {
+   if (!fs.existsSync(directory)) {
+     fs.mkdirSync(directory);
+   }
+-  let filename = directory + uuid() + '.feature';
+-  fs.writeFileSync(filename, content);
+-  return filename;
++  let path = directory + filename + '.feature';
++  fs.writeFileSync(path, content);
++  return path;
+ }
+ 
+ module.exports = {
+diff --git a/lib/features.js b/lib/features.js
+index 7902167..907d953 100644
+--- a/lib/features.js
++++ b/lib/features.js
+@@ -27,9 +27,25 @@ function extractExample(table) {
+   return result;
+ }
+ 
+-function extractDataTableArgument(argument) {
++function extractArgument(argument) {
+   if (!argument) return '';
++  if (argument.type === 'DocString') {
++    return extractDocStringArgument(argument);
++  } else if (argument.type === 'DataTable') {
++    return extractDataTableArgument(argument);
++  } else {
++    throw new Error(`Not implemented argument type: ${argument.type}`);
++  }
++}
+ 
++function extractDocStringArgument(argument) {
++  result = '"""\n';
++  result += argument.content + '\n';
++  result += '"""\n'
++  return result
++}
++
++function extractDataTableArgument(argument) {
+   let rows = argument.rows.map((row) => {
+     let values = row.cells.map((cell) => {
+       return cell.value;
+@@ -51,7 +67,7 @@ function extractScenarios(scenarios) {
+     const steps = child.steps;
+     for (let step = 0; step < steps.length; step++) {
+       result += '  ' + steps[step].keyword.trim() + ' ' + steps[step].text.trim() + '\n';
+-      result += extractDataTableArgument(steps[step].argument);
++      result += extractArgument(steps[step].argument);
+     }
+     const examples = child.examples ? child.examples : [];
+     for (let eg = 0; eg < examples.length; eg++) {

--- a/docker/slicer/Dockerfile
+++ b/docker/slicer/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:16-alpine
+
+RUN apk add git
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+
+RUN git clone https://github.com/bbc/cucumber-slicer.git
+WORKDIR cucumber-slicer
+RUN npm install
+
+COPY docker/slicer/DocStringSupport.patch ./
+COPY docker/slicer/slicer.js ./
+
+RUN git apply DocStringSupport.patch
+
+
+RUN mkdir features generatedFeatures
+ENTRYPOINT tar -C features -xv &>/dev/null; \
+    node slicer.js; \
+    (cd generatedFeatures; tar -c .)

--- a/docker/slicer/slicer.js
+++ b/docker/slicer/slicer.js
@@ -1,0 +1,6 @@
+const glob = require('glob');
+const { cucumberSlicer } = require('./lib/cucumber-slicer');
+
+const featureFiles = glob.sync('./features/**/*.feature');
+const generatedFiles = cucumberSlicer(featureFiles,
+'./generatedFeatures');

--- a/test/feature/spqr_test.go
+++ b/test/feature/spqr_test.go
@@ -764,11 +764,16 @@ func InitializeScenario(s *godog.ScenarioContext, t *testing.T) {
 
 func TestSpqr(t *testing.T) {
 	features := "features"
+	if feauterDirEnv, ok := os.LookupEnv("GODOG_FEATURE_DIR"); ok {
+		if len(feauterDirEnv) != 0 {
+			features = feauterDirEnv
+		}
+	}
 	if featureEnv, ok := os.LookupEnv("GODOG_FEATURE"); ok {
 		if !strings.HasSuffix(featureEnv, ".feature") {
 			featureEnv += ".feature"
 		}
-		features = fmt.Sprintf("features/%s", featureEnv)
+		features = fmt.Sprintf("%s/%s", features, featureEnv)
 	}
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(s *godog.ScenarioContext) {

--- a/test/feature/spqr_test.go
+++ b/test/feature/spqr_test.go
@@ -763,25 +763,32 @@ func InitializeScenario(s *godog.ScenarioContext, t *testing.T) {
 }
 
 func TestSpqr(t *testing.T) {
-	features := "features"
+	paths := make([]string, 0)
+	featureDir := "features"
 	if feauterDirEnv, ok := os.LookupEnv("GODOG_FEATURE_DIR"); ok {
 		if len(feauterDirEnv) != 0 {
-			features = feauterDirEnv
+			featureDir = feauterDirEnv
 		}
 	}
 	if featureEnv, ok := os.LookupEnv("GODOG_FEATURE"); ok {
-		if !strings.HasSuffix(featureEnv, ".feature") {
-			featureEnv += ".feature"
+		for _, feature := range strings.Split(featureEnv, ";") {
+			if !strings.HasSuffix(feature, ".feature") {
+				feature += ".feature"
+			}
+			paths = append(paths, fmt.Sprintf("%s/%s", featureDir, feature))
 		}
-		features = fmt.Sprintf("%s/%s", features, featureEnv)
 	}
+	if len(paths) == 0 {
+		paths = append(paths, featureDir)
+	}
+
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(s *godog.ScenarioContext) {
 			InitializeScenario(s, t)
 		},
 		Options: &godog.Options{
 			Format:        "pretty",
-			Paths:         []string{features},
+			Paths:         paths,
 			Strict:        true,
 			NoColors:      true,
 			StopOnFailure: true,


### PR DESCRIPTION
Currently feature tests run in parallel in CI. But this take about 20 min, because a big feature file (e.g. Coordinator.feature). This pull request split big feature files automatically at runtime.

I have a question:
1) Is it OK to use external dependency https://github.com/bbc/cucumber-slicer.git and patch it with patch file?

Also there are a problem I discovered:
1) Overhead of creating new jobs is about 4 minutes, so if we will have a lot feature files in the future, it would be better to not split them.
2) This repo seems only run 20 jobs in parallel, while in my fork it I can run 40 jobs