### PR TITLE
fix panics in CmpRangesEqual  and CmpRangesLessEqual 

### DIFF
--- a/pkg/client/clientpool.go
+++ b/pkg/client/clientpool.go
@@ -126,7 +126,8 @@ func (c *PoolImpl) Shutdown() error {
 // ClientPoolForeach iterates over all clients in the client pool and executes the provided function for each client.
 //
 // The provided function should have the following signature:
-//   func(clientID uint, client Client) error
+//
+//	func(clientID uint, client Client) error
 //
 // Parameters:
 //   - f (func): The function to be executed for each client.
@@ -146,7 +147,6 @@ func (c *PoolImpl) ClientPoolForeach(cb func(client ClientInfo) error) error {
 
 	return nil
 }
-
 
 // NewClientPool creates a new instance of the PoolImpl struct, which implements the Pool interface.
 //

--- a/pkg/config/balancer.go
+++ b/pkg/config/balancer.go
@@ -37,7 +37,7 @@ var cfgBalancer Balancer
 // LoadBalancerCfg loads the balancer configuration from the specified file path.
 //
 // Parameters:
-//  - cfgPath (string): The path of the configuration file.
+//   - cfgPath (string): The path of the configuration file.
 //
 // Returns:
 //   - error: an error if any occurred during the loading process.
@@ -70,6 +70,7 @@ func LoadBalancerCfg(cfgPath string) error {
 // Parameters:
 //   - file (*os.File): the file containing the configuration data.
 //   - filepath (string): the path of the configuration file.
+//
 // Returns:
 //   - error: an error if any occurred during the initialization process.
 func initBalancerConfig(file *os.File, filepath string) error {
@@ -85,7 +86,6 @@ func initBalancerConfig(file *os.File, filepath string) error {
 	}
 	return fmt.Errorf("unknown config format type: %s. Use .toml, .yaml or .json suffix in filename", filepath)
 }
-
 
 // BalancerConfig returns a pointer to the Balancer configuration.
 //

--- a/pkg/config/coordinator.go
+++ b/pkg/config/coordinator.go
@@ -58,6 +58,7 @@ func LoadCoordinatorCfg(cfgPath string) error {
 // Parameters:
 //   - file (*os.File): the file containing the configuration data.
 //   - filepath (string): the path of the configuration file.
+//
 // Returns:
 //   - error: an error if any occurred during the initialization process.
 func initCoordinatorConfig(file *os.File, filepath string) error {

--- a/pkg/coord/adapter.go
+++ b/pkg/coord/adapter.go
@@ -37,10 +37,8 @@ func NewAdapter(conn *grpc.ClientConn) *Adapter {
 	}
 }
 
-
 // QDB returns the QDB object associated with the Adapter.
 
-//
 // Parameters:
 // - None.
 //
@@ -383,7 +381,7 @@ func (a *Adapter) DropKeyRange(ctx context.Context, krid string) error {
 //
 // Parameters:
 // - ctx (context.Context): The context for the request.
-// 
+//
 // Returns:
 // - error: An error if the key range drop fails, otherwise nil.
 func (a *Adapter) DropKeyRangeAll(ctx context.Context) error {
@@ -416,7 +414,7 @@ func (a *Adapter) RegisterRouter(ctx context.Context, r *topology.Router) error 
 //
 // Parameters:
 // - ctx (context.Context): The context for the request.
-// 
+//
 // Returns:
 // - []*topology.Router: A list of router instances.
 // - error: An error if listing routers fails, otherwise nil.
@@ -767,7 +765,6 @@ func (a *Adapter) WriteTaskGroup(ctx context.Context, taskGroup *tasks.TaskGroup
 	})
 	return err
 }
-
 
 // RemoveTaskGroup removes a task group from the system.
 //

--- a/pkg/decode/spqrql_test.go
+++ b/pkg/decode/spqrql_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 // TestKeyRange is a unit test function for the KeyRange function.
 //
 // It tests the KeyRange function by creating a key range with the given parameters and
 // asserting that the returned string matches the expected value.
-// 
+//
 // Parameters:
 // - t (*testing.T): The testing object used for assertions.
 //
@@ -48,7 +47,7 @@ func TestKeyRange(t *testing.T) {
 //
 // It tests the Distribution function by creating a distribution with the given parameters and
 // asserting that the returned string matches the expected value.
-// 
+//
 // Parameters:
 // - t (*testing.T): The testing object used for assertions.
 //
@@ -90,7 +89,7 @@ func TestDistribution(t *testing.T) {
 // TestDistributedRelation is a unit test function for the DistributedRelation function.
 //
 // It tests the DistributedRelation function by asserting that the returned string matches the expected string.
-// 
+//
 // Parameters:
 // - t (*testing.T): The testing object used for assertions.
 //

--- a/pkg/models/kr/keyrange.go
+++ b/pkg/models/kr/keyrange.go
@@ -3,6 +3,7 @@ package kr
 import (
 	"encoding/binary"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/pg-sharding/spqr/pkg/models/distributions"
@@ -149,7 +150,19 @@ func CmpRangesLess(bound KeyRangeBound, key KeyRangeBound, types []string) bool 
 			}
 		case qdb.ColumnTypeInteger:
 			i1 := bound[i].(int64)
-			i2 := key[i].(int64)
+			// TODO what is happening here?
+			// When you passing SPQR_SHARDING_KEY param, this params has a string type
+			// But you sharding key could be an integer type and in this case, obviously,
+			// we try to cast a to int and getting a panic: interface conversion.
+			// A workaroud solution
+			i2, ok := key[i].(int64)
+			if !ok {
+				i2temp, err := strconv.ParseInt(key[i].(string), 10, 64)
+				if err != nil {
+					panic(err)
+				}
+				i2 = i2temp
+			}
 			if i1 == i2 {
 				// continue
 			} else if i1 < i2 {
@@ -201,7 +214,19 @@ func CmpRangesEqual(bound KeyRangeBound, key KeyRangeBound, types []string) bool
 			}
 		case qdb.ColumnTypeInteger:
 			i1 := bound[i].(int64)
-			i2 := key[i].(int64)
+			// TODO what is happening here?
+			// When you passing SPQR_SHARDING_KEY param, this params has a string type
+			// But you sharding key could be an integer type and in this case, obviously,
+			// we try to cast a to int and getting a panic: interface conversion.
+			// A workaroud solution
+			i2, ok := key[i].(int64)
+			if !ok {
+				i2temp, err := strconv.ParseInt(key[i].(string), 10, 64)
+				if err != nil {
+					panic(err)
+				}
+				i2 = i2temp
+			}
 			if i1 == i2 {
 				// continue
 			} else {

--- a/router/qrouter/proxy_routing.go
+++ b/router/qrouter/proxy_routing.go
@@ -1106,7 +1106,7 @@ func (qr *ProxyQrouter) Route(ctx context.Context, stmt lyx.Node, sph session.Se
 	case routingstate.MultiMatchState:
 		switch sph.DefaultRouteBehaviour() {
 		case "BLOCK":
-			return routingstate.SkipRoutingState{}, spqrerror.NewByCode(spqrerror.SPQR_NO_DATASHARD) 
+			return routingstate.SkipRoutingState{}, spqrerror.NewByCode(spqrerror.SPQR_NO_DATASHARD)
 		default:
 			return routingstate.MultiMatchState{}, nil
 		}

--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -1233,7 +1233,7 @@ func (rst *RelayStateImpl) ProcessExtendedBuffer(cmngr poolmgr.PoolMgr) error {
 					if err != nil {
 						return err
 					}
-					
+
 					/* Here we close portal, so other clients can reuse it */
 					_, _, err = rst.RelayStep(&pgproto3.Close{
 						ObjectType: 'P',


### PR DESCRIPTION
```
panic: interface conversion: interface {} is string, not int64

goroutine 198 [running]:
github.com/pg-sharding/spqr/pkg/models/kr.CmpRangesEqual({0xc00033d0d0, 0x1, 0x1}, {0xc00033d100, 0x1, 0x1}, {0xc00033c190, 0x1, 0x1})
        /spqr/pkg/models/kr/keyrange.go:204 +0x697
github.com/pg-sharding/spqr/pkg/models/kr.CmpRangesLessEqual({0xc00033d0d0, 0x1, 0x1}, {0xc00033d100, 0x1, 0x1}, {0xc00033c190, 0x1, 0x1})
        /spqr/pkg/models/kr/keyrange.go:237 +0x94
github.com/pg-sharding/spqr/router/qrouter.(*ProxyQrouter).DeparseKeyWithRangesInternal(0xc000099360, {0x1, 0x216f580}, {0xc00033d100, 0x1, 0x1}, {0xc00033d0f0, 0x2, 0x2})
        /spqr/router/qrouter/proxy_routing.go:184 +0x1fd
github.com/pg-sharding/spqr/router/relay.deparseRouteHint({0x195a8a0, 0xc000400ea0}, 0xc0003cf0b0)
        /spqr/router/relay/qstate.go:49 +0x5f0
github.com/pg-sharding/spqr/router/relay.ProcQueryAdvanced({0x195a8a0, 0xc000400ea0}, {0xc000547570, 0x65}, {0x1944ef0, 0xc00033d050}, 0xc0002ef948)
        /spqr/router/relay/qstate.go:81 +0x589
github.com/pg-sharding/spqr/router/frontend.ProcessMessage({0x1945b80, 0xc000099360}, {0x1945ae0, 0x216f580}, {0x195a8a0, 0xc000400ea0}, {0x193d060, 0xc000202380})
        /spqr/router/frontend/frontend.go:138 +0x17ab
github.com/pg-sharding/spqr/router/frontend.Frontend({0x1945b80, 0xc000099360}, {0x195c610, 0xc00052efc0}, {0x1945ae0, 0x216f580}, 0x2140120, {0x1943c50, 0xc00036cfc0})
        /spqr/router/frontend/frontend.go:195 +0x989
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).serv(0xc00039e180, {0x1946088, 0xc000124080}, 0x0)
        /spqr/router/instance/instance.go:192 +0x931
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run.func4()
        /spqr/router/instance/instance.go:245 +0x45
created by github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run in goroutine 51
        /spqr/router/instance/instance.go:244 +0x925
```