### PR TITLE
Add go fmt check

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -10,6 +10,30 @@ permissions:
   contents: read
 
 jobs:
+  govet:
+    name: go vet check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.0'
+          cache: false
+      - name: go vet
+        run: make govet
+  
+  fmtcheck:
+    name: go fmt check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.0'
+          cache: false
+      - name: go fmt check
+        run: make fmtcheck
+
   golangci:
     name: golangci-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -10,18 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  govet:
-    name: go vet check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.23.0'
-          cache: false
-      - name: go vet
-        run: make vet
-  
   fmtcheck:
     name: go fmt check
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -20,7 +20,7 @@ jobs:
           go-version: '1.23.0'
           cache: false
       - name: go vet
-        run: make govet
+        run: make vet
   
   fmtcheck:
     name: go fmt check

--- a/Makefile
+++ b/Makefile
@@ -140,15 +140,6 @@ feature_test: clean_feature_test build_images
 
 ####################### LINTERS #######################
 
-vet:
-	@echo "go vet ."
-	@go vet $(GOFMT_FILES) ; if [ $$? -eq 1 ]; then \
-		echo ""; \
-		echo "Vet found suspicious constructs. Please check the reported constructs"; \
-		echo "and fix them if necessary before submitting the code for review."; \
-		exit 1; \
-	fi
-
 fmt:
 	gofmt -w $(GOFMT_FILES)
 

