### PR TITLE
 Refactor query routing internals. Separate rmeta-related logic. 

### DIFF
--- a/router/frontend/frontend_test.go
+++ b/router/frontend/frontend_test.go
@@ -406,19 +406,18 @@ func TestFrontendSimpleCopyIn(t *testing.T) {
 			ID:      "id1",
 			ShardID: "sh1",
 			LowerBound: kr.KeyRangeBound{
-				1,
+				int64(1),
 			},
+			ColumnTypes: []string{"integer"},
 		},
 	}
 
 	mmgr.EXPECT().GetRelationDistribution(gomock.Any(), gomock.Any()).Return(d, nil).AnyTimes()
 	mmgr.EXPECT().ListKeyRanges(gomock.Any(), gomock.Any()).Return(krs, nil).AnyTimes()
 
+	mmgr.EXPECT().ShareKeyRange(gomock.Any()).AnyTimes()
+
 	qr.EXPECT().Mgr().Return(mmgr).AnyTimes()
-	qr.EXPECT().DeparseKeyWithRangesInternal(gomock.Any(), gomock.Any(), gomock.Any()).Return(
-		&kr.ShardKey{
-			Name: "sh1",
-		}, nil).AnyTimes()
 
 	qr.EXPECT().Route(gomock.Any(), &lyx.Copy{
 		TableRef: tableref,

--- a/router/mock/qrouter/mock_qrouter.go
+++ b/router/mock/qrouter/mock_qrouter.go
@@ -54,21 +54,6 @@ func (mr *MockQueryRouterMockRecorder) DataShardsRoutes() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataShardsRoutes", reflect.TypeOf((*MockQueryRouter)(nil).DataShardsRoutes))
 }
 
-// DeparseKeyWithRangesInternal mocks base method.
-func (m *MockQueryRouter) DeparseKeyWithRangesInternal(ctx context.Context, key []interface{}, krs []*kr.KeyRange) (*kr.ShardKey, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeparseKeyWithRangesInternal", ctx, key, krs)
-	ret0, _ := ret[0].(*kr.ShardKey)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeparseKeyWithRangesInternal indicates an expected call of DeparseKeyWithRangesInternal.
-func (mr *MockQueryRouterMockRecorder) DeparseKeyWithRangesInternal(ctx, key, krs interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeparseKeyWithRangesInternal", reflect.TypeOf((*MockQueryRouter)(nil).DeparseKeyWithRangesInternal), ctx, key, krs)
-}
-
 // Initialize mocks base method.
 func (m *MockQueryRouter) Initialize() bool {
 	m.ctrl.T.Helper()

--- a/router/pgcopy/state.go
+++ b/router/pgcopy/state.go
@@ -3,10 +3,14 @@ package pgcopy
 import (
 	"github.com/pg-sharding/spqr/pkg/models/hashfunction"
 	"github.com/pg-sharding/spqr/pkg/models/kr"
+	"github.com/pg-sharding/spqr/router/rmeta"
 )
 
 type CopyState struct {
-	ExpRoute   *kr.ShardKey
+	ExpRoute *kr.ShardKey
+
+	RM *rmeta.RoutingMetadataContext
+
 	Delimiter  byte
 	TargetType string
 

--- a/router/qrouter/qrouter.go
+++ b/router/qrouter/qrouter.go
@@ -24,8 +24,6 @@ type QueryRouter interface {
 	WorldShardsRoutes() []*kr.ShardKey
 	DataShardsRoutes() []*kr.ShardKey
 
-	DeparseKeyWithRangesInternal(ctx context.Context, key []interface{}, krs []*kr.KeyRange) (*kr.ShardKey, error)
-
 	Initialized() bool
 	Initialize() bool
 

--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pg-sharding/spqr/router/plan"
 	"github.com/pg-sharding/spqr/router/poolmgr"
 	"github.com/pg-sharding/spqr/router/qrouter"
+	"github.com/pg-sharding/spqr/router/rmeta"
 	"github.com/pg-sharding/spqr/router/route"
 	"github.com/pg-sharding/spqr/router/server"
 	"github.com/pg-sharding/spqr/router/statistics"
@@ -842,6 +843,7 @@ func (rst *RelayStateImpl) ProcCopyPrepare(ctx context.Context, stmt *lyx.Copy) 
 		Delimiter:  delimiter,
 		ExpRoute:   &kr.ShardKey{},
 		Krs:        krs,
+		RM:         rmeta.NewRoutingMetadataContext(rst.Cl, rst.Qr.Mgr()),
 		TargetType: TargetType,
 		HashFunc:   hashFunc,
 	}, nil
@@ -897,7 +899,7 @@ func (rst *RelayStateImpl) ProcCopy(ctx context.Context, data *pgproto3.CopyData
 		}
 
 		// check where this tuple should go
-		currroute, err := rst.Qr.DeparseKeyWithRangesInternal(ctx, values, cps.Krs)
+		currroute, err := cps.RM.DeparseKeyWithRangesInternal(ctx, values, cps.Krs)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
moving code around
