### PR TITLE
Fix Dockerfile for spqr-router

### DIFF
--- a/docker/router/Dockerfile
+++ b/docker/router/Dockerfile
@@ -3,4 +3,5 @@ FROM spqr-base-image
 RUN apt-get update && apt-get install -y postgresql-client
 COPY ./docker/router/ssl/localhost.crt /etc/spqr/ssl/server.crt
 COPY ./docker/router/ssl/localhost.key /etc/spqr/ssl/server.key
-ENTRYPOINT CONFIG_PATH=${ROUTER_CONFIG=/spqr/docker/router/cfg.yaml} COORD_CONFIG_PATH=${COORDINATOR_CONFIG=/spqr/docker/coordinator/cfg.yaml} && CUR_HOST=$(cat ${CONFIG_PATH} | grep "host:") && sed -i "s/${CUR_HOST}/${ROUTER_HOST=${CUR_HOST}}/g" ${CONFIG_PATH}  && /spqr/spqr-router run --config ${CONFIG_PATH} --coordinator-config ${COORD_CONFIG_PATH} >> ${ROUTER_LOG}
+ENTRYPOINT CONFIG_PATH=${ROUTER_CONFIG=/spqr/docker/router/cfg.yaml} COORD_CONFIG_PATH=${COORDINATOR_CONFIG=/spqr/docker/coordinator/cfg.yaml} && \
+    /spqr/spqr-router run --config ${CONFIG_PATH} --coordinator-config ${COORD_CONFIG_PATH} >> ${ROUTER_LOG}


### PR DESCRIPTION
It's currentlty impossible to run spqr-router in Docker container with custom bound config. Also ROUTER_HOST is not used in any place internally, so it can be removed easilly