### PR TITLE
do not listen localhost by default

### DIFF
--- a/router/app/app.go
+++ b/router/app/app.go
@@ -31,12 +31,10 @@ func (app *App) ServeRouter(ctx context.Context) error {
 	var lwg sync.WaitGroup
 
 	listen := map[string]port.RouterPortType{
-		net.JoinHostPort("localhost", app.spqr.RuleRouter.Config().RouterPort):                       port.DefaultRouterPortType,
 		net.JoinHostPort(app.spqr.RuleRouter.Config().Host, app.spqr.RuleRouter.Config().RouterPort): port.DefaultRouterPortType,
 	}
 
 	if app.spqr.RuleRouter.Config().RouterROPort != "" {
-		listen[net.JoinHostPort("localhost", app.spqr.RuleRouter.Config().RouterROPort)] = port.RORouterPortType
 		listen[net.JoinHostPort(app.spqr.RuleRouter.Config().Host, app.spqr.RuleRouter.Config().RouterROPort)] = port.RORouterPortType
 	}
 

--- a/test/feature/conf/router.yaml
+++ b/test/feature/conf/router.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_cluster.yaml
+++ b/test/feature/conf/router_cluster.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_coordinator.yaml
+++ b/test/feature/conf/router_coordinator.yaml
@@ -1,4 +1,4 @@
-host: regress_router
+host: ''
 coordinator_port: 7002
 grpc_api_port: 7003
 qdb_addr: '[regress_qdb_0_1]:2379'

--- a/test/feature/conf/router_coordinator_2.yaml
+++ b/test/feature/conf/router_coordinator_2.yaml
@@ -1,4 +1,4 @@
-host: regress_router_2
+host: ''
 coordinator_port: 7002
 grpc_api_port: 7003
 qdb_addr: '[regress_qdb_0_1]:2379'

--- a/test/feature/conf/router_with_backup.yaml
+++ b/test/feature/conf/router_with_backup.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_backup_and_initsql.yaml
+++ b/test/feature/conf/router_with_backup_and_initsql.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_coordinator.yaml
+++ b/test/feature/conf/router_with_coordinator.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_fake_initsql_and_backup.yaml
+++ b/test/feature/conf/router_with_fake_initsql_and_backup.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_gss_frontend.yaml
+++ b/test/feature/conf/router_with_gss_frontend.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_initsql.yaml
+++ b/test/feature/conf/router_with_initsql.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_initsql_and_coordinator_init.yaml
+++ b/test/feature/conf/router_with_initsql_and_coordinator_init.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_ldap_frontend.yaml
+++ b/test/feature/conf/router_with_ldap_frontend.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_scram_backend.yaml
+++ b/test/feature/conf/router_with_scram_backend.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/conf/router_with_scram_frontend.yaml
+++ b/test/feature/conf/router_with_scram_frontend.yaml
@@ -1,4 +1,4 @@
-host: 'regress_router'
+host: ''
 router_port: '6432'
 admin_console_port: '7432'
 grpc_api_port: '7000'

--- a/test/feature/docker-compose.yaml
+++ b/test/feature/docker-compose.yaml
@@ -38,7 +38,6 @@ services:
     environment:
       - ROUTER_CONFIG=${ROUTER_CONFIG}
       - ROUTER_LOG=/var/log/spqr-router.log
-      - 'ROUTER_HOST=host: ''regress_router'''
       - COORDINATOR_CONFIG=${COORDINATOR_CONFIG}
     hostname: regress_router
     container_name: regress_router
@@ -68,7 +67,6 @@ services:
     environment:
       - ROUTER_CONFIG=${ROUTER_CONFIG}
       - ROUTER_LOG=/var/log/spqr-router.log
-      - 'ROUTER_HOST=host: ''regress_router_2'''
       - COORDINATOR_CONFIG=${COORDINATOR_CONFIG_2}
     hostname: regress_router_2
     container_name: regress_router_2

--- a/test/feature/features/coordinator_show.feature
+++ b/test/feature/features/coordinator_show.feature
@@ -380,7 +380,7 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router_2",
+                "pool router":"",
                 "pool host":"spqr_shard_2:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",
@@ -394,7 +394,7 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router",
+                "pool router":"",
                 "pool host":"spqr_shard_2:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",
@@ -408,7 +408,7 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router_2",
+                "pool router":"",
                 "pool host":"spqr_shard_1:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",
@@ -422,7 +422,7 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router",
+                "pool router":"",
                 "pool host":"spqr_shard_1:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",
@@ -443,21 +443,7 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router_2",
-                "pool host":"spqr_shard_2:6432",
-                "pool usr":"regress",
-                "queue residual size":"50",
-                "used connections":"0"
-            }
-        ]
-        """
-         And SQL result should match json
-        """
-        [
-            {
-                "idle connections":"1",
-                "pool db":"regress",
-                "pool router":"regress_router",
+                "pool router":"",
                 "pool host":"spqr_shard_2:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",
@@ -471,7 +457,21 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router_2",
+                "pool router":"",
+                "pool host":"spqr_shard_2:6432",
+                "pool usr":"regress",
+                "queue residual size":"50",
+                "used connections":"0"
+            }
+        ]
+        """
+        And SQL result should match json
+        """
+        [
+            {
+                "idle connections":"1",
+                "pool db":"regress",
+                "pool router":"",
                 "pool host":"spqr_shard_1:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",
@@ -485,7 +485,7 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router",
+                "pool router":"",
                 "pool host":"spqr_shard_1:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",
@@ -513,7 +513,7 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router_2",
+                "pool router":"",
                 "pool host":"spqr_shard_1:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",
@@ -527,7 +527,7 @@ Feature: Coordinator show clients, pools and backend_connections
             {
                 "idle connections":"1",
                 "pool db":"regress",
-                "pool router":"regress_router_2",
+                "pool router":"",
                 "pool host":"spqr_shard_2:6432",
                 "pool usr":"regress",
                 "queue residual size":"50",


### PR DESCRIPTION
Listening localhost by default was added in https://github.com/pg-sharding/spqr/commit/2b741a36fd954a80ebc0c7947076c39c0dbaa48f
If I set host in config to empty string (to listen to all addresses), there's a race between goroutines to take the address
If you want to connect to spqr on localhost, use unix socket