### PR TITLE
better console messages

### DIFF
--- a/pkg/clientinteractor/interactor.go
+++ b/pkg/clientinteractor/interactor.go
@@ -174,13 +174,13 @@ func (pi *PSQLInteractor) Version(_ context.Context) error {
 
 // TODO : unit tests
 func (pi *PSQLInteractor) AddShard(shard *datashards.DataShard) error {
-	if err := pi.WriteHeader("add datashard"); err != nil {
+	if err := pi.WriteHeader("add shard"); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}
 
 	for _, msg := range []pgproto3.BackendMessage{
-		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("created datashard %s", shard.ID))}},
+		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("shard id -> %s", shard.ID))}},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
@@ -199,7 +199,7 @@ func (pi *PSQLInteractor) DropShard(id string) error {
 	}
 
 	for _, msg := range []pgproto3.BackendMessage{
-		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("dropped shard %s", id))}},
+		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("shard id -> %s", id))}},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
@@ -253,7 +253,7 @@ func (pi *PSQLInteractor) CreateKeyRange(ctx context.Context, keyRange *kr.KeyRa
 	}
 
 	for _, msg := range []pgproto3.BackendMessage{
-		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("created key range with bound %s", keyRange.LowerBound))}},
+		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("bound -> %s", keyRange.LowerBound))}},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
@@ -272,7 +272,7 @@ func (pi *PSQLInteractor) SplitKeyRange(ctx context.Context, split *kr.SplitKeyR
 	}
 
 	for _, msg := range []pgproto3.BackendMessage{
-		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("split key range %v by %s", split.SourceID, string(split.Bound)))}},
+		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("key range id -> %v\nbound        -> %s", split.SourceID, string(split.Bound)))}},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
@@ -292,7 +292,7 @@ func (pi *PSQLInteractor) LockKeyRange(ctx context.Context, krid string) error {
 
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.DataRow{Values: [][]byte{
-			[]byte(fmt.Sprintf("lock key range %v", krid))},
+			[]byte(fmt.Sprintf("key range id -> %v", krid))},
 		},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
@@ -314,7 +314,7 @@ func (pi *PSQLInteractor) UnlockKeyRange(ctx context.Context, krid string) error
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.DataRow{Values: [][]byte{
 			[]byte(
-				fmt.Sprintf("unlocked key range %v", krid)),
+				fmt.Sprintf("key rande id -> %v", krid)),
 		},
 		},
 	} {
@@ -338,7 +338,7 @@ func (pi *PSQLInteractor) Shards(ctx context.Context, shards []*datashards.DataS
 
 	for _, shard := range shards {
 		if err := pi.cl.Send(&pgproto3.DataRow{
-			Values: [][]byte{[]byte(fmt.Sprintf("datashard %s", shard.ID))},
+			Values: [][]byte{[]byte(fmt.Sprintf("shard id -> %s", shard.ID))},
 		}); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
@@ -611,7 +611,7 @@ func (pi *PSQLInteractor) Routers(resp []*topology.Router) error {
 	}
 
 	for _, msg := range resp {
-		if err := pi.WriteDataRow(fmt.Sprintf("router %s-%s", msg.ID, msg.Address), string(msg.State)); err != nil {
+		if err := pi.WriteDataRow(fmt.Sprintf("router -> %s-%s", msg.ID, msg.Address), string(msg.State)); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
 		}
@@ -622,12 +622,12 @@ func (pi *PSQLInteractor) Routers(resp []*topology.Router) error {
 
 // TODO : unit tests
 func (pi *PSQLInteractor) UnregisterRouter(id string) error {
-	if err := pi.WriteHeader("unregister routers"); err != nil {
+	if err := pi.WriteHeader("unregister router"); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}
 
-	if err := pi.WriteDataRow(fmt.Sprintf("router %s unregistered", id)); err != nil {
+	if err := pi.WriteDataRow(fmt.Sprintf("router id -> %s", id)); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}
@@ -637,12 +637,12 @@ func (pi *PSQLInteractor) UnregisterRouter(id string) error {
 
 // TODO : unit tests
 func (pi *PSQLInteractor) RegisterRouter(ctx context.Context, id string, addr string) error {
-	if err := pi.WriteHeader("register routers"); err != nil {
+	if err := pi.WriteHeader("register router"); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}
 
-	if err := pi.WriteDataRow(fmt.Sprintf("router %s-%s registered", id, addr)); err != nil {
+	if err := pi.WriteDataRow(fmt.Sprintf("router -> %s-%s", id, addr)); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}
@@ -688,7 +688,7 @@ func (pi *PSQLInteractor) DropKeyRange(ctx context.Context, ids []string) error 
 	}
 
 	for _, id := range ids {
-		if err := pi.WriteDataRow(fmt.Sprintf("drop key range %s", id)); err != nil {
+		if err := pi.WriteDataRow(fmt.Sprintf("key range id -> %s", id)); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
 		}
@@ -704,7 +704,7 @@ func (pi *PSQLInteractor) AddDistribution(ctx context.Context, ks *distributions
 		return err
 	}
 
-	if err := pi.WriteDataRow(fmt.Sprintf("created distribution %s", ks.ID())); err != nil {
+	if err := pi.WriteDataRow(fmt.Sprintf("distribution id -> %s", ks.ID())); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}
@@ -719,7 +719,7 @@ func (pi *PSQLInteractor) DropDistribution(ctx context.Context, ids []string) er
 	}
 
 	for _, id := range ids {
-		if err := pi.WriteDataRow(fmt.Sprintf("drop distribution %s", id)); err != nil {
+		if err := pi.WriteDataRow(fmt.Sprintf("distribution id -> %s", id)); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
 		}
@@ -736,7 +736,7 @@ func (pi *PSQLInteractor) AlterDistributionAttach(ctx context.Context, id string
 	}
 
 	for _, r := range ds {
-		if err := pi.WriteDataRow(fmt.Sprintf("attached relation %s to distribution %s", r.Name, id)); err != nil {
+		if err := pi.WriteDataRow(fmt.Sprintf("relation name   -> %s\ndistribution id -> %s", r.Name, id)); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
 		}
@@ -752,7 +752,7 @@ func (pi *PSQLInteractor) AlterDistributionDetach(_ context.Context, id string, 
 		return err
 	}
 
-	if err := pi.WriteDataRow(fmt.Sprintf("detached relation %s from distribution %s", relName, id)); err != nil {
+	if err := pi.WriteDataRow(fmt.Sprintf("relation name   -> %s\ndistribution id -> %s", relName, id)); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}
@@ -781,7 +781,7 @@ func (pi *PSQLInteractor) KillClient(clientID uint) error {
 		return err
 	}
 
-	if err := pi.WriteDataRow(fmt.Sprintf("the client %d was killed", clientID)); err != nil {
+	if err := pi.WriteDataRow(fmt.Sprintf("client id -> %d", clientID)); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}

--- a/pkg/clientinteractor/interactor.go
+++ b/pkg/clientinteractor/interactor.go
@@ -180,7 +180,7 @@ func (pi *PSQLInteractor) AddShard(shard *datashards.DataShard) error {
 	}
 
 	for _, msg := range []pgproto3.BackendMessage{
-		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("created datashard with name %s", shard.ID))}},
+		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("created datashard %s", shard.ID))}},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
@@ -199,7 +199,7 @@ func (pi *PSQLInteractor) DropShard(id string) error {
 	}
 
 	for _, msg := range []pgproto3.BackendMessage{
-		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("dropped shard with %s", id))}},
+		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("dropped shard %s", id))}},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
@@ -292,7 +292,7 @@ func (pi *PSQLInteractor) LockKeyRange(ctx context.Context, krid string) error {
 
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.DataRow{Values: [][]byte{
-			[]byte(fmt.Sprintf("lock key range with id %v", krid))},
+			[]byte(fmt.Sprintf("lock key range %v", krid))},
 		},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
