### PR TITLE
fix index out of range

### DIFF
--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -922,10 +922,10 @@ func (rst *RelayStateImpl) DeployPrepStmt(qname string) (shard.PreparedStatement
 
 	// TODO: multi-shard statements
 	routes := rst.CurrentRoutes()
-	if len(routes) > 0 {
+	if len(routes) == 1 {
 		rst.bindRoute = routes[0]
 	} else {
-		rst.bindRoute = nil
+		return shard.PreparedStatementDescriptor{}, fmt.Errorf("failed to deplou prepared statement %s", query)
 	}
 
 	name := fmt.Sprintf("%d", hash)


### PR DESCRIPTION
```
panic: runtime error: index out of range [0] with length 0

goroutine 117 [running]:
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).DeployPrepStmt(0xc000481040, {0x0, 0x0})
	/root/build/spqr/router/relay/relay.go:924 +0x2e6
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).ProcessExtendedBuffer(0xc000481040, {0x1271b30, 0xc00004b639})
	/root/build/spqr/router/relay/relay.go:1003 +0x778
github.com/pg-sharding/spqr/router.ProcessMessage({0xc0002fac40?, 0x1086283?}, {0x1271b30, 0xc00004b639}, {0x12894d0, 0xc000481040}, {0x126aab0?, 0xc000353330?})
	/root/build/spqr/router/frontend.go:291 +0x675
github.com/pg-sharding/spqr/router.Frontend({0x1271bd0?, 0xc000514000}, {0x128a590, 0xc0002fac40}, {0x1271b30?, 0xc00004b639}, 0x1be82e0, {0x126fa30, 0xc000510070})
	/root/build/spqr/router/frontend.go:387 +0x625
github.com/pg-sharding/spqr/router.(*InstanceImpl).serv(0xc000518200, {0x1272c00?, 0xc0004aa068}, 0x0)
	/root/build/spqr/router/instance.go:199 +0x332
github.com/pg-sharding/spqr/router.(*InstanceImpl).Run.func4()
	/root/build/spqr/router/instance.go:252 +0x29
created by github.com/pg-sharding/spqr/router.(*InstanceImpl).Run
	/root/build/spqr/router/instance.go:251 +0x4d7
```