### PR TITLE
Drop RequestData()

### DIFF
--- a/coordinator/provider/shards.go
+++ b/coordinator/provider/shards.go
@@ -77,11 +77,6 @@ type CoordShardInfo struct {
 	router     string
 }
 
-// RequestData implements shard.Shardinfo.
-func (c *CoordShardInfo) RequestData() {
-	panic("CoordShardInfo.RequestData not implemented")
-}
-
 // DataPending implements shard.Shardinfo.
 func (c *CoordShardInfo) DataPending() bool {
 	panic("CoordShardInfo.DataPending not implemented")

--- a/pkg/datashard/datashard.go
+++ b/pkg/datashard/datashard.go
@@ -98,10 +98,6 @@ func (sh *Conn) DataPending() bool {
 	return sh.dataPending
 }
 
-func (sh *Conn) RequestData() {
-	sh.dataPending = true
-}
-
 // TxServed returns the number of transactions served by the Conn struct.
 //
 // Parameters:

--- a/pkg/mock/shard/mock_shard.go
+++ b/pkg/mock/shard/mock_shard.go
@@ -124,18 +124,6 @@ func (mr *MockShardinfoMockRecorder) Pid() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pid", reflect.TypeOf((*MockShardinfo)(nil).Pid))
 }
 
-// RequestData mocks base method.
-func (m *MockShardinfo) RequestData() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RequestData")
-}
-
-// RequestData indicates an expected call of RequestData.
-func (mr *MockShardinfoMockRecorder) RequestData() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestData", reflect.TypeOf((*MockShardinfo)(nil).RequestData))
-}
-
 // ShardKeyName mocks base method.
 func (m *MockShardinfo) ShardKeyName() string {
 	m.ctrl.T.Helper()
@@ -311,18 +299,6 @@ func (m *MockCoordShardinfo) Pid() uint32 {
 func (mr *MockCoordShardinfoMockRecorder) Pid() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pid", reflect.TypeOf((*MockCoordShardinfo)(nil).Pid))
-}
-
-// RequestData mocks base method.
-func (m *MockCoordShardinfo) RequestData() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RequestData")
-}
-
-// RequestData indicates an expected call of RequestData.
-func (mr *MockCoordShardinfoMockRecorder) RequestData() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestData", reflect.TypeOf((*MockCoordShardinfo)(nil).RequestData))
 }
 
 // Router mocks base method.
@@ -628,18 +604,6 @@ func (m *MockShard) Receive() (pgproto3.BackendMessage, error) {
 func (mr *MockShardMockRecorder) Receive() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockShard)(nil).Receive))
-}
-
-// RequestData mocks base method.
-func (m *MockShard) RequestData() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RequestData")
-}
-
-// RequestData indicates an expected call of RequestData.
-func (mr *MockShardMockRecorder) RequestData() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestData", reflect.TypeOf((*MockShard)(nil).RequestData))
 }
 
 // SHKey mocks base method.

--- a/pkg/shard/shard.go
+++ b/pkg/shard/shard.go
@@ -51,8 +51,6 @@ type Shardinfo interface {
 	Sync() int64
 	DataPending() bool
 
-	RequestData()
-
 	TxServed() int64
 	TxStatus() txstatus.TXStatus
 

--- a/router/mock/poolmgr/mock_pool_mgr.go
+++ b/router/mock/poolmgr/mock_pool_mgr.go
@@ -91,18 +91,6 @@ func (mr *MockConnectionKeeperMockRecorder) DataPending() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataPending", reflect.TypeOf((*MockConnectionKeeper)(nil).DataPending))
 }
 
-// RequestData mocks base method.
-func (m *MockConnectionKeeper) RequestData() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RequestData")
-}
-
-// RequestData indicates an expected call of RequestData.
-func (mr *MockConnectionKeeperMockRecorder) RequestData() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestData", reflect.TypeOf((*MockConnectionKeeper)(nil).RequestData))
-}
-
 // SetTxStatus mocks base method.
 func (m *MockConnectionKeeper) SetTxStatus(status txstatus.TXStatus) {
 	m.ctrl.T.Helper()

--- a/router/mock/server/mock_server.go
+++ b/router/mock/server/mock_server.go
@@ -140,18 +140,6 @@ func (mr *MockServerMockRecorder) Receive() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Receive", reflect.TypeOf((*MockServer)(nil).Receive))
 }
 
-// RequestData mocks base method.
-func (m *MockServer) RequestData() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RequestData")
-}
-
-// RequestData indicates an expected call of RequestData.
-func (mr *MockServerMockRecorder) RequestData() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestData", reflect.TypeOf((*MockServer)(nil).RequestData))
-}
-
 // Reset mocks base method.
 func (m *MockServer) Reset() error {
 	m.ctrl.T.Helper()

--- a/router/poolmgr/pool_mgr.go
+++ b/router/poolmgr/pool_mgr.go
@@ -22,7 +22,6 @@ type ConnectionKeeper interface {
 	SyncCount() int64
 
 	DataPending() bool
-	RequestData()
 
 	Client() client.RouterClient
 }

--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -175,11 +175,6 @@ func (rst *RelayStateImpl) UnholdRouting() {
 	rst.holdRouting = false
 }
 
-// RequestData implements RelayStateMgr.
-func (rst *RelayStateImpl) RequestData() {
-	rst.Cl.Server().RequestData()
-}
-
 func NewRelayState(qr qrouter.QueryRouter, client client.RouterClient, manager poolmgr.PoolMgr, rcfg *config.Router) RelayStateMgr {
 	return &RelayStateImpl{
 		activeShards:       nil,
@@ -1405,9 +1400,6 @@ func (rst *RelayStateImpl) ProcessExtendedBuffer(cmngr poolmgr.PoolMgr) error {
 						return fmt.Errorf("failed to deploy prepared statement")
 					}
 				}
-
-				// /* do not unroute after bind was send */
-				// rst.RequestData()
 
 				rst.execute = func() error {
 					err := rst.PrepareRelayStepOnHintRoute(cmngr, rst.bindRoute)

--- a/router/server/multishard.go
+++ b/router/server/multishard.go
@@ -68,11 +68,6 @@ func (m *MultiShardServer) StorePrepareStatement(hash uint64, d *prepstatement.P
 
 }
 
-// RequestData implements Server.
-func (m *MultiShardServer) RequestData() {
-
-}
-
 // DataPending implements Server.
 func (m *MultiShardServer) DataPending() bool {
 	for _, shard := range m.activeShards {

--- a/router/server/server.go
+++ b/router/server/server.go
@@ -28,5 +28,4 @@ type Server interface {
 	Sync() int64
 
 	DataPending() bool
-	RequestData()
 }

--- a/router/server/shard.go
+++ b/router/server/shard.go
@@ -29,10 +29,6 @@ func (srv *ShardServer) DataPending() bool {
 	return srv.shard.DataPending()
 }
 
-func (srv *ShardServer) RequestData() {
-	srv.shard.RequestData()
-}
-
 func NewShardServer(spool *pool.DBPool) *ShardServer {
 	return &ShardServer{
 		pool: spool,


### PR DESCRIPTION
It was added in https://github.com/pg-sharding/spqr/pull/679.

On the one hand, there are no calls to .RequestData(). On the other hand, the only real implementation of RequestData is here (https://github.com/pg-sharding/spqr/blob/master/pkg/datashard/datashard.go#L102). As you can see, it is completely useless. So, we may safely delete all mentions of RequestData.
