### PR TITLE
Minor enhancement of coordinator log messages

### DIFF
--- a/cmd/worldmock/worldmock.go
+++ b/cmd/worldmock/worldmock.go
@@ -76,11 +76,6 @@ func (w *WorldMock) serv(netconn net.Conn) error {
 		return err
 	}
 
-	spqrlog.Zero.Info().
-		Str("user", cl.Usr()).
-		Str("db", cl.DB()).
-		Msg("initialized client connection")
-
 	if err := cl.AssignRule(&config.FrontendRule{
 		AuthRule: &config.AuthCfg{
 			Method: config.AuthOK,

--- a/coordinator/provider/coordinator.go
+++ b/coordinator/provider/coordinator.go
@@ -1769,6 +1769,13 @@ func (qc *qdbCoordinator) PrepareClient(nconn net.Conn, pt port.RouterPortType) 
 	if pt == port.UnixSocketPortType {
 		tlsconfig = nil
 	}
+
+	spqrlog.Zero.Info().
+		Str("user", cl.Usr()).
+		Str("db", cl.DB()).
+		Bool("ssl", tlsconfig != nil).
+		Msg("init client connection...")
+
 	if err := cl.Init(tlsconfig); err != nil {
 		return nil, err
 	}
@@ -1780,7 +1787,8 @@ func (qc *qdbCoordinator) PrepareClient(nconn net.Conn, pt port.RouterPortType) 
 	spqrlog.Zero.Info().
 		Str("user", cl.Usr()).
 		Str("db", cl.DB()).
-		Msg("initialized client connection")
+		Bool("ssl", tlsconfig != nil).
+		Msg("init client connection OK")
 
 	var authRule *config.AuthCfg
 	if config.CoordinatorConfig().Auth != nil {

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -654,10 +654,6 @@ func (cl *PsqlClient) AssignRule(rule *config.FrontendRule) error {
 
 // startup + ssl/cancel
 func (cl *PsqlClient) Init(tlsconfig *tls.Config) error {
-	spqrlog.Zero.Info().
-		Bool("ssl", tlsconfig != nil).
-		Msg("init client connection")
-
 	for {
 		var backend *pgproto3.Backend
 


### PR DESCRIPTION
How It was:

```
{"level":"info","ssl":true,"time":"2024-12-26T12:33:10Z","message":"init client connection"}
{"level":"info","user":"spqr-console","db":"spqr-console","time":"2024-12-26T12:33:10Z","message":"initialized client connection"}
```

How it became:

```
{"level":"info","ssl":true,"time":"2024-12-26T12:33:10Z","message":"init client connection"}
{"level":"info","user":"spqr-console","db":"spqr-console", "ssl":true, "time":"2024-12-26T12:33:10Z","message":"init client connection OK"}
```