### PR TITLE
Fix typo in QDB

### DIFF
--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -426,7 +426,7 @@ func (q *EtcdQDB) ShareKeyRange(id string) error {
 }
 
 // ==============================================================================
-//                           Transfer transactions
+//                           TRANSACTION TRANSFERS
 // ==============================================================================
 
 // TODO : unit tests

--- a/qdb/memqdb.go
+++ b/qdb/memqdb.go
@@ -410,7 +410,7 @@ func (q *MemQDB) ShareKeyRange(id string) error {
 }
 
 // ==============================================================================
-//                           Transfer transactions
+//                            TRANSACTION TRANSFERS
 // ==============================================================================
 
 // TODO : unit tests


### PR DESCRIPTION
`Transfer transactions` - > This action is because the verb comes first
`Transaction transfers` -> These are two nouns
