### PR TITLE
Explain InsecureSkipVerify

### DIFF
--- a/cmd/spqrdump/main.go
+++ b/cmd/spqrdump/main.go
@@ -38,6 +38,7 @@ var endpoint string
 var proto string
 var passwd string
 var logLevel string
+var insecureSkipVerify bool
 
 // TODO : unit tests
 func waitRFQ(fr *pgproto3.Frontend) error {
@@ -85,7 +86,7 @@ func getconn() (*pgproto3.Frontend, error) {
 		Bytes("response", resp).
 		Msg("startup got bytes")
 	cc = tls.Client(cc, &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: insecureSkipVerify,
 	})
 
 	frontend = pgproto3.NewFrontend(cc, cc)
@@ -309,6 +310,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&passwd, "passwd", "p", "", "password to use for communication")
 
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "error", "log level")
+
+	rootCmd.PersistentFlags().BoolVar(&insecureSkipVerify, "insecure-skip-verify", false, "skip TLS certificate verification")
 
 	rootCmd.AddCommand(dump)
 }

--- a/cmd/spqrdump/main.go
+++ b/cmd/spqrdump/main.go
@@ -86,6 +86,7 @@ func getconn() (*pgproto3.Frontend, error) {
 		Bytes("response", resp).
 		Msg("startup got bytes")
 	cc = tls.Client(cc, &tls.Config{
+		// codeql[go/disabled-certificate-verification]
 		InsecureSkipVerify: insecureSkipVerify,
 	})
 

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -45,7 +45,7 @@ func (c *TLSConfig) Init(host string) (*tls.Config, error) {
 	case "disable":
 		return nil, nil
 	case "allow", "prefer":
-		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.InsecureSkipVerify = true // because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L633
 	case "require":
 		// According to PostgreSQL documentation, if a root CA file exists,
 		// the behavior of sslmode=require should be the same as that of verify-ca
@@ -54,7 +54,7 @@ func (c *TLSConfig) Init(host string) (*tls.Config, error) {
 		if c.RootCertFile != "" {
 			goto nextCase
 		}
-		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.InsecureSkipVerify = true // because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L642
 		break
 	nextCase:
 		fallthrough
@@ -68,7 +68,7 @@ func (c *TLSConfig) Init(host string) (*tls.Config, error) {
 		// See https://github.com/golang/go/issues/21971#issuecomment-332693931
 		// and https://pkg.go.dev/crypto/tls?tab=doc#example-Config-VerifyPeerCertificate
 		// for more info.
-		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.InsecureSkipVerify = true // because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L656
 		tlsConfig.VerifyPeerCertificate = func(certificates [][]byte, _ [][]*x509.Certificate) error {
 			certs := make([]*x509.Certificate, len(certificates))
 			for i, asn1Data := range certificates {

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -45,7 +45,9 @@ func (c *TLSConfig) Init(host string) (*tls.Config, error) {
 	case "disable":
 		return nil, nil
 	case "allow", "prefer":
-		tlsConfig.InsecureSkipVerify = true // because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L633
+		// We use InsecureSkipVerify here because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L633
+		// codeql[go/disabled-certificate-verification]
+		tlsConfig.InsecureSkipVerify = true
 	case "require":
 		// According to PostgreSQL documentation, if a root CA file exists,
 		// the behavior of sslmode=require should be the same as that of verify-ca
@@ -54,7 +56,9 @@ func (c *TLSConfig) Init(host string) (*tls.Config, error) {
 		if c.RootCertFile != "" {
 			goto nextCase
 		}
-		tlsConfig.InsecureSkipVerify = true // because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L642
+		// We use InsecureSkipVerify here because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L642
+		// codeql[go/disabled-certificate-verification]
+		tlsConfig.InsecureSkipVerify = true
 		break
 	nextCase:
 		fallthrough
@@ -68,7 +72,9 @@ func (c *TLSConfig) Init(host string) (*tls.Config, error) {
 		// See https://github.com/golang/go/issues/21971#issuecomment-332693931
 		// and https://pkg.go.dev/crypto/tls?tab=doc#example-Config-VerifyPeerCertificate
 		// for more info.
-		tlsConfig.InsecureSkipVerify = true // because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L656
+		// We use InsecureSkipVerify here because https://github.com/jackc/pgx/blob/a968ce3437eefc4168b39bbc4b1ea685f4c8ae66/pgconn/config.go#L656
+		// codeql[go/disabled-certificate-verification]
+		tlsConfig.InsecureSkipVerify = true
 		tlsConfig.VerifyPeerCertificate = func(certificates [][]byte, _ [][]*x509.Certificate) error {
 			certs := make([]*x509.Certificate, len(certificates))
 			for i, asn1Data := range certificates {


### PR DESCRIPTION
In this PR:
- add comments in `pkg/config/tls.go` to not forget why we use `InsecureSkipVerify: true`.
- add InsecureSkipVerify flag to spqr-dump tool.

```
➜  spqr git:(comment-potential-security-problems) ✗ ./spqr-dump --help
Usage:
  spqr-dump [command]

Available Commands:
  dump        dump current sharding configuration
  help        Help about any command

Flags:
  -e, --endpoint string        endpoint for dump metadata (default "localhost:7000")
  -h, --help                   help for spqr-dump
      --insecure-skip-verify   skip TLS certificate verification
  -l, --log-level string       log level (default "error")
  -p, --passwd string          password to use for communication
  -t, --proto string           protocol to use for communication (default "grpc")

Use "spqr-dump [command] --help" for more information about a command.
```