### PR TITLE
Execute expanded transaction query on specified execution targets

### DIFF
--- a/router/frontend/frontend_test.go
+++ b/router/frontend/frontend_test.go
@@ -118,8 +118,8 @@ func TestFrontendSimple(t *testing.T) {
 			&lyx.AExprIConst{Value: 1},
 		},
 		Where: &lyx.AExprEmpty{},
-	}, gomock.Any()).Return(plan.ShardMatchState{
-		Route: &kr.ShardKey{
+	}, gomock.Any()).Return(plan.ShardDispatchPlan{
+		ExecTarget: &kr.ShardKey{
 			Name: "sh1",
 		},
 	}, nil).Times(1)
@@ -136,7 +136,7 @@ func TestFrontendSimple(t *testing.T) {
 
 	cl.EXPECT().Receive().Times(1).Return(query, nil)
 
-	srv.EXPECT().Send(query).Times(1).Return(nil)
+	srv.EXPECT().SendShard(query, gomock.Any()).Times(1).Return(nil)
 
 	srv.EXPECT().Receive().Times(1).Return(&pgproto3.RowDescription{}, nil)
 	srv.EXPECT().Receive().Times(1).Return(&pgproto3.DataRow{
@@ -292,7 +292,7 @@ func TestFrontendXProto(t *testing.T) {
 		ObjectType: 'S',
 	}).Times(1).Return(nil)
 
-	srv.EXPECT().Send(&pgproto3.Sync{}).Times(1).Return(nil)
+	srv.EXPECT().SendShard(&pgproto3.Sync{}, gomock.Any()).Times(1).Return(nil)
 
 	srv.EXPECT().Receive().Times(1).Return(&pgproto3.ParseComplete{}, nil)
 	srv.EXPECT().Receive().Times(1).Return(&pgproto3.ParameterDescription{

--- a/router/mock/server/mock_server.go
+++ b/router/mock/server/mock_server.go
@@ -199,17 +199,17 @@ func (mr *MockServerMockRecorder) Send(query interface{}) *gomock.Call {
 }
 
 // SendShard mocks base method.
-func (m *MockServer) SendShard(query pgproto3.FrontendMessage, shardId uint) error {
+func (m *MockServer) SendShard(query pgproto3.FrontendMessage, shKey *kr.ShardKey) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendShard", query, shardId)
+	ret := m.ctrl.Call(m, "SendShard", query, shKey)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendShard indicates an expected call of SendShard.
-func (mr *MockServerMockRecorder) SendShard(query, shardId interface{}) *gomock.Call {
+func (mr *MockServerMockRecorder) SendShard(query, shKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendShard", reflect.TypeOf((*MockServer)(nil).SendShard), query, shardId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendShard", reflect.TypeOf((*MockServer)(nil).SendShard), query, shKey)
 }
 
 // SetTxStatus mocks base method.

--- a/router/qrouter/local.go
+++ b/router/qrouter/local.go
@@ -65,8 +65,8 @@ func (l *LocalQrouter) AddDataShard(_ context.Context, ds *topology.DataShard) e
 
 // TODO : unit tests
 func (l *LocalQrouter) Route(_ context.Context, _ lyx.Node, _ session.SessionParamsHolder) (plan.Plan, error) {
-	return plan.ShardMatchState{
-		Route: &kr.ShardKey{
+	return plan.ShardDispatchPlan{
+		ExecTarget: &kr.ShardKey{
 			Name: l.ds.ID,
 		},
 	}, nil

--- a/router/qrouter/proxy_routing_test.go
+++ b/router/qrouter/proxy_routing_test.go
@@ -380,8 +380,8 @@ func TestComment(t *testing.T) {
 	for _, tt := range []tcase{
 		{
 			query: "select /* oiwejow--23**/ * from  xx where i = 4;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -479,8 +479,8 @@ func TestCTE(t *testing.T) {
 			  SELECT * FROM qqq;
 			`,
 			err: nil,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -495,8 +495,8 @@ func TestCTE(t *testing.T) {
 			SELECT * from xxxx;
 			`,
 			err: nil,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -515,8 +515,8 @@ func TestCTE(t *testing.T) {
 			SELECT * FROM xxxx;
 			`,
 			err: nil,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -550,8 +550,8 @@ func TestCTE(t *testing.T) {
 			SELECT * FROM xxxx;
 			`,
 			err: nil,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -686,8 +686,8 @@ func TestSingleShard(t *testing.T) {
 
 		{
 			query: "SELECT * FROM sh1.xxtt1 WHERE sh1.xxtt1.i = 21;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -697,8 +697,8 @@ func TestSingleShard(t *testing.T) {
 
 		{
 			query: "SELECT * FROM xxtt1 a WHERE a.i = 21 and w_idj + w_idi != 0;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -708,8 +708,8 @@ func TestSingleShard(t *testing.T) {
 
 		{
 			query: "SELECT * FROM xxtt1 a WHERE a.i = '21' and w_idj + w_idi != 0;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -727,8 +727,8 @@ func TestSingleShard(t *testing.T) {
 			/* __spqr__default_route_behaviour: BLOCK */  returning *;
 			`,
 			err: nil,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -745,8 +745,8 @@ func TestSingleShard(t *testing.T) {
 			/* __spqr__default_route_behaviour: BLOCK */  returning *;
 			`,
 			err: nil,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -754,8 +754,8 @@ func TestSingleShard(t *testing.T) {
 		},
 		{
 			query: "select * from  xx where i = 4;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -765,8 +765,8 @@ func TestSingleShard(t *testing.T) {
 
 		{
 			query: "INSERT INTO xx (i) SELECT 20;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -775,8 +775,8 @@ func TestSingleShard(t *testing.T) {
 		},
 		{
 			query: "select * from  xx where i = 11;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -786,8 +786,8 @@ func TestSingleShard(t *testing.T) {
 
 		{
 			query: "Insert into xx (i) values (1), (2)",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -800,8 +800,8 @@ func TestSingleShard(t *testing.T) {
 		 */
 		{
 			query: "Insert into xx (i) select * from yy a where a.i = 8",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -811,8 +811,8 @@ func TestSingleShard(t *testing.T) {
 
 		{
 			query: "SELECT * FROM xxmixed WHERE i BETWEEN 22 AND 30 ORDER BY id;;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -822,8 +822,8 @@ func TestSingleShard(t *testing.T) {
 
 		{
 			query: "SELECT * FROM t WHERE i = 12 AND j = 1;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -832,8 +832,8 @@ func TestSingleShard(t *testing.T) {
 		},
 		{
 			query: "SELECT * FROM t WHERE i = 12 UNION ALL SELECT * FROM xxmixed WHERE i = 22;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -933,8 +933,8 @@ func TestInsertOffsets(t *testing.T) {
 
 		{
 			query: `INSERT INTO xxtt1 SELECT * FROM xxtt1 a WHERE a.w_id = 20;`,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -946,8 +946,8 @@ func TestInsertOffsets(t *testing.T) {
 			query: `
 			INSERT INTO xxtt1 (j, i, w_id) VALUES(2121221, -211212, 21);
 			`,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -957,8 +957,8 @@ func TestInsertOffsets(t *testing.T) {
 		{
 			query: `
 			INSERT INTO "people" ("first_name","last_name","email","id") VALUES ('John','Smith','',1) RETURNING "id"`,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -969,8 +969,8 @@ func TestInsertOffsets(t *testing.T) {
 			query: `
 			INSERT INTO xxtt1 (j, w_id) SELECT a, 20 from unnest(ARRAY[10]) a
 			`,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -980,8 +980,8 @@ func TestInsertOffsets(t *testing.T) {
 
 		{
 			query: "Insert into xx (i, j, k) values (1, 12, 13), (2, 3, 4)",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -1076,8 +1076,8 @@ func TestJoins(t *testing.T) {
 	for _, tt := range []tcase{
 		{
 			query: "SELECT * FROM sshjt1 a join sshjt1 b ON TRUE WHERE a.i = 12 AND b.j = a.j;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -1087,8 +1087,8 @@ func TestJoins(t *testing.T) {
 
 		{
 			query: "SELECT * FROM sshjt1 join sshjt1 ON TRUE WHERE sshjt1.i = 12 AND sshjt1.j = sshjt1.j;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -1187,8 +1187,8 @@ func TestUnnest(t *testing.T) {
 
 		{
 			query: "INSERT INTO xxtt1 (j, i) SELECT a, 20 from unnest(ARRAY[10]) a;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -1198,8 +1198,8 @@ func TestUnnest(t *testing.T) {
 
 		{
 			query: "UPDATE xxtt1 set i=a.i, j=a.j from unnest(ARRAY[(1,10)]) as a(i int, j int) where i=20 and xxtt1.j=a.j;",
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh2",
 				},
 				TargetSessionAttrs: "any",
@@ -1627,8 +1627,8 @@ func TestRouteWithRules_Select(t *testing.T) {
 		{
 			query:        "SELECT * FROM users WHERE id = '5f57cd31-806f-4789-a6fa-1d959ec4c64a';",
 			distribution: distribution.ID,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",
@@ -1652,7 +1652,7 @@ LIMIT 1000
 		// {
 		// 	query:        "SELECT * FROM users WHERE '5f57cd31-806f-4789-a6fa-1d959ec4c64a' = id;",
 		// 	distribution: distribution.ID,
-		// 	exp: plan.ShardMatchState{
+		// 	exp: plan.ShardDispatchPlan{
 		// 		Route: &plan.DataShardRoute{
 		// 			Shkey: kr.ShardKey{
 		// 				Name: "sh1",
@@ -1744,8 +1744,8 @@ func TestHashRouting(t *testing.T) {
 		{
 			query:        "INSERT INTO xx (col1) VALUES ('Hello, world!');",
 			distribution: distribution1,
-			exp: plan.ShardMatchState{
-				Route: &kr.ShardKey{
+			exp: plan.ShardDispatchPlan{
+				ExecTarget: &kr.ShardKey{
 					Name: "sh1",
 				},
 				TargetSessionAttrs: "any",

--- a/router/rmeta/rmeta.go
+++ b/router/rmeta/rmeta.go
@@ -218,8 +218,8 @@ func (rm *RoutingMetadataContext) ResolveRouteHint() (routehint.RouteHint, error
 			return nil, err
 		}
 		return &routehint.TargetRouteHint{
-			State: plan.ShardMatchState{
-				Route: ds,
+			State: plan.ShardDispatchPlan{
+				ExecTarget: ds,
 			},
 		}, nil
 	}

--- a/router/server/server.go
+++ b/router/server/server.go
@@ -16,7 +16,9 @@ type Server interface {
 
 	Name() string
 	Send(query pgproto3.FrontendMessage) error
-	SendShard(query pgproto3.FrontendMessage, shardId uint) error
+
+	SendShard(query pgproto3.FrontendMessage, shKey *kr.ShardKey) error
+
 	Receive() (pgproto3.BackendMessage, error)
 	ReceiveShard(shardId uint) (pgproto3.BackendMessage, error)
 
@@ -34,4 +36,13 @@ type Server interface {
 	Sync() int64
 
 	DataPending() bool
+}
+
+func ServerShkeys(s Server) []*kr.ShardKey {
+	ret := []*kr.ShardKey{}
+	for _, sh := range s.Datashards() {
+		k := sh.SHKey()
+		ret = append(ret, &k)
+	}
+	return ret
 }

--- a/router/server/shard.go
+++ b/router/server/shard.go
@@ -157,8 +157,8 @@ func (srv *ShardServer) Send(query pgproto3.FrontendMessage) error {
 }
 
 // TODO : unit tests
-func (srv *ShardServer) SendShard(query pgproto3.FrontendMessage, shardId uint) error {
-	if srv.shard.ID() != shardId {
+func (srv *ShardServer) SendShard(query pgproto3.FrontendMessage, shkey *kr.ShardKey) error {
+	if srv.shard.SHKey().Name != shkey.Name {
 		return spqrerror.NewByCode(spqrerror.SPQR_NO_DATASHARD)
 	}
 	return srv.Send(query)

--- a/test/regress/tests/router/expected/begin.out
+++ b/test/regress/tests/router/expected/begin.out
@@ -56,7 +56,9 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO test_beg(id, age) VALUES (10, 16);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM test_beg WHERE id=10;
+NOTICE: send query to shard(s) : sh1
  id | age 
 ----+-----
  10 |  16
@@ -75,7 +77,9 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO test_beg(id, age) VALUES (10, 16);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM test_beg WHERE id=10;
+NOTICE: send query to shard(s) : sh1
  id | age 
 ----+-----
  10 |  16
@@ -94,7 +98,9 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO test_beg(id, age) VALUES (10, 16);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM test_beg WHERE id=10;
+NOTICE: send query to shard(s) : sh1
  id | age 
 ----+-----
  10 |  16
@@ -113,7 +119,9 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO test_beg(id, age) VALUES (10, 16);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM test_beg WHERE id=10;
+NOTICE: send query to shard(s) : sh1
  id | age 
 ----+-----
  10 |  16
@@ -133,7 +141,9 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO test_beg(id, age) VALUES (10, 16);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM test_beg WHERE id=10;
+NOTICE: send query to shard(s) : sh1
  id | age 
 ----+-----
  10 |  16
@@ -152,7 +162,9 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO test_beg(id, age) VALUES (10, 16);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM test_beg WHERE id=10;
+NOTICE: send query to shard(s) : sh1
  id | age 
 ----+-----
  10 |  16
@@ -171,7 +183,9 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO test_beg(id, age) VALUES (10, 16);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM test_beg WHERE id=10;
+NOTICE: send query to shard(s) : sh1
  id | age 
 ----+-----
  10 |  16
@@ -190,6 +204,7 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO test_beg(id, age) VALUES (10, 16);
+NOTICE: send query to shard(s) : sh1
 ERROR:  cannot execute INSERT in a read-only transaction
 ROLLBACK;
 -- test ignore of all cmds after error
@@ -203,6 +218,7 @@ NOTICE: send query to shard(s) : sh1
 (2 rows)
 
 INSERT INTO fff VALUES(1);
+NOTICE: send query to shard(s) : sh1
 ERROR:  relation "fff" does not exist
 LINE 1: INSERT INTO fff VALUES(1);
                     ^

--- a/test/regress/tests/router/expected/copy_inside_singleshard_connection.out
+++ b/test/regress/tests/router/expected/copy_inside_singleshard_connection.out
@@ -67,6 +67,7 @@ NOTICE: send query to shard(s) : sh1
 (0 rows)
 
 COPY copy_test(id) FROM STDIN;
+NOTICE: send query to shard(s) : sh1
 COMMIT;
 SELECT id FROM copy_test ORDER BY id /* __spqr__execute_on: sh1 */;
 NOTICE: send query to shard(s) : sh1

--- a/test/regress/tests/router/expected/ddl.out
+++ b/test/regress/tests/router/expected/ddl.out
@@ -49,7 +49,9 @@ BEGIN;
 ALTER TABLE "table_1" RENAME TO "tmp" /* __spqr__engine_v2: true */;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 ALTER TABLE "table_2" RENAME TO "table_1";
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 ALTER TABLE "tmp" RENAME TO "table_2";
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 COMMIT;
 DROP SCHEMA sh1;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4

--- a/test/regress/tests/router/expected/engine_v2.out
+++ b/test/regress/tests/router/expected/engine_v2.out
@@ -57,6 +57,7 @@ BEGIN;
 DELETE FROM table1 /* __spqr__engine_v2: true  */; 
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 SELECT id FROM table1 ORDER BY id;
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
  id 
 ----
 (0 rows)

--- a/test/regress/tests/router/expected/error2.out
+++ b/test/regress/tests/router/expected/error2.out
@@ -50,7 +50,9 @@ BEGIN;
 INSERT INTO tt (i) VALUES(1);
 NOTICE: send query to shard(s) : sh1
 DROP TABLE tt;
+NOTICE: send query to shard(s) : sh1
 INSERT INTO tt (i) VALUES(1);
+NOTICE: send query to shard(s) : sh1
 ERROR:  relation "tt" does not exist
 LINE 1: INSERT INTO tt (i) VALUES(1);
                     ^

--- a/test/regress/tests/router/expected/multishard_expand_tx.out
+++ b/test/regress/tests/router/expected/multishard_expand_tx.out
@@ -53,12 +53,20 @@ BEGIN;
 UPDATE xxm_expd SET j = j + 1 WHERE id = 1 /* __spqr__engine_v2: true */;
 NOTICE: send query to shard(s) : sh1
 UPDATE xxm_expd SET j = j + 1 WHERE id = 101 /* __spqr__engine_v2: true */;
-NOTICE: send query to shard(s) : sh1,sh2
+NOTICE: send query to shard(s) : sh2
 UPDATE xxm_expd SET j = j + 1 WHERE id = 299 /* __spqr__engine_v2: true */;
-NOTICE: send query to shard(s) : sh1,sh2,sh3
+NOTICE: send query to shard(s) : sh3
 UPDATE xxm_expd SET j = j + 1 WHERE id = 399 /* __spqr__engine_v2: true */;
-NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
+NOTICE: send query to shard(s) : sh4
 COMMIT;
+BEGIN;
+INSERT INTO xxm_expd (id, j) VALUES(55, 55) /* __spqr__engine_v2: true */;
+NOTICE: send query to shard(s) : sh1
+INSERT INTO xxm_expd (id, j) VALUES(155, 155) /* __spqr__engine_v2: true */;
+NOTICE: send query to shard(s) : sh2
+INSERT INTO xxm_expd (id, j) VALUES(355, 355) /* __spqr__engine_v2: true */;
+NOTICE: send query to shard(s) : sh4
+ROLLBACK;
 SELECT * FROM xxm_expd ORDER BY id;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
  id  |  j  

--- a/test/regress/tests/router/expected/transactions.out
+++ b/test/regress/tests/router/expected/transactions.out
@@ -43,7 +43,9 @@ NOTICE: send query to shard(s) : sh1
 (0 rows)
 
 INSERT INTO transactions_test (id) VALUES (1);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM transactions_test WHERE id = 1;;
+NOTICE: send query to shard(s) : sh1
  id 
 ----
   1
@@ -65,7 +67,9 @@ NOTICE: send query to shard(s) : sh1
 (0 rows)
 
 INSERT INTO transactions_test (id) VALUES (1);
+NOTICE: send query to shard(s) : sh1
 SELECT * FROM transactions_test WHERE id = 1;;
+NOTICE: send query to shard(s) : sh1
  id 
 ----
   1

--- a/test/regress/tests/router/sql/multishard_expand_tx.sql
+++ b/test/regress/tests/router/sql/multishard_expand_tx.sql
@@ -40,6 +40,12 @@ UPDATE xxm_expd SET j = j + 1 WHERE id = 299 /* __spqr__engine_v2: true */;
 UPDATE xxm_expd SET j = j + 1 WHERE id = 399 /* __spqr__engine_v2: true */;
 COMMIT;
 
+BEGIN;
+INSERT INTO xxm_expd (id, j) VALUES(55, 55) /* __spqr__engine_v2: true */;
+INSERT INTO xxm_expd (id, j) VALUES(155, 155) /* __spqr__engine_v2: true */;
+INSERT INTO xxm_expd (id, j) VALUES(355, 355) /* __spqr__engine_v2: true */;
+ROLLBACK;
+
 SELECT * FROM xxm_expd ORDER BY id;
 
 UPDATE xxm_expd SET id = -1 /* __spqr__engine_v2: true */;


### PR DESCRIPTION
For example, after establishing multi-shard slice connection (say, ddl), we should still route single-shard modification sql (insert for example) to its execution target