### PR TITLE
revoke lease when other coordinator is active

### DIFF
--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -521,7 +521,10 @@ func (q *EtcdQDB) TryCoordinatorLock(ctx context.Context) error {
 	}
 
 	if !stat.Succeeded {
-		_ = q.cli.Lease.Close()
+		_, err := q.cli.Lease.Revoke(ctx, leaseGrantResp.ID)
+		if err != nil {
+			return err
+		}
 		return spqrerror.New(spqrerror.SPQR_UNEXPECTED, "qdb is already in use")
 	}
 

--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -521,6 +521,7 @@ func (q *EtcdQDB) TryCoordinatorLock(ctx context.Context) error {
 	}
 
 	if !stat.Succeeded {
+		_ = q.cli.Lease.Close()
 		return spqrerror.New(spqrerror.SPQR_UNEXPECTED, "qdb is already in use")
 	}
 


### PR DESCRIPTION
```{"level":"warn","ts":"2024-04-02T11:28:53.793541Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:53.79357Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293437Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293501Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293522Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293548Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293566Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293591Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293618Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293652Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293691Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293723Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293753Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293779Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293811Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293841Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
{"level":"warn","ts":"2024-04-02T11:28:54.293871Z","logger":"etcd-client","caller":"v3@v3.5.12/lease.go:535","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}```