@@ -314,7 +314,7 @@ func (pi *PSQLInteractor) UnlockKeyRange(ctx context.Context, krid string) error
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.DataRow{Values: [][]byte{
 			[]byte(
-				fmt.Sprintf("unlocked key range with id %v", krid)),
+				fmt.Sprintf("unlocked key range %v", krid)),
 		},
 		},
 	} {
@@ -338,7 +338,7 @@ func (pi *PSQLInteractor) Shards(ctx context.Context, shards []*datashards.DataS
 
 	for _, shard := range shards {
 		if err := pi.cl.Send(&pgproto3.DataRow{
-			Values: [][]byte{[]byte(fmt.Sprintf("datashard with ID %s", shard.ID))},
+			Values: [][]byte{[]byte(fmt.Sprintf("datashard %s", shard.ID))},
 		}); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
@@ -704,7 +704,7 @@ func (pi *PSQLInteractor) AddDistribution(ctx context.Context, ks *distributions
 		return err
 	}
 
-	if err := pi.WriteDataRow(fmt.Sprintf("created distribution with id %s", ks.ID())); err != nil {
+	if err := pi.WriteDataRow(fmt.Sprintf("created distribution %s", ks.ID())); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}

--- a/pkg/clientinteractor/interactor.go
+++ b/pkg/clientinteractor/interactor.go
@@ -293,7 +293,7 @@ func (pi *PSQLInteractor) LockKeyRange(ctx context.Context, krid string) error {
 
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.DataRow{Values: [][]byte{
-			[]byte(fmt.Sprintf("key range id -> %v", krid))},
+			[]byte(fmt.Sprintf("key range id -\u003e %v", krid))},
 		},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
@@ -315,7 +315,7 @@ func (pi *PSQLInteractor) UnlockKeyRange(ctx context.Context, krid string) error
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.DataRow{Values: [][]byte{
 			[]byte(
-				fmt.Sprintf("key rande id -> %v", krid)),
+				fmt.Sprintf("key range id -\u003e %v", krid)),
 		},
 		},
 	} {

--- a/pkg/clientinteractor/interactor.go
+++ b/pkg/clientinteractor/interactor.go
@@ -293,7 +293,7 @@ func (pi *PSQLInteractor) LockKeyRange(ctx context.Context, krid string) error {
 
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.DataRow{Values: [][]byte{
-			[]byte(fmt.Sprintf("key range id -\u003e %v", krid))},
+			[]byte(fmt.Sprintf("key range id -> %v", krid))},
 		},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
@@ -315,7 +315,7 @@ func (pi *PSQLInteractor) UnlockKeyRange(ctx context.Context, krid string) error
 	for _, msg := range []pgproto3.BackendMessage{
 		&pgproto3.DataRow{Values: [][]byte{
 			[]byte(
-				fmt.Sprintf("key range id -\u003e %v", krid)),
+				fmt.Sprintf("key range id -> %v", krid)),
 		},
 		},
 	} {

--- a/pkg/clientinteractor/interactor.go
+++ b/pkg/clientinteractor/interactor.go
@@ -272,7 +272,8 @@ func (pi *PSQLInteractor) SplitKeyRange(ctx context.Context, split *kr.SplitKeyR
 	}
 
 	for _, msg := range []pgproto3.BackendMessage{
-		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("key range id -> %v\nbound        -> %s", split.SourceID, string(split.Bound)))}},
+		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("key range id -> %v", split.SourceID))}},
+		&pgproto3.DataRow{Values: [][]byte{[]byte(fmt.Sprintf("bound        -> %s", string(split.Bound)))}},
 	} {
 		if err := pi.cl.Send(msg); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
@@ -736,7 +737,12 @@ func (pi *PSQLInteractor) AlterDistributionAttach(ctx context.Context, id string
 	}
 
 	for _, r := range ds {
-		if err := pi.WriteDataRow(fmt.Sprintf("relation name   -> %s\ndistribution id -> %s", r.Name, id)); err != nil {
+		if err := pi.WriteDataRow(fmt.Sprintf("relation name   -> %s", r.Name)); err != nil {
+			spqrlog.Zero.Error().Err(err).Msg("")
+			return err
+		}
+
+		if err := pi.WriteDataRow(fmt.Sprintf("distribution id -> %s", id)); err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
 		}
@@ -752,7 +758,12 @@ func (pi *PSQLInteractor) AlterDistributionDetach(_ context.Context, id string, 
 		return err
 	}
 
-	if err := pi.WriteDataRow(fmt.Sprintf("relation name   -> %s\ndistribution id -> %s", relName, id)); err != nil {
+	if err := pi.WriteDataRow(fmt.Sprintf("relation name   -> %s", relName)); err != nil {
+		spqrlog.Zero.Error().Err(err).Msg("")
+		return err
+	}
+
+	if err := pi.WriteDataRow(fmt.Sprintf("distribution id -> %s", id)); err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return err
 	}

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -465,10 +465,10 @@ Feature: Coordinator test
     """
     [
       {
-        "listing data shards": "datashard with ID sh1"
+        "listing data shards": "shard id -\u003e sh1"
       },
       {
-        "listing data shards": "datashard with ID sh2"
+        "listing data shards": "shard id -\u003e sh2"
       }
     ]
     """
@@ -486,7 +486,7 @@ Feature: Coordinator test
     """
     [
       {
-        "listing data shards": "datashard with ID sh2"
+        "listing data shards": "shard id -\u003e sh2"
       }
     ]
     """

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -122,7 +122,7 @@ Feature: Coordinator test
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    router -\\u003e r2-regress_router:7000
+    router -> r2-regress_router:7000
     """
 
   Scenario: Register 2 routers with same address fails
@@ -141,7 +141,7 @@ Feature: Coordinator test
     """
     Then SQL result should match regexp
     """
-    router r1-regress_router:7000
+    router -> r1-regress_router:7000
     """
 
   Scenario: Register 2 routers with same id fails
@@ -160,7 +160,7 @@ Feature: Coordinator test
     """
     Then SQL result should match regexp
     """
-    router r1-regress_router:7000
+    router -> r1-regress_router:7000
     """
 
   Scenario: Register router with invalid address fails
@@ -180,7 +180,7 @@ Feature: Coordinator test
     Then SQL result should match json_exactly
     """
     [{
-      "show routers":"router r1-regress_router:7000",
+      "show routers":"router -> r1-regress_router:7000",
       "status":"OPENED"
     }]
     """
@@ -503,7 +503,7 @@ Feature: Coordinator test
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    router r1-regress_router:7000
+    router -> r1-regress_router:7000
     """
 
     #

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -122,7 +122,7 @@ Feature: Coordinator test
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    router -\u003e r2-regress_router:7000
+    router -\\u003e r2-regress_router:7000
     """
 
   Scenario: Register 2 routers with same address fails

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -122,7 +122,7 @@ Feature: Coordinator test
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    router r2-regress_router:7000
+    router -> r2-regress_router:7000
     """
 
   Scenario: Register 2 routers with same address fails

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -122,7 +122,7 @@ Feature: Coordinator test
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    router -> r2-regress_router:7000
+    router -\u003e r2-regress_router:7000
     """
 
   Scenario: Register 2 routers with same address fails

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -122,7 +122,7 @@ Feature: Coordinator test
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    router -> r2-regress_router:7000
+    router -\\u003e r2-regress_router:7000
     """
 
   Scenario: Register 2 routers with same address fails
@@ -141,7 +141,7 @@ Feature: Coordinator test
     """
     Then SQL result should match regexp
     """
-    router -> r1-regress_router:7000
+    router -\\u003e r1-regress_router:7000
     """
 
   Scenario: Register 2 routers with same id fails
@@ -160,7 +160,7 @@ Feature: Coordinator test
     """
     Then SQL result should match regexp
     """
-    router -> r1-regress_router:7000
+    router -\\u003e r1-regress_router:7000
     """
 
   Scenario: Register router with invalid address fails
@@ -180,7 +180,7 @@ Feature: Coordinator test
     Then SQL result should match json_exactly
     """
     [{
-      "show routers":"router -\u003e r1-regress_router:7000",
+      "show routers":"router -\\u003e r1-regress_router:7000",
       "status":"OPENED"
     }]
     """

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -180,7 +180,7 @@ Feature: Coordinator test
     Then SQL result should match json_exactly
     """
     [{
-      "show routers":"router -> r1-regress_router:7000",
+      "show routers":"router -\u003e r1-regress_router:7000",
       "status":"OPENED"
     }]
     """
@@ -503,7 +503,7 @@ Feature: Coordinator test
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    router -> r1-regress_router:7000
+    router -\\u003e r1-regress_router:7000
     """
 
     #

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -180,7 +180,7 @@ Feature: Coordinator test
     Then SQL result should match json_exactly
     """
     [{
-      "show routers":"router -\\u003e r1-regress_router:7000",
+      "show routers":"router -\u003e r1-regress_router:7000",
       "status":"OPENED"
     }]
     """

--- a/test/feature/features/memqdb.feature
+++ b/test/feature/features/memqdb.feature
@@ -130,7 +130,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -\u003e krid1
+    key range id -\\u003e krid1
     """
     When host "router" is stopped
     And host "router" is started
@@ -141,7 +141,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -\u003e krid1
+    key range id -\\u003e krid1
     """
 
   Scenario: Sharding is not initialized if init.sql file doesn't exists

--- a/test/feature/features/memqdb.feature
+++ b/test/feature/features/memqdb.feature
@@ -130,7 +130,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -\\u003e krid1
+    key range id -> krid1
     """
     When host "router" is stopped
     And host "router" is started
@@ -141,7 +141,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -\\u003e krid1
+    key range id -> krid1
     """
 
   Scenario: Sharding is not initialized if init.sql file doesn't exists

--- a/test/feature/features/memqdb.feature
+++ b/test/feature/features/memqdb.feature
@@ -130,7 +130,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    lock key range with id krid1
+    key range id -> krid1
     """
     When host "router" is stopped
     And host "router" is started
@@ -141,7 +141,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    unlocked key range with id krid1
+    key range id -> krid1
     """
 
   Scenario: Sharding is not initialized if init.sql file doesn't exists

--- a/test/feature/features/memqdb.feature
+++ b/test/feature/features/memqdb.feature
@@ -130,7 +130,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -> krid1
+    key range id -\\u003e krid1
     """
     When host "router" is stopped
     And host "router" is started
@@ -141,7 +141,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -> krid1
+    key range id -\u003e krid1
     """
 
   Scenario: Sharding is not initialized if init.sql file doesn't exists

--- a/test/feature/features/memqdb.feature
+++ b/test/feature/features/memqdb.feature
@@ -141,7 +141,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -\u003e krid1
+    key range id -\\u003e krid1
     """
 
   Scenario: Sharding is not initialized if init.sql file doesn't exists

--- a/test/feature/features/memqdb.feature
+++ b/test/feature/features/memqdb.feature
@@ -130,7 +130,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -> krid1
+    key range id -\u003e krid1
     """
     When host "router" is stopped
     And host "router" is started
@@ -141,7 +141,7 @@ Feature: MemQDB save state into a file
     Then command return code should be "0"
     And SQL result should match regexp
     """
-    key range id -> krid1
+    key range id -\u003e krid1
     """
 
   Scenario: Sharding is not initialized if init.sql file doesn't exists

--- a/test/feature/features/proxy_console.feature
+++ b/test/feature/features/proxy_console.feature
@@ -230,9 +230,9 @@ Feature: Proxy console
         """
         Then SQL result should match regexp
         """
-        router -\\u003e r1-regress_router:7000
+        router -> r1-regress_router:7000
         """
         And SQL result should match regexp
         """
-        router -\\u003e r2-regress_router_2:7000
+        router -> r2-regress_router_2:7000
         """

--- a/test/feature/features/proxy_console.feature
+++ b/test/feature/features/proxy_console.feature
@@ -230,9 +230,9 @@ Feature: Proxy console
         """
         Then SQL result should match regexp
         """
-        router -> r1-regress_router:7000
+        router -\u003e r1-regress_router:7000
         """
         And SQL result should match regexp
         """
-        router -> r2-regress_router_2:7000
+        router -\u003e r2-regress_router_2:7000
         """

--- a/test/feature/features/proxy_console.feature
+++ b/test/feature/features/proxy_console.feature
@@ -230,9 +230,9 @@ Feature: Proxy console
         """
         Then SQL result should match regexp
         """
-        router -\u003e r1-regress_router:7000
+        router -\\u003e r1-regress_router:7000
         """
         And SQL result should match regexp
         """
-        router -\u003e r2-regress_router_2:7000
+        router -\\u003e r2-regress_router_2:7000
         """

--- a/test/feature/features/proxy_console.feature
+++ b/test/feature/features/proxy_console.feature
@@ -230,9 +230,9 @@ Feature: Proxy console
         """
         Then SQL result should match regexp
         """
-        router r1-regress_router:7000
+        router -> r1-regress_router:7000
         """
         And SQL result should match regexp
         """
-        router r2-regress_router_2:7000
+        router -> r2-regress_router_2:7000
         """

--- a/test/feature/features/proxy_console.feature
+++ b/test/feature/features/proxy_console.feature
@@ -230,9 +230,9 @@ Feature: Proxy console
         """
         Then SQL result should match regexp
         """
-        router -> r1-regress_router:7000
+        router -\\u003e r1-regress_router:7000
         """
         And SQL result should match regexp
         """
-        router -> r2-regress_router_2:7000
+        router -\\u003e r2-regress_router_2:7000
         """

--- a/test/regress/tests/console/expected/add.out
+++ b/test/regress/tests/console/expected/add.out
@@ -6,19 +6,19 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
@@ -31,7 +31,7 @@ SHOW key_ranges;
 (2 rows)
 
 DROP KEY RANGE krid1;
-    drop key range
+    drop key range     
 -----------------------
  key range id -> krid1
 (1 row)
@@ -47,7 +47,7 @@ SHOW key_ranges;
 CREATE KEY RANGE krid2 FROM 33 ROUTE TO nonexistentshard FOR DISTRIBUTION ds1;
 ERROR:  unknown shard nonexistentshard.
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/console/expected/add.out
+++ b/test/regress/tests/console/expected/add.out
@@ -6,21 +6,21 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 SHOW key_ranges;
@@ -31,9 +31,9 @@ SHOW key_ranges;
 (2 rows)
 
 DROP KEY RANGE krid1;
-    drop key range    
-----------------------
- drop key range krid1
+    drop key range
+-----------------------
+ key range id -> krid1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
@@ -47,9 +47,9 @@ SHOW key_ranges;
 CREATE KEY RANGE krid2 FROM 33 ROUTE TO nonexistentshard FOR DISTRIBUTION ds1;
 ERROR:  unknown shard nonexistentshard.
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/console/expected/delete_distribution.out
+++ b/test/regress/tests/console/expected/delete_distribution.out
@@ -6,37 +6,37 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE DISTRIBUTION ds2;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds2
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 CREATE KEY RANGE krid3 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds2;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION rel DISTRIBUTION KEY id;
-      attach table
+      attach table      
 ------------------------
  relation name   -> rel
  distribution id -> ds1
@@ -52,13 +52,13 @@ HINT: Use DROP ... CASCADE to drop the dependent objects too.
     
 -- non-cascade drop with attached relations
 DROP KEY RANGE krid1;
-    drop key range
+    drop key range     
 -----------------------
  key range id -> krid1
 (1 row)
 
 DROP KEY RANGE krid2;
-    drop key range
+    drop key range     
 -----------------------
  key range id -> krid2
 (1 row)
@@ -67,7 +67,7 @@ DROP DISTRIBUTION ds1;
 ERROR:  cannot drop distribution ds1 because there are relations attached to it
 HINT: Use DROP ... CASCADE to detach relations automatically.
 DROP DISTRIBUTION ds1 CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
@@ -79,7 +79,7 @@ SHOW distributions;
 (1 row)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds2
 (1 row)

--- a/test/regress/tests/console/expected/delete_distribution.out
+++ b/test/regress/tests/console/expected/delete_distribution.out
@@ -40,7 +40,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION rel DISTRIBUTION KEY id;
 ------------------------
  relation name   -> rel
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 -- drop non-existing one
 DROP DISTRIBUTION ds23223;

--- a/test/regress/tests/console/expected/delete_distribution.out
+++ b/test/regress/tests/console/expected/delete_distribution.out
@@ -6,39 +6,40 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE DISTRIBUTION ds2;
-         add distribution         
-----------------------------------
- created distribution with id ds2
+    add distribution
+------------------------
+ distribution id -> ds2
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 CREATE KEY RANGE krid3 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds2;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION rel DISTRIBUTION KEY id;
-               attach table                
--------------------------------------------
- attached relation rel to distribution ds1
+      attach table
+------------------------
+ relation name   -> rel
+ distribution id -> ds1
 (1 row)
 
 -- drop non-existing one
@@ -51,24 +52,24 @@ HINT: Use DROP ... CASCADE to drop the dependent objects too.
     
 -- non-cascade drop with attached relations
 DROP KEY RANGE krid1;
-    drop key range    
-----------------------
- drop key range krid1
+    drop key range
+-----------------------
+ key range id -> krid1
 (1 row)
 
 DROP KEY RANGE krid2;
-    drop key range    
-----------------------
- drop key range krid2
+    drop key range
+-----------------------
+ key range id -> krid2
 (1 row)
 
 DROP DISTRIBUTION ds1;
 ERROR:  cannot drop distribution ds1 because there are relations attached to it
 HINT: Use DROP ... CASCADE to detach relations automatically.
 DROP DISTRIBUTION ds1 CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 SHOW distributions;
@@ -78,9 +79,9 @@ SHOW distributions;
 (1 row)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds2
+   drop distribution
+------------------------
+ distribution id -> ds2
 (1 row)
 
 SHOW distributions;

--- a/test/regress/tests/console/expected/drop.out
+++ b/test/regress/tests/console/expected/drop.out
@@ -6,19 +6,19 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
@@ -41,7 +41,7 @@ SHOW key_ranges;
 (0 rows)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/console/expected/drop.out
+++ b/test/regress/tests/console/expected/drop.out
@@ -6,21 +6,21 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 SHOW key_ranges;
@@ -41,8 +41,8 @@ SHOW key_ranges;
 (0 rows)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 

--- a/test/regress/tests/console/expected/hash.out
+++ b/test/regress/tests/console/expected/hash.out
@@ -16,28 +16,28 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION r1 DISTRIBUTION KEY col1 HASH FUNCTION ID
 ------------------------
  relation name   -> r1
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r2 DISTRIBUTION KEY col1 HASH FUNCTION IDENTITY;
       attach table      
 ------------------------
  relation name   -> r2
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r3 DISTRIBUTION KEY col1 HASH FUNCTION MURMUR;
       attach table      
 ------------------------
  relation name   -> r3
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r4 DISTRIBUTION KEY col1 HASH FUNCTION CITY;
       attach table      
 ------------------------
  relation name   -> r4
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 SHOW DISTRIBUTIONS;
  Distribution ID | Column types 

--- a/test/regress/tests/console/expected/hash.out
+++ b/test/regress/tests/console/expected/hash.out
@@ -6,34 +6,34 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r1 DISTRIBUTION KEY col1 HASH FUNCTION IDENT;
-      attach table
+      attach table      
 ------------------------
  relation name   -> r1
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r2 DISTRIBUTION KEY col1 HASH FUNCTION IDENTITY;
-      attach table
+      attach table      
 ------------------------
  relation name   -> r2
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r3 DISTRIBUTION KEY col1 HASH FUNCTION MURMUR;
-      attach table
+      attach table      
 ------------------------
  relation name   -> r3
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r4 DISTRIBUTION KEY col1 HASH FUNCTION CITY;
-      attach table
+      attach table      
 ------------------------
  relation name   -> r4
  distribution id -> ds1
@@ -55,7 +55,7 @@ SHOW RELATIONS;
 (4 rows)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/console/expected/hash.out
+++ b/test/regress/tests/console/expected/hash.out
@@ -6,33 +6,37 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r1 DISTRIBUTION KEY col1 HASH FUNCTION IDENT;
-               attach table               
-------------------------------------------
- attached relation r1 to distribution ds1
+      attach table
+------------------------
+ relation name   -> r1
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r2 DISTRIBUTION KEY col1 HASH FUNCTION IDENTITY;
-               attach table               
-------------------------------------------
- attached relation r2 to distribution ds1
+      attach table
+------------------------
+ relation name   -> r2
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r3 DISTRIBUTION KEY col1 HASH FUNCTION MURMUR;
-               attach table               
-------------------------------------------
- attached relation r3 to distribution ds1
+      attach table
+------------------------
+ relation name   -> r3
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION r4 DISTRIBUTION KEY col1 HASH FUNCTION CITY;
-               attach table               
-------------------------------------------
- attached relation r4 to distribution ds1
+      attach table
+------------------------
+ relation name   -> r4
+ distribution id -> ds1
 (1 row)
 
 SHOW DISTRIBUTIONS;
@@ -51,9 +55,9 @@ SHOW RELATIONS;
 (4 rows)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/console/expected/show_distributions.out
+++ b/test/regress/tests/console/expected/show_distributions.out
@@ -6,13 +6,13 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE DISTRIBUTION ds2 COLUMN TYPES varchar, integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds2
 (1 row)
@@ -25,7 +25,7 @@ SHOW distributions;
 (2 rows)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
  distribution id -> ds2

--- a/test/regress/tests/console/expected/show_distributions.out
+++ b/test/regress/tests/console/expected/show_distributions.out
@@ -6,15 +6,15 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE DISTRIBUTION ds2 COLUMN TYPES varchar, integer;
-         add distribution         
-----------------------------------
- created distribution with id ds2
+    add distribution
+------------------------
+ distribution id -> ds2
 (1 row)
 
 SHOW distributions;
@@ -25,10 +25,10 @@ SHOW distributions;
 (2 rows)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
- drop distribution ds2
+   drop distribution
+------------------------
+ distribution id -> ds1
+ distribution id -> ds2
 (2 rows)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/console/expected/show_key_ranges.out
+++ b/test/regress/tests/console/expected/show_key_ranges.out
@@ -6,21 +6,21 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 SHOW key_ranges;
@@ -31,9 +31,9 @@ SHOW key_ranges;
 (2 rows)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/console/expected/show_key_ranges.out
+++ b/test/regress/tests/console/expected/show_key_ranges.out
@@ -6,19 +6,19 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
@@ -31,7 +31,7 @@ SHOW key_ranges;
 (2 rows)
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/console/expected/show_relations.out
+++ b/test/regress/tests/console/expected/show_relations.out
@@ -22,14 +22,14 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION a DISTRIBUTION KEY a_id;
 ------------------------
  relation name   -> a
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION b DISTRIBUTION KEY b_id HASH FUNCTION MURMUR;
       attach table      
 ------------------------
  relation name   -> b
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds2 ATTACH RELATION c DISTRIBUTION KEY c_id_1 HASH FUNCTION IDENT,
                                                           c_id_2 HASH FUNCTION CITY;
@@ -37,7 +37,7 @@ ALTER DISTRIBUTION ds2 ATTACH RELATION c DISTRIBUTION KEY c_id_1 HASH FUNCTION I
 ------------------------
  relation name   -> c
  distribution id -> ds2
-(1 row)
+(2 rows)
 
 SHOW relations;
  Relation name | Distribution ID |           Distribution key            

--- a/test/regress/tests/console/expected/show_relations.out
+++ b/test/regress/tests/console/expected/show_relations.out
@@ -6,34 +6,37 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE DISTRIBUTION ds2 COLUMN TYPES varchar, integer;
-         add distribution         
-----------------------------------
- created distribution with id ds2
+    add distribution
+------------------------
+ distribution id -> ds2
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION a DISTRIBUTION KEY a_id;
-              attach table               
------------------------------------------
- attached relation a to distribution ds1
+      attach table
+------------------------
+ relation name   -> a
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION b DISTRIBUTION KEY b_id HASH FUNCTION MURMUR;
-              attach table               
------------------------------------------
- attached relation b to distribution ds1
+      attach table
+------------------------
+ relation name   -> b
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds2 ATTACH RELATION c DISTRIBUTION KEY c_id_1 HASH FUNCTION IDENT,
                                                           c_id_2 HASH FUNCTION CITY;
-              attach table               
------------------------------------------
- attached relation c to distribution ds2
+      attach table
+------------------------
+ relation name   -> c
+ distribution id -> ds2
 (1 row)
 
 SHOW relations;
@@ -54,10 +57,10 @@ SHOW relations WHERE distribution_id = 'ds1';
 SHOW relations WHERE unknown_param = 'ds1';
 ERROR:  column unknown_param does not exist.
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
- drop distribution ds2
+   drop distribution
+------------------------
+ distribution id -> ds1
+ distribution id -> ds2
 (2 rows)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/console/expected/show_relations.out
+++ b/test/regress/tests/console/expected/show_relations.out
@@ -6,26 +6,26 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE DISTRIBUTION ds2 COLUMN TYPES varchar, integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds2
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION a DISTRIBUTION KEY a_id;
-      attach table
+      attach table      
 ------------------------
  relation name   -> a
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION b DISTRIBUTION KEY b_id HASH FUNCTION MURMUR;
-      attach table
+      attach table      
 ------------------------
  relation name   -> b
  distribution id -> ds1
@@ -33,7 +33,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION b DISTRIBUTION KEY b_id HASH FUNCTION MUR
 
 ALTER DISTRIBUTION ds2 ATTACH RELATION c DISTRIBUTION KEY c_id_1 HASH FUNCTION IDENT,
                                                           c_id_2 HASH FUNCTION CITY;
-      attach table
+      attach table      
 ------------------------
  relation name   -> c
  distribution id -> ds2
@@ -57,7 +57,7 @@ SHOW relations WHERE distribution_id = 'ds1';
 SHOW relations WHERE unknown_param = 'ds1';
 ERROR:  column unknown_param does not exist.
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
  distribution id -> ds2

--- a/test/regress/tests/console/expected/show_routers.out
+++ b/test/regress/tests/console/expected/show_routers.out
@@ -6,8 +6,8 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 SHOW routers;
- show routers  | status 
----------------+--------
- router local- | 
+   show routers   | status
+------------------+--------
+ router -> local- |
 (1 row)
 

--- a/test/regress/tests/console/expected/show_routers.out
+++ b/test/regress/tests/console/expected/show_routers.out
@@ -6,8 +6,8 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 SHOW routers;
-   show routers   | status
+   show routers   | status 
 ------------------+--------
- router -> local- |
+ router -> local- | 
 (1 row)
 

--- a/test/regress/tests/console/expected/show_shards.out
+++ b/test/regress/tests/console/expected/show_shards.out
@@ -6,7 +6,7 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 SHOW shards;
- listing data shards
+ listing data shards 
 ---------------------
  shard id -> sh1
  shard id -> sh2

--- a/test/regress/tests/console/expected/show_shards.out
+++ b/test/regress/tests/console/expected/show_shards.out
@@ -6,9 +6,9 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 SHOW shards;
-  listing data shards  
------------------------
- datashard with ID sh1
- datashard with ID sh2
+ listing data shards
+---------------------
+ shard id -> sh1
+ shard id -> sh2
 (2 rows)
 

--- a/test/regress/tests/coordinator/expected/coordinator.out
+++ b/test/regress/tests/coordinator/expected/coordinator.out
@@ -1,6 +1,6 @@
 -- UNREGISTER ROUTER ALL
 REGISTER ROUTER r1 ADDRESS regress_router:7000;
-         register router
+         register router          
 ----------------------------------
  router -> r1-regress_router:7000
 (1 row)

--- a/test/regress/tests/coordinator/expected/coordinator.out
+++ b/test/regress/tests/coordinator/expected/coordinator.out
@@ -1,7 +1,7 @@
 -- UNREGISTER ROUTER ALL
 REGISTER ROUTER r1 ADDRESS regress_router:7000;
-             register routers             
-------------------------------------------
- router r1-regress_router:7000 registered
+         register router
+----------------------------------
+ router -> r1-regress_router:7000
 (1 row)
 

--- a/test/regress/tests/router/expected/alter_distribution.out
+++ b/test/regress/tests/router/expected/alter_distribution.out
@@ -47,14 +47,14 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION xx DISTRIBUTION KEY w_id;
 ------------------------
  relation name   -> xx
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds2 ATTACH RELATION yy DISTRIBUTION KEY w_id;
       attach table      
 ------------------------
  relation name   -> yy
  distribution id -> ds2
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds3 ATTACH RELATION xx DISTRIBUTION KEY w_id;
 ERROR:  no such distribution.
@@ -99,21 +99,21 @@ ALTER DISTRIBUTION ds2 DETACH RELATION yy;
 ------------------------
  relation name   -> yy
  distribution id -> ds2
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds2 DETACH RELATION yy;
     detach relation     
 ------------------------
  relation name   -> yy
  distribution id -> ds2
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION yy DISTRIBUTION KEY w_id;
       attach table      
 ------------------------
  relation name   -> yy
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 SELECT * FROM yy WHERE w_id=5;

--- a/test/regress/tests/router/expected/alter_distribution.out
+++ b/test/regress/tests/router/expected/alter_distribution.out
@@ -7,50 +7,50 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE DISTRIBUTION ds2;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds2
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 CREATE KEY RANGE krid3 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds2;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 CREATE KEY RANGE FROM 1 ROUTE TO sh2 FOR DISTRIBUTION ds2;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xx DISTRIBUTION KEY w_id;
-      attach table
+      attach table      
 ------------------------
  relation name   -> xx
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds2 ATTACH RELATION yy DISTRIBUTION KEY w_id;
-      attach table
+      attach table      
 ------------------------
  relation name   -> yy
  distribution id -> ds2
@@ -95,21 +95,21 @@ https://github.com/pg-sharding/spqr/tree/master/docs
 ALTER DISTRIBUTION ds1 ATTACH RELATION yy DISTRIBUTION KEY w_id;
 ERROR:  relation "yy" is already attached.
 ALTER DISTRIBUTION ds2 DETACH RELATION yy;
-    detach relation
+    detach relation     
 ------------------------
  relation name   -> yy
  distribution id -> ds2
 (1 row)
 
 ALTER DISTRIBUTION ds2 DETACH RELATION yy;
-    detach relation
+    detach relation     
 ------------------------
  relation name   -> yy
  distribution id -> ds2
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION yy DISTRIBUTION KEY w_id;
-      attach table
+      attach table      
 ------------------------
  relation name   -> yy
  distribution id -> ds1
@@ -135,7 +135,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
  distribution id -> ds2

--- a/test/regress/tests/router/expected/alter_distribution.out
+++ b/test/regress/tests/router/expected/alter_distribution.out
@@ -7,51 +7,53 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE DISTRIBUTION ds2;
-         add distribution         
-----------------------------------
- created distribution with id ds2
+    add distribution
+------------------------
+ distribution id -> ds2
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 CREATE KEY RANGE krid3 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds2;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 CREATE KEY RANGE FROM 1 ROUTE TO sh2 FOR DISTRIBUTION ds2;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xx DISTRIBUTION KEY w_id;
-               attach table               
-------------------------------------------
- attached relation xx to distribution ds1
+      attach table
+------------------------
+ relation name   -> xx
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds2 ATTACH RELATION yy DISTRIBUTION KEY w_id;
-               attach table               
-------------------------------------------
- attached relation yy to distribution ds2
+      attach table
+------------------------
+ relation name   -> yy
+ distribution id -> ds2
 (1 row)
 
 ALTER DISTRIBUTION ds3 ATTACH RELATION xx DISTRIBUTION KEY w_id;
@@ -93,21 +95,24 @@ https://github.com/pg-sharding/spqr/tree/master/docs
 ALTER DISTRIBUTION ds1 ATTACH RELATION yy DISTRIBUTION KEY w_id;
 ERROR:  relation "yy" is already attached.
 ALTER DISTRIBUTION ds2 DETACH RELATION yy;
-              detach relation               
---------------------------------------------
- detached relation yy from distribution ds2
+    detach relation
+------------------------
+ relation name   -> yy
+ distribution id -> ds2
 (1 row)
 
 ALTER DISTRIBUTION ds2 DETACH RELATION yy;
-              detach relation               
---------------------------------------------
- detached relation yy from distribution ds2
+    detach relation
+------------------------
+ relation name   -> yy
+ distribution id -> ds2
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION yy DISTRIBUTION KEY w_id;
-               attach table               
-------------------------------------------
- attached relation yy to distribution ds1
+      attach table
+------------------------
+ relation name   -> yy
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -130,10 +135,10 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
- drop distribution ds2
+   drop distribution
+------------------------
+ distribution id -> ds1
+ distribution id -> ds2
 (2 rows)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/begin.out
+++ b/test/regress/tests/router/expected/begin.out
@@ -29,7 +29,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION test_beg DISTRIBUTION KEY id;
 -----------------------------
  relation name   -> test_beg
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE test_beg(id int, age int);

--- a/test/regress/tests/router/expected/begin.out
+++ b/test/regress/tests/router/expected/begin.out
@@ -7,27 +7,28 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION test_beg DISTRIBUTION KEY id;
-                  attach table                  
-------------------------------------------------
- attached relation test_beg to distribution ds1
+        attach table
+-----------------------------
+ relation name   -> test_beg+
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -202,9 +203,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/begin.out
+++ b/test/regress/tests/router/expected/begin.out
@@ -7,27 +7,27 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION test_beg DISTRIBUTION KEY id;
-        attach table
+        attach table         
 -----------------------------
- relation name   -> test_beg+
+ relation name   -> test_beg
  distribution id -> ds1
 (1 row)
 
@@ -203,7 +203,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/copy_routing.out
+++ b/test/regress/tests/router/expected/copy_routing.out
@@ -7,27 +7,28 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 30 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 30
+ add key range
+---------------
+ bound -> 30
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION copy_test DISTRIBUTION KEY id;
-                  attach table                   
--------------------------------------------------
- attached relation copy_test to distribution ds1
+         attach table
+------------------------------
+ relation name   -> copy_test
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -73,9 +74,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/copy_routing.out
+++ b/test/regress/tests/router/expected/copy_routing.out
@@ -29,7 +29,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION copy_test DISTRIBUTION KEY id;
 ------------------------------
  relation name   -> copy_test
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE copy_test (id int);

--- a/test/regress/tests/router/expected/copy_routing.out
+++ b/test/regress/tests/router/expected/copy_routing.out
@@ -7,25 +7,25 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 30 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 30
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION copy_test DISTRIBUTION KEY id;
-         attach table
+         attach table         
 ------------------------------
  relation name   -> copy_test
  distribution id -> ds1
@@ -74,7 +74,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/error.out
+++ b/test/regress/tests/router/expected/error.out
@@ -29,7 +29,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION x DISTRIBUTION KEY id;
 ------------------------
  relation name   -> x
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE x(id int);

--- a/test/regress/tests/router/expected/error.out
+++ b/test/regress/tests/router/expected/error.out
@@ -7,27 +7,28 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE kridi1 from 1 route to sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE kridi2 from 11 route to sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION x DISTRIBUTION KEY id;
-              attach table               
------------------------------------------
- attached relation x to distribution ds1
+      attach table
+------------------------
+ relation name   -> x
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -63,9 +64,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/error.out
+++ b/test/regress/tests/router/expected/error.out
@@ -7,25 +7,25 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE kridi1 from 1 route to sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE kridi2 from 11 route to sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION x DISTRIBUTION KEY id;
-      attach table
+      attach table      
 ------------------------
  relation name   -> x
  distribution id -> ds1
@@ -64,7 +64,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/joins.out
+++ b/test/regress/tests/router/expected/joins.out
@@ -29,14 +29,14 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION xjoin DISTRIBUTION KEY id;
 --------------------------
  relation name   -> xjoin
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION yjoin DISTRIBUTION KEY w_id;
        attach table       
 --------------------------
  relation name   -> yjoin
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE xjoin(id int);

--- a/test/regress/tests/router/expected/joins.out
+++ b/test/regress/tests/router/expected/joins.out
@@ -7,33 +7,35 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE kridi1 from 0 route to sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 0
+ add key range
+---------------
+ bound -> 0
 (1 row)
 
 CREATE KEY RANGE kridi2 from 11 route to sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xjoin DISTRIBUTION KEY id;
-                attach table                 
----------------------------------------------
- attached relation xjoin to distribution ds1
+       attach table
+--------------------------
+ relation name   -> xjoin
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION yjoin DISTRIBUTION KEY w_id;
-                attach table                 
----------------------------------------------
- attached relation yjoin to distribution ds1
+       attach table
+--------------------------
+ relation name   -> yjoin
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -96,9 +98,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/joins.out
+++ b/test/regress/tests/router/expected/joins.out
@@ -7,32 +7,32 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE kridi1 from 0 route to sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 0
 (1 row)
 
 CREATE KEY RANGE kridi2 from 11 route to sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xjoin DISTRIBUTION KEY id;
-       attach table
+       attach table       
 --------------------------
  relation name   -> xjoin
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION yjoin DISTRIBUTION KEY w_id;
-       attach table
+       attach table       
 --------------------------
  relation name   -> yjoin
  distribution id -> ds1
@@ -98,7 +98,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/mixed_routing.out
+++ b/test/regress/tests/router/expected/mixed_routing.out
@@ -30,7 +30,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION xxmixed DISTRIBUTION KEY id;
 ----------------------------
  relation name   -> xxmixed
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE xxmixed(id int);
@@ -169,7 +169,7 @@ ALTER DISTRIBUTION ds2 ATTACH RELATION xxmixeduuid DISTRIBUTION KEY id;
 --------------------------------
  relation name   -> xxmixeduuid
  distribution id -> ds2
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE xxmixeduuid(id uuid);

--- a/test/regress/tests/router/expected/mixed_routing.out
+++ b/test/regress/tests/router/expected/mixed_routing.out
@@ -8,25 +8,25 @@ https://github.com/pg-sharding/spqr/tree/master/docs
 
 -- check that numeric type works
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxmixed DISTRIBUTION KEY id;
-        attach table
+        attach table        
 ----------------------------
  relation name   -> xxmixed
  distribution id -> ds1
@@ -147,25 +147,25 @@ https://github.com/pg-sharding/spqr/tree/master/docs
 
 -- check that uuid type works
 CREATE DISTRIBUTION ds2 COLUMN TYPES varchar;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds2
 (1 row)
 
 CREATE KEY RANGE krid3 FROM 00000000-0000-0000-0000-000000000000 ROUTE TO sh1 FOR DISTRIBUTION ds2;
-                 add key range
+                 add key range                 
 -----------------------------------------------
  bound -> 00000000-0000-0000-0000-000000000000
 (1 row)
 
 CREATE KEY RANGE krid4 FROM 88888888-8888-8888-8888-888888888888 ROUTE TO sh2 FOR DISTRIBUTION ds2;
-                 add key range
+                 add key range                 
 -----------------------------------------------
  bound -> 88888888-8888-8888-8888-888888888888
 (1 row)
 
 ALTER DISTRIBUTION ds2 ATTACH RELATION xxmixeduuid DISTRIBUTION KEY id;
-          attach table
+          attach table          
 --------------------------------
  relation name   -> xxmixeduuid
  distribution id -> ds2
@@ -228,7 +228,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
  distribution id -> ds2

--- a/test/regress/tests/router/expected/mixed_routing.out
+++ b/test/regress/tests/router/expected/mixed_routing.out
@@ -8,27 +8,28 @@ https://github.com/pg-sharding/spqr/tree/master/docs
 
 -- check that numeric type works
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxmixed DISTRIBUTION KEY id;
-                 attach table                  
------------------------------------------------
- attached relation xxmixed to distribution ds1
+        attach table
+----------------------------
+ relation name   -> xxmixed
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -146,27 +147,28 @@ https://github.com/pg-sharding/spqr/tree/master/docs
 
 -- check that uuid type works
 CREATE DISTRIBUTION ds2 COLUMN TYPES varchar;
-         add distribution         
-----------------------------------
- created distribution with id ds2
+    add distribution
+------------------------
+ distribution id -> ds2
 (1 row)
 
 CREATE KEY RANGE krid3 FROM 00000000-0000-0000-0000-000000000000 ROUTE TO sh1 FOR DISTRIBUTION ds2;
-                           add key range                           
--------------------------------------------------------------------
- created key range with bound 00000000-0000-0000-0000-000000000000
+                 add key range
+-----------------------------------------------
+ bound -> 00000000-0000-0000-0000-000000000000
 (1 row)
 
 CREATE KEY RANGE krid4 FROM 88888888-8888-8888-8888-888888888888 ROUTE TO sh2 FOR DISTRIBUTION ds2;
-                           add key range                           
--------------------------------------------------------------------
- created key range with bound 88888888-8888-8888-8888-888888888888
+                 add key range
+-----------------------------------------------
+ bound -> 88888888-8888-8888-8888-888888888888
 (1 row)
 
 ALTER DISTRIBUTION ds2 ATTACH RELATION xxmixeduuid DISTRIBUTION KEY id;
-                   attach table                    
----------------------------------------------------
- attached relation xxmixeduuid to distribution ds2
+          attach table
+--------------------------------
+ relation name   -> xxmixeduuid
+ distribution id -> ds2
 (1 row)
 
 \c regress
@@ -226,10 +228,10 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
- drop distribution ds2
+   drop distribution
+------------------------
+ distribution id -> ds1
+ distribution id -> ds2
 (2 rows)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/multishard.out
+++ b/test/regress/tests/router/expected/multishard.out
@@ -30,7 +30,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION xxmixed DISTRIBUTION KEY id;
 ----------------------------
  relation name   -> xxmixed
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE xxmixed(id int);

--- a/test/regress/tests/router/expected/multishard.out
+++ b/test/regress/tests/router/expected/multishard.out
@@ -8,25 +8,25 @@ https://github.com/pg-sharding/spqr/tree/master/docs
 
 -- check that numeric type works
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxmixed DISTRIBUTION KEY id;
-        attach table
+        attach table        
 ----------------------------
  relation name   -> xxmixed
  distribution id -> ds1
@@ -92,7 +92,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/multishard.out
+++ b/test/regress/tests/router/expected/multishard.out
@@ -8,27 +8,28 @@ https://github.com/pg-sharding/spqr/tree/master/docs
 
 -- check that numeric type works
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxmixed DISTRIBUTION KEY id;
-                 attach table                  
------------------------------------------------
- attached relation xxmixed to distribution ds1
+        attach table
+----------------------------
+ relation name   -> xxmixed
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -91,9 +92,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/shard_routing.out
+++ b/test/regress/tests/router/expected/shard_routing.out
@@ -7,45 +7,45 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 CREATE KEY RANGE krid3 FROM 21 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 21
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xx DISTRIBUTION KEY w_id;
-      attach table
+      attach table      
 ------------------------
  relation name   -> xx
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxerr DISTRIBUTION KEY id;
-       attach table
+       attach table       
 --------------------------
  relation name   -> xxerr
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxtt1 DISTRIBUTION KEY w_id;
-       attach table
+       attach table       
 --------------------------
  relation name   -> xxtt1
  distribution id -> ds1
@@ -294,7 +294,7 @@ ERROR:  table "xxerr" does not exist
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/shard_routing.out
+++ b/test/regress/tests/router/expected/shard_routing.out
@@ -35,21 +35,21 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION xx DISTRIBUTION KEY w_id;
 ------------------------
  relation name   -> xx
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxerr DISTRIBUTION KEY id;
        attach table       
 --------------------------
  relation name   -> xxerr
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxtt1 DISTRIBUTION KEY w_id;
        attach table       
 --------------------------
  relation name   -> xxtt1
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE xx (w_id int);

--- a/test/regress/tests/router/expected/shard_routing.out
+++ b/test/regress/tests/router/expected/shard_routing.out
@@ -7,45 +7,48 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 11 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 CREATE KEY RANGE krid3 FROM 21 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 21
+ add key range
+---------------
+ bound -> 21
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xx DISTRIBUTION KEY w_id;
-               attach table               
-------------------------------------------
- attached relation xx to distribution ds1
+      attach table
+------------------------
+ relation name   -> xx
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxerr DISTRIBUTION KEY id;
-                attach table                 
----------------------------------------------
- attached relation xxerr to distribution ds1
+       attach table
+--------------------------
+ relation name   -> xxerr
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION xxtt1 DISTRIBUTION KEY w_id;
-                attach table                 
----------------------------------------------
- attached relation xxtt1 to distribution ds1
+       attach table
+--------------------------
+ relation name   -> xxtt1
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -291,9 +294,9 @@ ERROR:  table "xxerr" does not exist
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/single_shard_joins.out
+++ b/test/regress/tests/router/expected/single_shard_joins.out
@@ -29,7 +29,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION sshjt1 DISTRIBUTION KEY i;
 ---------------------------
  relation name   -> sshjt1
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE sshjt1(i int, j int);

--- a/test/regress/tests/router/expected/single_shard_joins.out
+++ b/test/regress/tests/router/expected/single_shard_joins.out
@@ -7,25 +7,25 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE kridi1 from 0 route to sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 0
 (1 row)
 
 CREATE KEY RANGE kridi2 from 11 route to sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION sshjt1 DISTRIBUTION KEY i;
-       attach table
+       attach table        
 ---------------------------
  relation name   -> sshjt1
  distribution id -> ds1
@@ -85,7 +85,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/single_shard_joins.out
+++ b/test/regress/tests/router/expected/single_shard_joins.out
@@ -7,27 +7,28 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE kridi1 from 0 route to sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 0
+ add key range
+---------------
+ bound -> 0
 (1 row)
 
 CREATE KEY RANGE kridi2 from 11 route to sh2 FOR DISTRIBUTION ds1;
-          add key range          
----------------------------------
- created key range with bound 11
+ add key range
+---------------
+ bound -> 11
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION sshjt1 DISTRIBUTION KEY i;
-                 attach table                 
-----------------------------------------------
- attached relation sshjt1 to distribution ds1
+       attach table
+---------------------------
+ relation name   -> sshjt1
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -84,9 +85,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/target_session_attrs.out
+++ b/test/regress/tests/router/expected/target_session_attrs.out
@@ -7,25 +7,25 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 101 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 101
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION tsa_test DISTRIBUTION KEY id;
-        attach table
+        attach table         
 -----------------------------
  relation name   -> tsa_test
  distribution id -> ds1
@@ -73,7 +73,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/target_session_attrs.out
+++ b/test/regress/tests/router/expected/target_session_attrs.out
@@ -7,27 +7,28 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 101 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range           
-----------------------------------
- created key range with bound 101
+ add key range
+---------------
+ bound -> 101
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION tsa_test DISTRIBUTION KEY id;
-                  attach table                  
-------------------------------------------------
- attached relation tsa_test to distribution ds1
+        attach table
+-----------------------------
+ relation name   -> tsa_test
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -72,9 +73,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/target_session_attrs.out
+++ b/test/regress/tests/router/expected/target_session_attrs.out
@@ -29,7 +29,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION tsa_test DISTRIBUTION KEY id;
 -----------------------------
  relation name   -> tsa_test
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE tsa_test (id int);

--- a/test/regress/tests/router/expected/transactions.out
+++ b/test/regress/tests/router/expected/transactions.out
@@ -29,7 +29,7 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION transactions_test DISTRIBUTION KEY id;
 --------------------------------------
  relation name   -> transactions_test
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE transactions_test (id int);

--- a/test/regress/tests/router/expected/transactions.out
+++ b/test/regress/tests/router/expected/transactions.out
@@ -7,25 +7,25 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 101 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 101
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION transactions_test DISTRIBUTION KEY id;
-             attach table
+             attach table             
 --------------------------------------
  relation name   -> transactions_test
  distribution id -> ds1
@@ -90,7 +90,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/transactions.out
+++ b/test/regress/tests/router/expected/transactions.out
@@ -7,27 +7,28 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 101 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range           
-----------------------------------
- created key range with bound 101
+ add key range
+---------------
+ bound -> 101
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION transactions_test DISTRIBUTION KEY id;
-                      attach table                       
----------------------------------------------------------
- attached relation transactions_test to distribution ds1
+             attach table
+--------------------------------------
+ relation name   -> transactions_test
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -89,9 +90,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/with_tables.out
+++ b/test/regress/tests/router/expected/with_tables.out
@@ -7,33 +7,35 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-         add distribution         
-----------------------------------
- created distribution with id ds1
+    add distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
-         add key range          
---------------------------------
- created key range with bound 1
+ add key range
+---------------
+ bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 101 ROUTE TO sh2 FOR DISTRIBUTION ds1;
-          add key range           
-----------------------------------
- created key range with bound 101
+ add key range
+---------------
+ bound -> 101
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION orders DISTRIBUTION KEY id;
-                 attach table                 
-----------------------------------------------
- attached relation orders to distribution ds1
+       attach table
+---------------------------
+ relation name   -> orders
+ distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION delivery DISTRIBUTION KEY order_id;
-                  attach table                  
-------------------------------------------------
- attached relation delivery to distribution ds1
+        attach table
+-----------------------------
+ relation name   -> delivery
+ distribution id -> ds1
 (1 row)
 
 \c regress
@@ -77,9 +79,9 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution   
------------------------
- drop distribution ds1
+   drop distribution
+------------------------
+ distribution id -> ds1
 (1 row)
 
 DROP KEY RANGE ALL;

--- a/test/regress/tests/router/expected/with_tables.out
+++ b/test/regress/tests/router/expected/with_tables.out
@@ -7,32 +7,32 @@
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
-    add distribution
+    add distribution    
 ------------------------
  distribution id -> ds1
 (1 row)
 
 CREATE KEY RANGE krid1 FROM 1 ROUTE TO sh1 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 1
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 101 ROUTE TO sh2 FOR DISTRIBUTION ds1;
- add key range
+ add key range 
 ---------------
  bound -> 101
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION orders DISTRIBUTION KEY id;
-       attach table
+       attach table        
 ---------------------------
  relation name   -> orders
  distribution id -> ds1
 (1 row)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION delivery DISTRIBUTION KEY order_id;
-        attach table
+        attach table         
 -----------------------------
  relation name   -> delivery
  distribution id -> ds1
@@ -79,7 +79,7 @@ NOTICE: send query to shard(s) : sh1,sh2
 https://github.com/pg-sharding/spqr/tree/master/docs
 
 DROP DISTRIBUTION ALL CASCADE;
-   drop distribution
+   drop distribution    
 ------------------------
  distribution id -> ds1
 (1 row)

--- a/test/regress/tests/router/expected/with_tables.out
+++ b/test/regress/tests/router/expected/with_tables.out
@@ -29,14 +29,14 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION orders DISTRIBUTION KEY id;
 ---------------------------
  relation name   -> orders
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 ALTER DISTRIBUTION ds1 ATTACH RELATION delivery DISTRIBUTION KEY order_id;
         attach table         
 -----------------------------
  relation name   -> delivery
  distribution id -> ds1
-(1 row)
+(2 rows)
 
 \c regress
 CREATE TABLE orders(id INT PRIMARY KEY);


### PR DESCRIPTION
[Issue 398](https://github.com/pg-sharding/spqr/issues/398). У SPQR роутера и координатора есть административная консоль, в которой можно настраивать правила шардирования. Настройка происходит в консоли в формате запрос->ответ, и сейчас эти ответы не очень user-friendly. Надо изменить формат сообщений.