### PR TITLE
Support COPY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/libp2p/go-reuseport v0.4.0
 	github.com/opentracing/opentracing-go v1.2.0
-	github.com/pg-sharding/lyx v0.0.0-20240819153240-bbdc782d01c1
+	github.com/pg-sharding/lyx v0.0.0-20240823123817-e655173c284c
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0
 	github.com/sevlyar/go-daemon v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrB
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/pg-sharding/lyx v0.0.0-20240819153240-bbdc782d01c1 h1:AwlQkwnrqRyL8lqZTTAzfQ09niEc+6oFiDvQkMImTPE=
-github.com/pg-sharding/lyx v0.0.0-20240819153240-bbdc782d01c1/go.mod h1:2dPBQAhqv/30mhzj2yBXQkXhsGJQ8GhM+oWOfbGua58=
+github.com/pg-sharding/lyx v0.0.0-20240823123817-e655173c284c h1:4sXBG7ZDtG/rN2jqgmzsMawfcTKQvTCTTo8iQ7eR6VU=
+github.com/pg-sharding/lyx v0.0.0-20240823123817-e655173c284c/go.mod h1:2dPBQAhqv/30mhzj2yBXQkXhsGJQ8GhM+oWOfbGua58=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/router/frontend/frontend_test.go
+++ b/router/frontend/frontend_test.go
@@ -329,6 +329,15 @@ func TestFrontendSimpleCopyIn(t *testing.T) {
 	qr := mockqr.NewMockQueryRouter(ctrl)
 	cmngr := mockcmgr.NewMockPoolMgr(ctrl)
 
+	sh1 := mocksh.NewMockShard(ctrl)
+	sh1.EXPECT().Name().AnyTimes().Return("sh1")
+	sh1.EXPECT().SHKey().AnyTimes().Return(kr.ShardKey{Name: "sh1"})
+	sh1.EXPECT().ID().AnyTimes().Return(uint(1))
+	sh2 := mocksh.NewMockShard(ctrl)
+	sh2.EXPECT().Name().AnyTimes().Return("sh2")
+	sh2.EXPECT().SHKey().AnyTimes().Return(kr.ShardKey{Name: "sh2"})
+	sh2.EXPECT().ID().AnyTimes().Return(uint(2))
+
 	frrule := &config.FrontendRule{
 		DB:  "db1",
 		Usr: "user1",
@@ -337,7 +346,7 @@ func TestFrontendSimpleCopyIn(t *testing.T) {
 	beRule := &config.BackendRule{}
 
 	srv.EXPECT().Name().AnyTimes().Return("serv1")
-	srv.EXPECT().Datashards().AnyTimes().Return([]shard.Shard{})
+	srv.EXPECT().Datashards().AnyTimes().Return([]shard.Shard{sh1, sh2})
 
 	cl.EXPECT().Server().AnyTimes().Return(srv)
 	cl.EXPECT().MaintainParams().AnyTimes().Return(false)
@@ -375,22 +384,29 @@ func TestFrontendSimpleCopyIn(t *testing.T) {
 
 	cmngr.EXPECT().TXEndCB(gomock.Any()).AnyTimes()
 
+	tableref := &lyx.RangeVar{
+		RelationName: "xx",
+	}
+
 	qr.EXPECT().Route(gomock.Any(), &lyx.Copy{
-		TableRef: &lyx.RangeVar{
-			RelationName: "xx",
-		},
-		Where:  &lyx.AExprEmpty{},
-		IsFrom: true,
-	}, gomock.Any()).Return(routingstate.ShardMatchState{
-		Route: &routingstate.DataShardRoute{
-			Shkey: kr.ShardKey{
-				Name: "sh1",
-			},
-		},
-	}, nil).Times(1)
+		TableRef: tableref,
+		Where:    &lyx.AExprEmpty{},
+		IsFrom:   true,
+	}, gomock.Any()).Return(routingstate.MultiMatchState{}, nil).Times(1)
+
+	qr.EXPECT().Route(gomock.Any(), &lyx.Insert{
+		TableRef:  tableref,
+		SubSelect: &lyx.ValueClause{Values: []lyx.Node{&lyx.AExprSConst{Value: "1"}}},
+	}, cl).Times(4).Return(routingstate.ShardMatchState{Route: &routingstate.DataShardRoute{Shkey: sh1.SHKey()}}, nil)
+
+	qr.EXPECT().DataShardsRoutes().AnyTimes().Return([]*routingstate.DataShardRoute{
+		&routingstate.DataShardRoute{Shkey: sh1.SHKey()},
+		&routingstate.DataShardRoute{Shkey: sh2.SHKey()}},
+	)
 
 	route := route.NewRoute(beRule, frrule, map[string]*config.Shard{
 		"sh1": {},
+		"sh2": {},
 	})
 
 	cl.EXPECT().Route().AnyTimes().Return(route)
@@ -401,12 +417,12 @@ func TestFrontendSimpleCopyIn(t *testing.T) {
 
 	cl.EXPECT().Receive().Times(1).Return(query, nil)
 
-	cl.EXPECT().Receive().Times(4).Return(&pgproto3.CopyData{}, nil)
+	cl.EXPECT().Receive().Times(4).Return(&pgproto3.CopyData{Data: []byte("1\n")}, nil)
 	cl.EXPECT().Receive().Times(1).Return(&pgproto3.CopyDone{}, nil)
 
 	srv.EXPECT().Send(query).Times(1).Return(nil)
 
-	srv.EXPECT().Send(&pgproto3.CopyData{}).Times(4).Return(nil)
+	sh1.EXPECT().Send(&pgproto3.CopyData{Data: []byte("1\n1\n1\n1\n")}).Times(1).Return(nil)
 	srv.EXPECT().Send(&pgproto3.CopyDone{}).Times(1).Return(nil)
 
 	srv.EXPECT().Receive().Times(1).Return(&pgproto3.CopyInResponse{}, nil)

--- a/router/frontend/frontend_test.go
+++ b/router/frontend/frontend_test.go
@@ -422,7 +422,7 @@ func TestFrontendSimpleCopyIn(t *testing.T) {
 
 	srv.EXPECT().Send(query).Times(1).Return(nil)
 
-	sh1.EXPECT().Send(&pgproto3.CopyData{Data: []byte("1\n1\n1\n1\n")}).Times(1).Return(nil)
+	sh1.EXPECT().Send(&pgproto3.CopyData{Data: []byte("1\n")}).Times(4).Return(nil)
 	srv.EXPECT().Send(&pgproto3.CopyDone{}).Times(1).Return(nil)
 
 	srv.EXPECT().Receive().Times(1).Return(&pgproto3.CopyInResponse{}, nil)

--- a/router/qrouter/proxy_routing_test.go
+++ b/router/qrouter/proxy_routing_test.go
@@ -1426,25 +1426,8 @@ func TestCopySingleShard(t *testing.T) {
 	for _, tt := range []tcase{
 		{
 			query: "COPY xx FROM STDIN WHERE i = 1;",
-			exp: routingstate.ShardMatchState{
-				Route: &routingstate.DataShardRoute{
-					Shkey: kr.ShardKey{
-						Name: "sh1",
-					},
-					Matchedkr: &kr.KeyRange{
-						ShardID:      "sh1",
-						ID:           "id1",
-						Distribution: distribution,
-						LowerBound: []interface{}{
-							int64(1),
-						},
-
-						ColumnTypes: []string{qdb.ColumnTypeInteger},
-					},
-				},
-				TargetSessionAttrs: "any",
-			},
-			err: nil,
+			exp:   routingstate.MultiMatchState{},
+			err:   nil,
 		},
 	} {
 		parserRes, err := lyx.Parse(tt.query)

--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -666,7 +666,7 @@ func (rst *RelayStateImpl) ProcCopy(stmt *lyx.Copy, data *pgproto3.CopyData) err
 	defer rst.Client().RUnlock()
 
 	// Read delimiter from COPY options
-	delimiter := byte(';')
+	delimiter := byte('\t')
 	for _, opt := range stmt.Options {
 		if o := opt.(*lyx.Option); strings.ToLower(o.Name) == "delimiter" {
 			delimiter = o.Arg.(*lyx.AExprSConst).Value[0]

--- a/test/regress/tests/router/expected/copy_routing.out
+++ b/test/regress/tests/router/expected/copy_routing.out
@@ -34,8 +34,8 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION copy_test DISTRIBUTION KEY id;
 \c regress
 CREATE TABLE copy_test (id int);
 NOTICE: send query to shard(s) : sh1,sh2
-COPY copy_test FROM STDIN WHERE id <= 10;
-NOTICE: send query to shard(s) : sh1
+COPY copy_test(id) FROM STDIN WHERE id <= 10;
+NOTICE: send query to shard(s) : sh1,sh2
 SELECT * FROM copy_test WHERE id <= 10;
 NOTICE: send query to shard(s) : sh1
  id 
@@ -47,10 +47,11 @@ NOTICE: send query to shard(s) : sh1
   5
 (5 rows)
 
-COPY copy_test FROM STDIN WHERE id <= 30;
-NOTICE: send query to shard(s) : sh2
-SELECT * FROM copy_test WHERE id <= 30 ORDER BY copy_test;
-NOTICE: send query to shard(s) : sh2
+COPY copy_test(id) FROM STDIN;
+NOTICE: send query to shard(s) : sh1,sh2
+ERROR:  client processing error: multishard copy is not supported, tx status IDLE
+SELECT * FROM copy_test;
+NOTICE: send query to shard(s) : sh1,sh2
  id 
 ----
   1
@@ -58,10 +59,25 @@ NOTICE: send query to shard(s) : sh2
   3
   4
   5
- 12
- 22
- 23
-(8 rows)
+(5 rows)
+
+COPY copy_test(id) FROM STDIN;
+NOTICE: send query to shard(s) : sh1,sh2
+SELECT * FROM copy_test;
+NOTICE: send query to shard(s) : sh1,sh2
+ id 
+----
+  1
+  2
+  3
+  4
+  5
+ 41
+ 42
+ 43
+ 44
+ 45
+(10 rows)
 
 DROP TABLE copy_test;
 NOTICE: send query to shard(s) : sh1,sh2

--- a/test/regress/tests/router/sql/copy_routing.sql
+++ b/test/regress/tests/router/sql/copy_routing.sql
@@ -7,20 +7,17 @@ ALTER DISTRIBUTION ds1 ATTACH RELATION copy_test DISTRIBUTION KEY id;
 \c regress
 CREATE TABLE copy_test (id int);
 
-COPY copy_test FROM STDIN WHERE id <= 10;
+COPY copy_test(id) FROM STDIN WHERE id <= 10;
 1
 2
 3
 4
 5
-12
-3434
-43
 \.
 
 SELECT * FROM copy_test WHERE id <= 10;
 
-COPY copy_test FROM STDIN WHERE id <= 30;
+COPY copy_test(id) FROM STDIN;
 1
 2
 3
@@ -35,7 +32,17 @@ COPY copy_test FROM STDIN WHERE id <= 30;
 43
 \.
 
-SELECT * FROM copy_test WHERE id <= 30 ORDER BY copy_test;
+SELECT * FROM copy_test;
+
+COPY copy_test(id) FROM STDIN;
+41
+42
+43
+44
+45
+\.
+
+SELECT * FROM copy_test;
 
 DROP TABLE copy_test;
 


### PR DESCRIPTION
I suggest routing COPY command according to data to be copied. We parse the data, then get route for each row and compare. For now support only routing to one shard, which means if routes are different, return error.