### PR TITLE
Check shard name before establising connection

### DIFF
--- a/pkg/pool/dbpool.go
+++ b/pkg/pool/dbpool.go
@@ -221,6 +221,10 @@ func (s *InstancePoolImpl) Connection(
 	var posCache []string
 	var negCache []string
 
+	if _, ok := s.shardMapping[key.Name]; !ok {
+		return nil, fmt.Errorf("shard with name %q not found", key.Name)
+	}
+
 	for _, host := range s.shardMapping[key.Name].Hosts {
 		tsaKey := TsaKey{
 			Tsa:  targetSessionAttrs,


### PR DESCRIPTION
if no shards are specified, router panics when trying to connect to it
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xeb7810]

goroutine 35 [running]:
github.com/pg-sharding/spqr/pkg/pool.(*InstancePoolImpl).Connection(0x400030a7e0, 0xffffffffffffffff, {{0x0, 0x0}, 0x0}, {0x0, 0x0})
        /spqr/pkg/pool/dbpool.go:224 +0x100
github.com/pg-sharding/spqr/router/route.(*Route).Params(0x400030a840)
        /spqr/router/route/route.go:95 +0x1d8
github.com/pg-sharding/spqr/router/client.(*PsqlClient).Auth(0x4000207e60, 0x400030a840)
        /spqr/router/client/client.go:740 +0x498
github.com/pg-sharding/spqr/router/rulerouter.(*RuleRouterImpl).PreRoute(0x400038e050, {0x1673970, 0x4000061b60}, 0x3)
        /spqr/router/rulerouter/rulerouter.go:228 +0x830
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).serv(0x4000380300, {0x1673970, 0x4000061b60}, 0x3)
        /spqr/router/instance/instance.go:160 +0x6c
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run.func4()
        /spqr/router/instance/instance.go:245 +0x40
created by github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run in goroutine 23
        /spqr/router/instance/instance.go:244 +0x730
```