### PR TITLE
Add new routing runtime option: __spqr__execute_on

### DIFF
--- a/pkg/session/dummy_holder.go
+++ b/pkg/session/dummy_holder.go
@@ -9,16 +9,29 @@ type DummySessionParamHandler struct {
 	behaviour    string
 	key          string
 	rh           routehint.RouteHint
+
+	ms bool
+	eo string
+}
+
+// ExecuteOn implements SessionParamsHolder.
+func (t *DummySessionParamHandler) ExecuteOn() string {
+	return t.eo
+}
+
+// SetExecuteOn implements SessionParamsHolder.
+func (t *DummySessionParamHandler) SetExecuteOn(v string) {
+	t.eo = v
 }
 
 // AllowMultishard implements SessionParamsHolder.
 func (t *DummySessionParamHandler) AllowMultishard() bool {
-	panic("unimplemented")
+	return t.ms
 }
 
 // SetAllowMultishard implements SessionParamsHolder.
-func (t *DummySessionParamHandler) SetAllowMultishard(bool) {
-	panic("unimplemented")
+func (t *DummySessionParamHandler) SetAllowMultishard(v bool) {
+	t.ms = v
 }
 
 // DistributionKey implements SessionParamsHolder.

--- a/pkg/session/param.go
+++ b/pkg/session/param.go
@@ -39,6 +39,9 @@ type SessionParamsHolder interface {
 	MaintainParams() bool
 	SetMaintainParams(bool)
 
+	ExecuteOn() string
+	SetExecuteOn(string)
+
 	RouteHint() routehint.RouteHint
 	SetRouteHint(routehint.RouteHint)
 }
@@ -53,4 +56,5 @@ const (
 	SPQR_SCATTER_QUERY           = "__spqr__scatter_query"
 	SPQR_REPLY_NOTICE            = "__spqr__reply_notice"
 	SPQR_MAINTAIN_PARAMS         = "__spqr__maintain_params"
+	SPQR_EXECUTE_ON              = "__spqr__execute_on"
 )

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -133,6 +133,16 @@ func (cl *PsqlClient) SetDistribution(val string) {
 	cl.activeParamSet[session.SPQR_DISTRIBUTION] = val
 }
 
+// ExecuteOn implements RouterClient.
+func (cl *PsqlClient) ExecuteOn() string {
+	return cl.activeParamSet[session.SPQR_EXECUTE_ON]
+}
+
+// SetExecuteOn implements RouterClient.
+func (cl *PsqlClient) SetExecuteOn(val string) {
+	cl.activeParamSet[session.SPQR_EXECUTE_ON] = val
+}
+
 // SetAutoDistribution implements RouterClient.
 func (cl *PsqlClient) SetAutoDistribution(val string) {
 	cl.activeParamSet[session.SPQR_AUTO_DISTRIBUTION] = val

--- a/router/mock/client/mock_client.go
+++ b/router/mock/client/mock_client.go
@@ -294,6 +294,20 @@ func (mr *MockRouterClientMockRecorder) DistributionKey() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionKey", reflect.TypeOf((*MockRouterClient)(nil).DistributionKey))
 }
 
+// ExecuteOn mocks base method.
+func (m *MockRouterClient) ExecuteOn() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecuteOn")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ExecuteOn indicates an expected call of ExecuteOn.
+func (mr *MockRouterClientMockRecorder) ExecuteOn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteOn", reflect.TypeOf((*MockRouterClient)(nil).ExecuteOn))
+}
+
 // GetCancelKey mocks base method.
 func (m *MockRouterClient) GetCancelKey() uint32 {
 	m.ctrl.T.Helper()
@@ -976,6 +990,18 @@ func (m *MockRouterClient) SetDistributionKey(arg0 string) {
 func (mr *MockRouterClientMockRecorder) SetDistributionKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDistributionKey", reflect.TypeOf((*MockRouterClient)(nil).SetDistributionKey), arg0)
+}
+
+// SetExecuteOn mocks base method.
+func (m *MockRouterClient) SetExecuteOn(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetExecuteOn", arg0)
+}
+
+// SetExecuteOn indicates an expected call of SetExecuteOn.
+func (mr *MockRouterClientMockRecorder) SetExecuteOn(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExecuteOn", reflect.TypeOf((*MockRouterClient)(nil).SetExecuteOn), arg0)
 }
 
 // SetMaintainParams mocks base method.

--- a/router/relay/qstate.go
+++ b/router/relay/qstate.go
@@ -145,6 +145,16 @@ func ProcQueryAdvanced(rst RelayStateMgr, query string, ph ProtoStateHandler, bi
 					rst.Client().SetAllowMultishard(true)
 				}
 			}
+
+			if val, ok := mp[session.SPQR_EXECUTE_ON]; ok {
+				if _, ok := config.RouterConfig().ShardMapping[val]; !ok {
+					return fmt.Errorf("no such shard: %v", val)
+				}
+				rst.Client().SetExecuteOn(val)
+			} else {
+				/* unset or reset if any */
+				rst.Client().SetExecuteOn("")
+			}
 		}
 
 		return binderQ()

--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -415,7 +415,20 @@ func (rst *RelayStateImpl) Reroute() error {
 		Interface("params", rst.Client().BindParams()).
 		Msg("rerouting the client connection, resolving shard")
 
-	routingState, err := rst.Qr.Route(context.TODO(), rst.qp.Stmt(), rst.Cl)
+	var routingState routingstate.RoutingState
+	var err error
+
+	if v := rst.Client().ExecuteOn(); v != "" {
+		routingState = routingstate.ShardMatchState{
+			Route: &routingstate.DataShardRoute{
+				Shkey: kr.ShardKey{
+					Name: v,
+				},
+			},
+		}
+	} else {
+		routingState, err = rst.Qr.Route(context.TODO(), rst.qp.Stmt(), rst.Cl)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error processing query '%v': %v", rst.plainQ, err)


### PR DESCRIPTION
Similat to Greenplum's one, allowing for execute custom sql on shards

db1=# select count(1) from jp4;
 count
-------
    99
  1901
(2 rows)

db1=# select count(1) from jp4 /* __spqr__execute_on: sh1 */;
 count
-------
    99
(1 row)

db1=# select count(1) from jp4 /* __spqr__execute_on: sh2 */;
 count
-------
  1901
(1 row)

db1=# select count(1) from jp4 ;
 count
-------
    99
  1901
(2 rows)