### PR TITLE
`spqr-router run [-P|--pretty-log]` enables pretty logging

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -47,10 +47,11 @@ var (
 	cpuProfile         bool
 	memProfile         bool
 
-	qdbImpl    string
-	daemonize  bool
-	console    bool
-	gomaxprocs int
+	qdbImpl       string
+	daemonize     bool
+	console       bool
+	prettyLogging bool
+	gomaxprocs    int
 
 	rootCmd = &cobra.Command{
 		Use:   "spqr-router run --config `path-to-config-folder`",
@@ -90,6 +91,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&qdbImpl, "qdb-impl", "", "etcd", "which implementation of QDB to use.")
 	rootCmd.PersistentFlags().BoolVarP(&daemonize, "daemonize", "d", false, "run as a daemon or not. Opposite of `console`")
 	rootCmd.PersistentFlags().BoolVarP(&console, "console", "", false, "run as a console app or not. Opposite of `daemonize`")
+	rootCmd.PersistentFlags().BoolVarP(&prettyLogging, "pretty-log", "P", false, "enables pretty logging")
 	rootCmd.PersistentFlags().IntVarP(&gomaxprocs, "gomaxprocs", "", 0, "GOMAXPROCS value")
 
 	rootCmd.AddCommand(runCmd)
@@ -106,7 +108,7 @@ var runCmd = &cobra.Command{
 		}
 		log.Println("Running config:", cfgStr)
 
-		spqrlog.ReloadLogger(config.RouterConfig().LogFileName)
+		spqrlog.ReloadLogger(config.RouterConfig().LogFileName, prettyLogging)
 
 		// Logger
 		if logLevel != "" {
@@ -281,7 +283,7 @@ var runCmd = &cobra.Command{
 
 				switch s {
 				case syscall.SIGUSR1:
-					spqrlog.ReloadLogger(config.RouterConfig().LogFileName)
+					spqrlog.ReloadLogger(config.RouterConfig().LogFileName, prettyLogging)
 				case syscall.SIGUSR2:
 					if cpuProfile {
 						// write profile
@@ -310,7 +312,7 @@ var runCmd = &cobra.Command{
 					if err != nil {
 						spqrlog.Zero.Error().Err(err).Msg("")
 					}
-					spqrlog.ReloadLogger(config.RouterConfig().LogFileName)
+					spqrlog.ReloadLogger(config.RouterConfig().LogFileName, prettyLogging)
 				case syscall.SIGINT, syscall.SIGTERM:
 					if cpuProfile {
 						// write profile

--- a/pkg/spqrlog/zero.go
+++ b/pkg/spqrlog/zero.go
@@ -7,19 +7,18 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var Zero *zerolog.Logger
+var Zero = NewZeroLogger("", true)
 
-// NewZeroLogger creates a new ZeroLogger with the specified filepath.
-// It initializes a writer and creates a logger with a timestamp.
-// The logger is returned as a pointer to a zerolog.Logger.
-// If the filepath is empty, the logger will be set to os.Stdout.
-// Otherwise, a new log file will be opened and used for logging.
+// NewZeroLogger initializes a zerolog.Logger.
+// If prettyLogging is true, it outputs in a human-readable format.
+// Prints an error message if writer initialization fails.
 //
 // Parameters:
-//   - filepath: The path to the log file where the data will be written.
+// - filepath: Log file path.
+// - prettyLogging: Enable pretty logging.
 //
 // Returns:
-//   - *zerolog.Logger: A pointer to the created ZeroLogger.
+// - *zerolog.Logger: Pointer to the logger instance.
 func NewZeroLogger(filepath string, prettyLogging bool) *zerolog.Logger {
 	_, writer, err := newWriter(filepath)
 	if err != nil {
@@ -51,12 +50,11 @@ func UpdateZeroLogLevel(logLevel string) error {
 	return nil
 }
 
-// ReloadLogger reloads the logger with a new log file.
-// If the filepath is empty, the logger will be set to os.Stdout.
-// Otherwise, a new log file will be opened and used for logging.
+// ReloadLogger reloads the logger with a new log file or stdout if filepath is empty.
 //
 // Parameters:
-//   - filepath: The path to the log file where the data will be written.
+//   - filepath: The log file path.
+//   - prettyLogging: Enable pretty logging.
 func ReloadLogger(logFileName string, prettyLogging bool) {
 	Zero = NewZeroLogger(logFileName, prettyLogging)
 }

--- a/pkg/spqrlog/zero.go
+++ b/pkg/spqrlog/zero.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var Zero = NewZeroLogger("")
+var Zero *zerolog.Logger
 
 // NewZeroLogger creates a new ZeroLogger with the specified filepath.
 // It initializes a writer and creates a logger with a timestamp.
@@ -20,13 +20,17 @@ var Zero = NewZeroLogger("")
 //
 // Returns:
 //   - *zerolog.Logger: A pointer to the created ZeroLogger.
-func NewZeroLogger(filepath string) *zerolog.Logger {
+func NewZeroLogger(filepath string, prettyLogging bool) *zerolog.Logger {
 	_, writer, err := newWriter(filepath)
 	if err != nil {
 		fmt.Printf("FAILED TO INITIALIZED LOGGER: %v", err)
 	}
-	logger := zerolog.New(writer).With().Timestamp().Logger()
 
+	if prettyLogging {
+		writer = zerolog.ConsoleWriter{Out: writer}
+	}
+
+	logger := zerolog.New(writer).With().Timestamp().Logger() // TODO pass level here
 	return &logger
 }
 
@@ -53,12 +57,8 @@ func UpdateZeroLogLevel(logLevel string) error {
 //
 // Parameters:
 //   - filepath: The path to the log file where the data will be written.
-func ReloadLogger(filepath string) {
-	if filepath == "" {
-		return // this means os.Stdout, so no need to open new file
-	}
-	newLogger := NewZeroLogger(filepath).Level(Zero.GetLevel())
-	Zero = &newLogger
+func ReloadLogger(logFileName string, prettyLogging bool) {
+	Zero = NewZeroLogger(logFileName, prettyLogging)
 }
 
 // parseLevel parses the given level string and returns the corresponding zerolog.Level.


### PR DESCRIPTION
Even with color in your console!

```
➜  spqr git:(master) ✗ ./spqr-router run --config examples/1shardproxy.toml
...
{"level":"info","address":"localhost:7432","time":"2025-02-24T14:42:28+01:00","message":"SPQR Administative Console is ready on"}
{"level":"info","address":"localhost:6432","time":"2025-02-24T14:42:28+01:00","message":"SPQR Router is ready by postgresql proto"}
{"level":"info","address":"localhost:7001","time":"2025-02-24T14:42:28+01:00","message":"SPQR GRPC API is ready on"}

➜  spqr git:(master) ✗ ./spqr-router run --config examples/1shardproxy.toml --pretty-log
...
2:43PM DBG creating QueryRouter with type qtype=config.RouterMode
2:43PM INF adding node node=sh1
2:43PM DBG memqdb: add shard shard={"hosts":["localhost:5432"],"id":"sh1"}
2:43PM DBG adding frontend rule db=opgejrqr user=opgejrqr
2:43PM ERR error="mkdir /var/run/postgresql: permission denied"
2:43PM INF SPQR Administative Console is ready on address=localhost:7432
2:43PM INF SPQR Router is ready by postgresql proto address=localhost:6432
2:43PM INF SPQR GRPC API is ready on address=localhost:7001
...
```