### PR TITLE
 Able to use different username when internal backend connect to shards

### DIFF
--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -10,5 +10,6 @@ Methods supported for frontend auth, the way they`re specified in config:
 - `clear_text`, same as `password`
 - `md5`
 - `scram`, same as `scram-sha-256`
+- `ldap`
 
 For more information about authentication config, see [pkg/config/auth.go](../pkg/config/auth.go)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -44,7 +44,7 @@ func AuthBackend(shard conn.DBInstance, berule *config.BackendRule, msg pgproto3
 		return nil
 	case *pgproto3.AuthenticationMD5Password:
 
-		var rule *config.AuthCfg
+		var rule *config.AuthBackendCfg
 		if berule.AuthRules == nil {
 			rule = berule.DefaultAuthRule
 		} else if _, exists := berule.AuthRules[shard.ShardName()]; exists {
@@ -56,7 +56,10 @@ func AuthBackend(shard conn.DBInstance, berule *config.BackendRule, msg pgproto3
 		if rule == nil {
 			return fmt.Errorf("auth rule not set for %s-%s-%s", shard.ShardName(), berule.DB, berule.Usr)
 		}
-
+		username := berule.Usr
+		if rule != nil && rule.Usr != "" {
+			username = rule.Usr
+		}
 		var res []byte
 
 		/* password may be configured in partially-calculated
@@ -67,7 +70,7 @@ func AuthBackend(shard conn.DBInstance, berule *config.BackendRule, msg pgproto3
 			res = []byte(rule.Password[3:])
 		} else {
 			hash := md5.New()
-			hash.Write([]byte(rule.Password + berule.Usr))
+			hash.Write([]byte(rule.Password + username))
 			res = hash.Sum(nil)
 			res = []byte(hex.EncodeToString(res))
 		}
@@ -86,7 +89,7 @@ func AuthBackend(shard conn.DBInstance, berule *config.BackendRule, msg pgproto3
 
 		return shard.Send(&pgproto3.PasswordMessage{Password: "md5" + psswd})
 	case *pgproto3.AuthenticationCleartextPassword:
-		var rule *config.AuthCfg
+		var rule *config.AuthBackendCfg
 		if berule.AuthRules == nil {
 			rule = berule.DefaultAuthRule
 		} else if _, exists := berule.AuthRules[shard.ShardName()]; exists {
@@ -101,7 +104,7 @@ func AuthBackend(shard conn.DBInstance, berule *config.BackendRule, msg pgproto3
 
 		return shard.Send(&pgproto3.PasswordMessage{Password: rule.Password})
 	case *pgproto3.AuthenticationSASL:
-		var rule *config.AuthCfg
+		var rule *config.AuthBackendCfg
 		if berule.AuthRules == nil {
 			rule = berule.DefaultAuthRule
 		} else if _, exists := berule.AuthRules[shard.ShardName()]; exists {
@@ -109,7 +112,14 @@ func AuthBackend(shard conn.DBInstance, berule *config.BackendRule, msg pgproto3
 		} else {
 			rule = berule.DefaultAuthRule
 		}
-		clientSHA256, err := scram.SHA256.NewClient(berule.Usr, rule.Password, "")
+		if rule == nil {
+			return fmt.Errorf("auth rule not set for %s-%s-%s", shard.ShardName(), berule.DB, berule.Usr)
+		}
+		username := berule.Usr
+		if rule != nil && rule.Usr != "" {
+			username = rule.Usr
+		}
+		clientSHA256, err := scram.SHA256.NewClient(username, rule.Password, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -57,7 +57,7 @@ func AuthBackend(shard conn.DBInstance, berule *config.BackendRule, msg pgproto3
 			return fmt.Errorf("auth rule not set for %s-%s-%s", shard.ShardName(), berule.DB, berule.Usr)
 		}
 		username := berule.Usr
-		if rule != nil && rule.Usr != "" {
+		if rule.Usr != "" {
 			username = rule.Usr
 		}
 		var res []byte
@@ -116,7 +116,7 @@ func AuthBackend(shard conn.DBInstance, berule *config.BackendRule, msg pgproto3
 			return fmt.Errorf("auth rule not set for %s-%s-%s", shard.ShardName(), berule.DB, berule.Usr)
 		}
 		username := berule.Usr
-		if rule != nil && rule.Usr != "" {
+		if rule.Usr != "" {
 			username = rule.Usr
 		}
 		clientSHA256, err := scram.SHA256.NewClient(username, rule.Password, "")

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -32,17 +32,17 @@ var buf bytes.Buffer
 //
 // Returns:
 // - *config.BackendRule: The generated BackendRule object.
-func MockBakendRule(method string) *config.BackendRule {
-	auth1 := &config.AuthCfg{
-		Method:   config.AuthMethod(method),
+func MockBakendRule() *config.BackendRule {
+	auth1 := &config.AuthBackendCfg{
+		//Method:   config.AuthMethod(method),
 		Password: "123",
 	}
-	auth2 := &config.AuthCfg{
-		Method:   config.AuthMethod(method),
+	auth2 := &config.AuthBackendCfg{
+		// Method:   config.AuthMethod(method),
 		Password: "321",
 	}
 
-	authRules := map[string]*config.AuthCfg{shardName1: auth1, shardName2: auth2}
+	authRules := map[string]*config.AuthBackendCfg{shardName1: auth1, shardName2: auth2}
 
 	br := &config.BackendRule{
 		Usr:             "vasya",
@@ -94,10 +94,10 @@ func TestDifferentPasswordsForDifferentShards(t *testing.T) {
 	//init test data
 	assert := assert.New(t)
 
-	br_md5 := MockBakendRule("md5")
+	br_md5 := MockBakendRule()
 	message_md5 := &pgproto3.AuthenticationMD5Password{}
 
-	br_clear := MockBakendRule("clear_text")
+	br_clear := MockBakendRule()
 	message_clear := &pgproto3.AuthenticationCleartextPassword{}
 
 	shard1 := MockShard(shardName1)
@@ -155,10 +155,10 @@ func TestSamePasswordForOneShard(t *testing.T) {
 	//init test data
 	assert := assert.New(t)
 
-	br_md5 := MockBakendRule("md5")
+	br_md5 := MockBakendRule()
 	message_md5 := &pgproto3.AuthenticationMD5Password{}
 
-	br_clear := MockBakendRule("clear_text")
+	br_clear := MockBakendRule()
 	message_clear := &pgproto3.AuthenticationCleartextPassword{}
 
 	shard1 := MockShard(shardName1)
@@ -209,10 +209,10 @@ func TestErrorWhenNoPasswordForShard(t *testing.T) {
 	//init test data
 	assert := assert.New(t)
 
-	br_md5 := MockBakendRule("md5")
+	br_md5 := MockBakendRule()
 	message_md5 := &pgproto3.AuthenticationMD5Password{}
 
-	br_clear := MockBakendRule("clear_text")
+	br_clear := MockBakendRule()
 	message_clear := &pgproto3.AuthenticationCleartextPassword{}
 
 	shard := MockShard("unexisting")
@@ -243,8 +243,8 @@ func TestErrorWhenNoPasswordForShard(t *testing.T) {
 // - None.
 func TestCanConnectWithDefaultRule(t *testing.T) {
 	//init test data
-	authRule_md5 := &config.AuthCfg{
-		Method:   "md5",
+	authRule_md5 := &config.AuthBackendCfg{
+		// Method:   "md5",
 		Password: "12345",
 	}
 
@@ -256,8 +256,8 @@ func TestCanConnectWithDefaultRule(t *testing.T) {
 	}
 	message_md5 := &pgproto3.AuthenticationMD5Password{}
 
-	authRule_clear := &config.AuthCfg{
-		Method:   "clear_text",
+	authRule_clear := &config.AuthBackendCfg{
+		//Method:   "clear_text",
 		Password: "12345",
 	}
 
@@ -302,16 +302,16 @@ func TestCanConnectWithDefaultRule(t *testing.T) {
 // - None.
 func TestDifferentPasswordsForRuleAndDefault(t *testing.T) {
 	//init test data
-	br_md5 := MockBakendRule("md5")
-	br_md5.DefaultAuthRule = &config.AuthCfg{
-		Method:   "md5",
+	br_md5 := MockBakendRule()
+	br_md5.DefaultAuthRule = &config.AuthBackendCfg{
+		//Method:   "md5",
 		Password: "12345",
 	}
 	message_md5 := &pgproto3.AuthenticationMD5Password{}
 
-	br_clear := MockBakendRule("clear_text")
-	br_clear.DefaultAuthRule = &config.AuthCfg{
-		Method:   "clear_text",
+	br_clear := MockBakendRule()
+	br_clear.DefaultAuthRule = &config.AuthBackendCfg{
+		//Method:   "clear_text",
 		Password: "12345",
 	}
 	message_clear := &pgproto3.AuthenticationCleartextPassword{}
@@ -378,7 +378,6 @@ func MockFrontendRule(method string, ldapConfig *config.LDAPCfg) *config.Fronten
 	}
 	return fr
 }
-
 
 // TestAuthFrontend is a unit test function that tests the AuthFrontend function in the auth package.
 //

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -34,11 +34,9 @@ var buf bytes.Buffer
 // - *config.BackendRule: The generated BackendRule object.
 func MockBakendRule() *config.BackendRule {
 	auth1 := &config.AuthBackendCfg{
-		//Method:   config.AuthMethod(method),
 		Password: "123",
 	}
 	auth2 := &config.AuthBackendCfg{
-		// Method:   config.AuthMethod(method),
 		Password: "321",
 	}
 
@@ -244,7 +242,6 @@ func TestErrorWhenNoPasswordForShard(t *testing.T) {
 func TestCanConnectWithDefaultRule(t *testing.T) {
 	//init test data
 	authRule_md5 := &config.AuthBackendCfg{
-		// Method:   "md5",
 		Password: "12345",
 	}
 
@@ -257,7 +254,6 @@ func TestCanConnectWithDefaultRule(t *testing.T) {
 	message_md5 := &pgproto3.AuthenticationMD5Password{}
 
 	authRule_clear := &config.AuthBackendCfg{
-		//Method:   "clear_text",
 		Password: "12345",
 	}
 
@@ -304,14 +300,12 @@ func TestDifferentPasswordsForRuleAndDefault(t *testing.T) {
 	//init test data
 	br_md5 := MockBakendRule()
 	br_md5.DefaultAuthRule = &config.AuthBackendCfg{
-		//Method:   "md5",
 		Password: "12345",
 	}
 	message_md5 := &pgproto3.AuthenticationMD5Password{}
 
 	br_clear := MockBakendRule()
 	br_clear.DefaultAuthRule = &config.AuthBackendCfg{
-		//Method:   "clear_text",
 		Password: "12345",
 	}
 	message_clear := &pgproto3.AuthenticationCleartextPassword{}

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -375,7 +375,7 @@ func MockFrontendRule(method string, ldapConfig *config.LDAPCfg) *config.Fronten
 
 // TestAuthFrontend is a unit test function that tests the AuthFrontend function in the auth package.
 //
-// It sets up a mock client, defines the LDAP configuration for testing on an external open LDAP server,
+// It sets up a mock client, defines the LDAP configuration for testing on an external LDAP server,
 // and tests the AuthFrontend function with both search+bind and simple-bind modes.
 // The function asserts that there are no errors returned by the AuthFrontend function.
 //

--- a/pkg/config/auth_backend.go
+++ b/pkg/config/auth_backend.go
@@ -1,0 +1,6 @@
+package config
+
+type AuthBackendCfg struct {
+	Password string `json:"password" yaml:"password" toml:"password"`
+	Usr      string `json:"usr" yaml:"usr" toml:"usr"`
+}

--- a/pkg/config/router.go
+++ b/pkg/config/router.go
@@ -83,13 +83,13 @@ type QRouter struct {
 }
 
 type BackendRule struct {
-	DB                string              `json:"db" yaml:"db" toml:"db"`
-	Usr               string              `json:"usr" yaml:"usr" toml:"usr"`
-	AuthRules         map[string]*AuthCfg `json:"auth_rules" yaml:"auth_rules" toml:"auth_rules"` // TODO validate
-	DefaultAuthRule   *AuthCfg            `json:"auth_rule" yaml:"auth_rule" toml:"auth_rule"`
-	PoolDefault       bool                `json:"pool_default" yaml:"pool_default" toml:"pool_default"`
-	ConnectionLimit   int                 `json:"connection_limit" yaml:"connection_limit" toml:"connection_limit"`
-	ConnectionRetries int                 `json:"connection_retries" yaml:"connection_retries" toml:"connection_retries"`
+	DB                string                     `json:"db" yaml:"db" toml:"db"`
+	Usr               string                     `json:"usr" yaml:"usr" toml:"usr"`
+	AuthRules         map[string]*AuthBackendCfg `json:"auth_rules" yaml:"auth_rules" toml:"auth_rules"` // TODO validate
+	DefaultAuthRule   *AuthBackendCfg            `json:"auth_rule" yaml:"auth_rule" toml:"auth_rule"`
+	PoolDefault       bool                       `json:"pool_default" yaml:"pool_default" toml:"pool_default"`
+	ConnectionLimit   int                        `json:"connection_limit" yaml:"connection_limit" toml:"connection_limit"`
+	ConnectionRetries int                        `json:"connection_retries" yaml:"connection_retries" toml:"connection_retries"`
 }
 
 type FrontendRule struct {

--- a/pkg/datashard/datashard.go
+++ b/pkg/datashard/datashard.go
@@ -588,6 +588,13 @@ func (srv *Conn) PrepareStatement(hash uint64, rd *shard.PreparedStatementDescri
 	srv.mp[hash] = rd
 }
 
+// AuthRule returns the backend auth configuration of the Conn object.
+//
+// Parameters:
+// - None.
+//
+// Returns:
+// - config.AuthBackendCfg: the configuration config.
 func (sh *Conn) AuthRule() *config.AuthBackendCfg {
 	var rule *config.AuthBackendCfg
 	if sh.beRule.AuthRules == nil {


### PR DESCRIPTION
-Add a different auth configuration struct for backend auth rules (because AuthMethod is not used here).
-Add the ability to use different usernames when internal backend connects to shards. 
This may be used when:
- Different shards have different PostgreSQL usernames.
- When using LDAP/GSS auth - SPQR as one entrypoint for many LDAP users able to connect.