### PR TITLE
Drop `sharding rule` mentions

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -68,7 +68,7 @@ func processDrop(ctx context.Context, dstmt spqrparser.Statement, isCascade bool
 			return cli.DropKeyRange(ctx, []string{stmt.KeyRangeID})
 		}
 	case *spqrparser.ShardingRuleSelector:
-		return cli.ReportError(spqrerror.ShardingKeysRemoved)
+		return cli.ReportError(spqrerror.ShardingRulesRemoved)
 	case *spqrparser.DistributionSelector:
 		var krs []*kr.KeyRange
 		var err error
@@ -190,7 +190,7 @@ func processCreate(ctx context.Context, astmt spqrparser.Statement, mngr EntityM
 		}
 		return cli.AddDistribution(ctx, distribution)
 	case *spqrparser.ShardingRuleDefinition:
-		return cli.ReportError(spqrerror.ShardingKeysRemoved)
+		return cli.ReportError(spqrerror.ShardingRulesRemoved)
 	case *spqrparser.KeyRangeDefinition:
 		req := kr.KeyRangeFromSQL(stmt)
 		if err := mngr.CreateKeyRange(ctx, req); err != nil {
@@ -454,7 +454,7 @@ func ProcessShow(ctx context.Context, stmt *spqrparser.Show, mngr EntityMgr, ci 
 
 		return cli.Routers(resp)
 	case spqrparser.ShardingRules:
-		return cli.ReportError(spqrerror.ShardingKeysRemoved)
+		return cli.ReportError(spqrerror.ShardingRulesRemoved)
 	case spqrparser.ClientsStr:
 		var resp []client.ClientInfo
 		if err := ci.ClientPoolForeach(func(client client.ClientInfo) error {

--- a/pkg/models/spqrerror/spqrerror.go
+++ b/pkg/models/spqrerror/spqrerror.go
@@ -27,7 +27,6 @@ var existingErrorCodeMap = map[string]string{
 	SPQR_NO_DATASHARD:        "failed to match any datashard",
 	SPQR_SKIP:                "skip executing this query, wait for next",
 	SPQR_COMPLEX_QUERY:       "ComplexQuery",
-	SPQR_FAILED_MATCH:        "FailedToMatch",
 	SPQR_SKIP_COLUMN:         "SkipColumn",
 	SPQR_MISS_SHARDING_KEY:   "ShardingKeysMissing",
 	SPQR_CROSS_SHARD_QUERY:   "CrossShardQueryUnsupported",
@@ -43,7 +42,7 @@ var existingErrorCodeMap = map[string]string{
 	SPQR_INVALID_REQUEST:     "Invalid Request",
 }
 
-var ShardingKeysRemoved = New(SPQR_INVALID_REQUEST, "sharding rules are removed from SPQR, see https://github.com/pg-sharding/spqr/blob/master/docs/Syntax.md")
+var ShardingRulesRemoved = New(SPQR_INVALID_REQUEST, "sharding rules are removed from SPQR, see https://github.com/pg-sharding/spqr/blob/master/docs/Syntax.md")
 
 // GetMessageByCode returns the error message associated with the provided error code.
 // If the error code is not found in the existingErrorCodeMap, the function returns "Unexpected error".

--- a/router/grpc/qrouter.go
+++ b/router/grpc/qrouter.go
@@ -216,17 +216,17 @@ func (l *LocalQrouterServer) MoveKeyRange(ctx context.Context, request *protos.M
 
 // TODO : unit tests
 func (l *LocalQrouterServer) AddShardingRules(ctx context.Context, request *protos.AddShardingRuleRequest) (*protos.AddShardingRuleReply, error) {
-	return nil, spqrerror.ShardingKeysRemoved
+	return nil, spqrerror.ShardingRulesRemoved
 }
 
 // TODO : unit tests
 func (l *LocalQrouterServer) ListShardingRules(ctx context.Context, request *protos.ListShardingRuleRequest) (*protos.ListShardingRuleReply, error) {
-	return nil, spqrerror.ShardingKeysRemoved
+	return nil, spqrerror.ShardingRulesRemoved
 }
 
 // TODO : unit tests
 func (l *LocalQrouterServer) DropShardingRules(ctx context.Context, request *protos.DropShardingRuleRequest) (*protos.DropShardingRuleReply, error) {
-	return nil, spqrerror.ShardingKeysRemoved
+	return nil, spqrerror.ShardingRulesRemoved
 }
 
 // TODO : unit tests

--- a/router/qrouter/proxy_routing.go
+++ b/router/qrouter/proxy_routing.go
@@ -134,7 +134,6 @@ func (meta *RoutingMetadataContext) ResolveRelationByAlias(alias string) (Relati
 var ComplexQuery = fmt.Errorf("too complex query to route")
 var InformationSchemaCombinedQuery = fmt.Errorf("combined information schema and regular relation is not supported")
 var FailedToFindKeyRange = fmt.Errorf("failed to match key with ranges")
-var FailedToMatch = fmt.Errorf("failed to match query to any sharding rule")
 var SkipColumn = fmt.Errorf("skip column for routing")
 var ShardingKeysMissing = fmt.Errorf("sharding keys are missing in query")
 var CrossShardQueryUnsupported = fmt.Errorf("cross shard query unsupported")
@@ -992,7 +991,7 @@ func (qr *ProxyQrouter) Route(ctx context.Context, stmt lyx.Node, sph session.Se
 	case routingstate.MultiMatchState:
 		switch sph.DefaultRouteBehaviour() {
 		case "BLOCK":
-			return routingstate.SkipRoutingState{}, FailedToMatch
+			return routingstate.SkipRoutingState{}, spqrerror.NewByCode(spqrerror.SPQR_NO_DATASHARD) 
 		default:
 			return routingstate.MultiMatchState{}, nil
 		}


### PR DESCRIPTION
There is no `sharding rule` term anymore

```
regress=> create table denchick(i int);
ERROR:  client proccessing error: error processing query 'create table denchick(i int);': failed to match query to any sharding rule, tx status IDLE
```