### PR TITLE
Fix possible null dereference.

### DIFF
--- a/router/qrouter/proxy_routing_test.go
+++ b/router/qrouter/proxy_routing_test.go
@@ -599,6 +599,13 @@ func TestSingleShard(t *testing.T) {
 			err: nil,
 		},
 
+		/* should not be routed to one shard */
+		{
+			query: "SELECT * FROM xxtt1 a WHERE a IN (1,11,111)",
+			exp:   routingstate.MultiMatchState{},
+			err:   nil,
+		},
+
 		{
 			query: `
 			DELETE


### PR DESCRIPTION
Should never happen, but still check.