--- a/pkg/client/clientpool.go
+++ b/pkg/client/clientpool.go
@@ -126,7 +126,8 @@ func (c *PoolImpl) Shutdown() error {
 // ClientPoolForeach iterates over all clients in the client pool and executes the provided function for each client.
 //
 // The provided function should have the following signature:
-//   func(clientID uint, client Client) error
+//
+//	func(clientID uint, client Client) error
 //
 // Parameters:
 //   - f (func): The function to be executed for each client.
@@ -146,7 +147,6 @@ func (c *PoolImpl) ClientPoolForeach(cb func(client ClientInfo) error) error {
 
 	return nil
 }
-
 
 // NewClientPool creates a new instance of the PoolImpl struct, which implements the Pool interface.
 //

--- a/pkg/config/balancer.go
+++ b/pkg/config/balancer.go
@@ -37,7 +37,7 @@ var cfgBalancer Balancer
 // LoadBalancerCfg loads the balancer configuration from the specified file path.
 //
 // Parameters:
-//  - cfgPath (string): The path of the configuration file.
+//   - cfgPath (string): The path of the configuration file.
 //
 // Returns:
 //   - error: an error if any occurred during the loading process.
@@ -70,6 +70,7 @@ func LoadBalancerCfg(cfgPath string) error {
 // Parameters:
 //   - file (*os.File): the file containing the configuration data.
 //   - filepath (string): the path of the configuration file.
+//
 // Returns:
 //   - error: an error if any occurred during the initialization process.
 func initBalancerConfig(file *os.File, filepath string) error {
@@ -85,7 +86,6 @@ func initBalancerConfig(file *os.File, filepath string) error {
 	}
 	return fmt.Errorf("unknown config format type: %s. Use .toml, .yaml or .json suffix in filename", filepath)
 }
-
 
 // BalancerConfig returns a pointer to the Balancer configuration.
 //

--- a/pkg/config/coordinator.go
+++ b/pkg/config/coordinator.go
@@ -58,6 +58,7 @@ func LoadCoordinatorCfg(cfgPath string) error {
 // Parameters:
 //   - file (*os.File): the file containing the configuration data.
 //   - filepath (string): the path of the configuration file.
+//
 // Returns:
 //   - error: an error if any occurred during the initialization process.
 func initCoordinatorConfig(file *os.File, filepath string) error {

--- a/pkg/decode/spqrql_test.go
+++ b/pkg/decode/spqrql_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 // TestKeyRange is a unit test function for the KeyRange function.
 //
 // It tests the KeyRange function by creating a key range with the given parameters and
 // asserting that the returned string matches the expected value.
-// 
+//
 // Parameters:
 // - t (*testing.T): The testing object used for assertions.
 //
@@ -48,7 +47,7 @@ func TestKeyRange(t *testing.T) {
 //
 // It tests the Distribution function by creating a distribution with the given parameters and
 // asserting that the returned string matches the expected value.
-// 
+//
 // Parameters:
 // - t (*testing.T): The testing object used for assertions.
 //
@@ -90,7 +89,7 @@ func TestDistribution(t *testing.T) {
 // TestDistributedRelation is a unit test function for the DistributedRelation function.
 //
 // It tests the DistributedRelation function by asserting that the returned string matches the expected string.
-// 
+//
 // Parameters:
 // - t (*testing.T): The testing object used for assertions.
 //

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -122,10 +122,8 @@ func processDrop(ctx context.Context, dstmt spqrparser.Statement, isCascade bool
 		if err != nil {
 			return err
 		}
+		
 		ret := make([]string, 0)
-		if err != nil {
-			return err
-		}
 		for _, ds := range dss {
 			if ds.Id != "default" {
 				if len(ds.Relations) != 0 && !isCascade {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -122,7 +122,7 @@ func processDrop(ctx context.Context, dstmt spqrparser.Statement, isCascade bool
 		if err != nil {
 			return err
 		}
-		
+
 		ret := make([]string, 0)
 		for _, ds := range dss {
 			if ds.Id != "default" {

--- a/pkg/pool/dbpool.go
+++ b/pkg/pool/dbpool.go
@@ -411,7 +411,7 @@ func NewDBPool(mapping map[string]*config.Shard, startupParams *startup.StartupP
 		if err != nil {
 			return nil, err
 		}
-		
+
 		return datashard.NewShard(shardKey, pgi, mapping[shardKey.Name], rule, startupParams)
 	}
 

--- a/pkg/pool/dbpool_test.go
+++ b/pkg/pool/dbpool_test.go
@@ -31,7 +31,7 @@ func TestDbPoolOrderCaching(t *testing.T) {
 	clId := uint(1)
 
 	dbpool := pool.NewDBPoolFromMultiPool(map[string]*config.Shard{
-		key.Name: &config.Shard{
+		key.Name: {
 			Hosts: []string{
 				"h1",
 				"h2",
@@ -138,7 +138,7 @@ func TestDbPoolReadOnlyOrderDistribution(t *testing.T) {
 	clId := uint(1)
 
 	dbpool := pool.NewDBPoolFromMultiPool(map[string]*config.Shard{
-		key.Name: &config.Shard{
+		key.Name: {
 			Hosts: []string{
 				"h1",
 				"h2",

--- a/pkg/pool/shardpool_test.go
+++ b/pkg/pool/shardpool_test.go
@@ -100,7 +100,6 @@ func TestShardPoolConnectionAcquireDiscard(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(shardconn, conn)
 
-
 	statistics = shp.View()
 	assert.Equal(0, statistics.IdleConnections)
 	assert.Equal(0, statistics.QueueResidualSize)

--- a/qdb/memqdb_test.go
+++ b/qdb/memqdb_test.go
@@ -19,7 +19,7 @@ var mockShard = &qdb.Shard{
 	Hosts: []string{"host1", "host2"},
 }
 var mockKeyRange = &qdb.KeyRange{
-	LowerBound: [][]byte{[]byte{1, 2}},
+	LowerBound: [][]byte{{1, 2}},
 	ShardID:    mockShard.ID,
 	KeyRangeID: "key_range_id",
 }

--- a/script/gofmtcheck.sh
+++ b/script/gofmtcheck.sh
@@ -9,5 +9,7 @@ if [[ -n ${gofmt_files} ]]; then
     echo "You can use the command: \`make fmt\` to reformat code."
     exit 1
 fi
+echo "OK"
+
 
 exit 0

--- a/script/gofmtcheck.sh
+++ b/script/gofmtcheck.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Check gofmt
+echo "==> Checking that code complies with gofmt requirements..."
+gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor | grep -v yacc`)
+if [[ -n ${gofmt_files} ]]; then
+    echo 'gofmt needs running on the following files:'
+    echo "${gofmt_files}"
+    echo "You can use the command: \`make fmt\` to reformat code."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Introduce 2 brand-new commands: `make fmtcheck` and `make fmt`.

make fmcheck failed:

```
➜  spqr git:(denchick-journey-5) ✗ make fmtcheck
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./pkg/config/coordinator.go
./pkg/config/balancer.go
./pkg/meta/meta.go
./pkg/decode/spqrql_test.go
./pkg/pool/shardpool_test.go
./pkg/pool/dbpool.go
./pkg/client/clientpool.go
You can use the command: `make fmt` to reformat code.
make: *** [fmtcheck] Error 1
```

make fmcheck passed:

```
➜  spqr git:(more-linters) ✗ make fmtcheck
==> Checking that code complies with gofmt requirements...
OK
```
