### PR TITLE
fastfix: run all feature tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,12 @@ e2e: build_images
 stress: build_images
 	docker compose -f test/stress/docker-compose.yaml up --remove-orphans --exit-code-from stress --build router shard1 shard2 stress
 
-split_feature_test:
+split_feature_test_old:
 	docker compose build slicer
 	(cd test/feature/features; tar -c .) | docker compose run slicer | (mkdir test/feature/generatedFeatures; cd test/feature/generatedFeatures; tar -x)
+
+split_feature_test:
+	mkdir test/feature/generatedFeatures && cp test/feature/features/* test/feature/generatedFeatures
 
 clean_feature_test:
 	rm -rf test/feature/generatedFeatures


### PR DESCRIPTION
I noticed there are so many scenarios in feature tests that github actions workers just aren't enough to run all the splitted scenarios.
I propose run each feature file separately and do not split anything. At least for now.