### PR TITLE
Support __spqr__auto_distribution hint

### DIFF
--- a/pkg/session/dummy_holder.go
+++ b/pkg/session/dummy_holder.go
@@ -11,6 +11,26 @@ type DummySessionParamHandler struct {
 	rh           routehint.RouteHint
 }
 
+// DistributionKey implements SessionParamsHolder.
+func (t *DummySessionParamHandler) DistributionKey() string {
+	return ""
+}
+
+// SetDistributionKey implements SessionParamsHolder.
+func (t *DummySessionParamHandler) SetDistributionKey(string) {
+
+}
+
+// AutoDistribution implements SessionParamsHolder.
+func (t *DummySessionParamHandler) AutoDistribution() string {
+	return ""
+}
+
+// SetAutoDistribution implements SessionParamsHolder.
+func (t *DummySessionParamHandler) SetAutoDistribution(string) {
+
+}
+
 // MaintainParams implements SessionParamsHolder.
 func (t *DummySessionParamHandler) MaintainParams() bool {
 	panic("unimplemented")

--- a/pkg/session/param.go
+++ b/pkg/session/param.go
@@ -10,6 +10,12 @@ type SessionParamsHolder interface {
 	DefaultRouteBehaviour() string
 	SetDefaultRouteBehaviour(string)
 
+	SetAutoDistribution(string)
+	AutoDistribution() string
+
+	SetDistributionKey(string)
+	DistributionKey() string
+
 	// Get current session distribution
 	Distribution() string
 	SetDistribution(string)
@@ -37,6 +43,8 @@ type SessionParamsHolder interface {
 const (
 	SPQR_DISTRIBUTION            = "__spqr__distribution"
 	SPQR_DEFAULT_ROUTE_BEHAVIOUR = "__spqr__default_route_behaviour"
+	SPQR_AUTO_DISTRIBUTION       = "__spqr__auto_distribution"
+	SPQR_DISTRIBUTION_KEY        = "__spqr__distribution_key"
 	SPQR_SHARDING_KEY            = "__spqr__sharding_key"
 	SPQR_SCATTER_QUERY           = "__spqr__scatter_query"
 	SPQR_REPLY_NOTICE            = "__spqr__reply_notice"

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -132,6 +132,26 @@ func (cl *PsqlClient) SetDistribution(val string) {
 	cl.activeParamSet[session.SPQR_DISTRIBUTION] = val
 }
 
+// SetAutoDistribution implements RouterClient.
+func (cl *PsqlClient) SetAutoDistribution(val string) {
+	cl.activeParamSet[session.SPQR_AUTO_DISTRIBUTION] = val
+}
+
+// AutoDistribution implements RouterClient.
+func (cl *PsqlClient) AutoDistribution() string {
+	return cl.activeParamSet[session.SPQR_AUTO_DISTRIBUTION]
+}
+
+// SetDistributionKey implements RouterClient.
+func (cl *PsqlClient) SetDistributionKey(val string) {
+	cl.activeParamSet[session.SPQR_DISTRIBUTION_KEY] = val
+}
+
+// DistributionKey implements RouterClient.
+func (cl *PsqlClient) DistributionKey() string {
+	return cl.activeParamSet[session.SPQR_DISTRIBUTION_KEY]
+}
+
 // MaintainParams implements RouterClient.
 func (cl *PsqlClient) MaintainParams() bool {
 	return cl.maintain_params

--- a/router/mock/client/mock_client.go
+++ b/router/mock/client/mock_client.go
@@ -99,6 +99,20 @@ func (mr *MockRouterClientMockRecorder) Auth(rt interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Auth", reflect.TypeOf((*MockRouterClient)(nil).Auth), rt)
 }
 
+// AutoDistribution mocks base method.
+func (m *MockRouterClient) AutoDistribution() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AutoDistribution")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// AutoDistribution indicates an expected call of AutoDistribution.
+func (mr *MockRouterClientMockRecorder) AutoDistribution() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AutoDistribution", reflect.TypeOf((*MockRouterClient)(nil).AutoDistribution))
+}
+
 // BindParamFormatCodes mocks base method.
 func (m *MockRouterClient) BindParamFormatCodes() []int16 {
 	m.ctrl.T.Helper()
@@ -249,6 +263,20 @@ func (m *MockRouterClient) Distribution() string {
 func (mr *MockRouterClientMockRecorder) Distribution() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Distribution", reflect.TypeOf((*MockRouterClient)(nil).Distribution))
+}
+
+// DistributionKey mocks base method.
+func (m *MockRouterClient) DistributionKey() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DistributionKey")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// DistributionKey indicates an expected call of DistributionKey.
+func (mr *MockRouterClientMockRecorder) DistributionKey() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionKey", reflect.TypeOf((*MockRouterClient)(nil).DistributionKey))
 }
 
 // GetCancelKey mocks base method.
@@ -863,6 +891,18 @@ func (mr *MockRouterClientMockRecorder) SetAuthType(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAuthType", reflect.TypeOf((*MockRouterClient)(nil).SetAuthType), arg0)
 }
 
+// SetAutoDistribution mocks base method.
+func (m *MockRouterClient) SetAutoDistribution(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetAutoDistribution", arg0)
+}
+
+// SetAutoDistribution indicates an expected call of SetAutoDistribution.
+func (mr *MockRouterClientMockRecorder) SetAutoDistribution(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAutoDistribution", reflect.TypeOf((*MockRouterClient)(nil).SetAutoDistribution), arg0)
+}
+
 // SetBindParams mocks base method.
 func (m *MockRouterClient) SetBindParams(arg0 [][]byte) {
 	m.ctrl.T.Helper()
@@ -897,6 +937,18 @@ func (m *MockRouterClient) SetDistribution(arg0 string) {
 func (mr *MockRouterClientMockRecorder) SetDistribution(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDistribution", reflect.TypeOf((*MockRouterClient)(nil).SetDistribution), arg0)
+}
+
+// SetDistributionKey mocks base method.
+func (m *MockRouterClient) SetDistributionKey(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetDistributionKey", arg0)
+}
+
+// SetDistributionKey indicates an expected call of SetDistributionKey.
+func (mr *MockRouterClientMockRecorder) SetDistributionKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDistributionKey", reflect.TypeOf((*MockRouterClient)(nil).SetDistributionKey), arg0)
 }
 
 // SetMaintainParams mocks base method.

--- a/router/qrouter/proxy_routing.go
+++ b/router/qrouter/proxy_routing.go
@@ -868,6 +868,27 @@ func (qr *ProxyQrouter) routeWithRules(ctx context.Context, stmt lyx.Node, sph s
 
 	// XXX: need alter table which renames sharding column to non-sharding column check
 	case *lyx.CreateTable:
+		if val := sph.AutoDistribution(); val != "" {
+
+			switch q := node.TableRv.(type) {
+			case *lyx.RangeVar:
+
+				/* pre-attach relation to its distribution
+				 * sic! this is not transactional not abortable
+				 */
+				qr.mgr.AlterDistributionAttach(ctx, val, []*distributions.DistributedRelation{
+					{
+						Name: q.RelationName,
+						DistributionKey: []distributions.DistributionKeyEntry{
+							{
+								Column: sph.DistributionKey(),
+								/* support hash function here */
+							},
+						},
+					},
+				})
+			}
+		}
 		/*
 		 * Disallow to create table which does not contain any sharding column
 		 */

--- a/router/qrouter/proxy_routing.go
+++ b/router/qrouter/proxy_routing.go
@@ -876,7 +876,7 @@ func (qr *ProxyQrouter) routeWithRules(ctx context.Context, stmt lyx.Node, sph s
 				/* pre-attach relation to its distribution
 				 * sic! this is not transactional not abortable
 				 */
-				qr.mgr.AlterDistributionAttach(ctx, val, []*distributions.DistributedRelation{
+				if err := qr.mgr.AlterDistributionAttach(ctx, val, []*distributions.DistributedRelation{
 					{
 						Name: q.RelationName,
 						DistributionKey: []distributions.DistributionKeyEntry{
@@ -886,7 +886,9 @@ func (qr *ProxyQrouter) routeWithRules(ctx context.Context, stmt lyx.Node, sph s
 							},
 						},
 					},
-				})
+				}); err != nil {
+					return nil, err
+				}
 			}
 		}
 		/*

--- a/router/relay/qstate.go
+++ b/router/relay/qstate.go
@@ -119,7 +119,6 @@ func ProcQueryAdvanced(rst RelayStateMgr, query string, ph ProtoStateHandler, bi
 					rst.Client().SetRouteHint(routeHint)
 				} else {
 					spqrlog.Zero.Debug().Err(err).Msg("failed to deparse routing hint")
-					return err
 				}
 			}
 


### PR DESCRIPTION
Also `__spqr__distribution_key`



```

db1=# \c spqr-console

		SPQR router admin console
	Here you can configure your routing rules
------------------------------------------------
	You can find documentation here
https://github.com/pg-sharding/spqr/tree/master/docs

psql (16.2 (Ubuntu 16.2-1.pgdg20.04+1), server console)
WARNING: psql major version 16, server major version 0.0.
         Some psql features might not work.
You are now connected to database "spqr-console" as user "reshke".
spqr-console=> show relations;
 Relation name | Distribution ID | Distribution key
---------------+-----------------+------------------
 t             | ds1             | ("i", identity)
 t22           | ds1             | ("i", identity)
(2 rows)

spqr-console=> \c db1
psql (16.2 (Ubuntu 16.2-1.pgdg20.04+1), server 15.4)
You are now connected to database "db1" as user "reshke".
db1=# create table t33(i int, j int)  /* __spqr__auto_distribution: ds1, __spqr__distribution_key: i  */;
CREATE TABLE
db1=# \c db1
psql (16.2 (Ubuntu 16.2-1.pgdg20.04+1), server 15.4)
You are now connected to database "db1" as user "reshke".
db1=# \c spqr-console

		SPQR router admin console
	Here you can configure your routing rules
------------------------------------------------
	You can find documentation here
https://github.com/pg-sharding/spqr/tree/master/docs

psql (16.2 (Ubuntu 16.2-1.pgdg20.04+1), server console)
WARNING: psql major version 16, server major version 0.0.
         Some psql features might not work.
You are now connected to database "spqr-console" as user "reshke".
spqr-console=> show relations;
 Relation name | Distribution ID | Distribution key
---------------+-----------------+------------------
 t             | ds1             | ("i", identity)
 t22           | ds1             | ("i", identity)
 t33           | ds1             | ("i", identity)
(3 rows)

spqr-console=>
```