### PR TITLE
Better options for coordinator logging

### DIFF
--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -15,9 +15,11 @@ import (
 )
 
 var (
-	cfgPath    string
-	qdbImpl    string
-	gomaxprocs int
+	cfgPath       string
+	qdbImpl       string
+	gomaxprocs    int
+	prettyLogging bool
+	logLevel      string
 )
 
 var rootCmd = &cobra.Command{
@@ -36,6 +38,15 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 		log.Println("Running config:", cfgStr)
+
+		if logLevel != "" {
+			config.CoordinatorConfig().LogLevel = logLevel
+		}
+		if prettyLogging {
+			config.CoordinatorConfig().PrettyLogging = prettyLogging
+		}
+
+		spqrlog.ReloadLogger("", config.CoordinatorConfig().LogLevel, config.CoordinatorConfig().PrettyLogging)
 
 		if gomaxprocs > 0 {
 			runtime.GOMAXPROCS(gomaxprocs)
@@ -82,6 +93,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&cfgPath, "config", "c", "/etc/spqr/coordinator.yaml", "path to config file")
 	rootCmd.PersistentFlags().StringVarP(&qdbImpl, "qdb-impl", "", "etcd", "which implementation of QDB to use.")
 	rootCmd.PersistentFlags().IntVarP(&gomaxprocs, "gomaxprocs", "", 0, "GOMAXPROCS value")
+	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "", "overload for `log_level` option in router config")
+	rootCmd.PersistentFlags().BoolVarP(&prettyLogging, "pretty-log", "P", false, "enables pretty logging")
 
 	rootCmd.AddCommand(testCmd)
 }

--- a/docs/configuration/coordinator.mdx
+++ b/docs/configuration/coordinator.mdx
@@ -12,15 +12,16 @@ Refer to the [pkg/config/coordinator.go](https://github.com/pg-sharding/spqr/blo
 
 ## Coordinator Settings
 
-| Setting                  | Description                                           | Possible Values       |
-|--------------------------|-------------------------------------------------------|-----------------------|
-| `log_level `             | The level of logging output.                          | `debug`, `info`, `warning`, `error`, `fatal`|
-| `qdb_addr`               | the address of the QDB server                         | Any valid address     |
-| `host`                   | The host address the coordinator listens on.          | Any valid hostname    |
-| `coordinator_port`       | The port number for the coordinator.                  | Any valid port number |
-| `grpc_api_port`          | The port number for the gRPC API.                     | Any valid port number |
-| `auth`                   | See [auth.mdx](./auth)                                | Object of `AuthCfg`   |
-| `frontend_tls`           | See [auth.mdx](./auth)                                | Object of `TLSConfig` |
-| `use_systemd_notifier`   | Whether to use systemd notifier.                      | `true`, `false`       |
-| `systemd_notifier_debug` | Whether to run systemd notifier in debug mode.        | `true`, `false`       |
+| Setting                  | Description                                                   | Possible Values       |
+|--------------------------|---------------------------------------------------------------|-----------------------|
+| `log_level`              | The level of logging output.                                  | `debug`, `info`, `warning`, `error`, `fatal`|
+| `pretty_logging`         | Whether to write logs in an colorized, human-friendly format. | `true`, `false`       |
+| `qdb_addr`               | the address of the QDB server                                 | Any valid address     |
+| `host`                   | The host address the coordinator listens on.                  | Any valid hostname    |
+| `coordinator_port`       | The port number for the coordinator.                          | Any valid port number |
+| `grpc_api_port`          | The port number for the gRPC API.                             | Any valid port number |
+| `auth`                   | See [auth.mdx](./auth)                                        | Object of `AuthCfg`   |
+| `frontend_tls`           | See [auth.mdx](./auth)                                        | Object of `TLSConfig` |
+| `use_systemd_notifier`   | Whether to use systemd notifier.                              | `true`, `false`       |
+| `systemd_notifier_debug` | Whether to run systemd notifier in debug mode.                | `true`, `false`       |
 

--- a/pkg/config/coordinator.go
+++ b/pkg/config/coordinator.go
@@ -15,6 +15,7 @@ var cfgCoordinator Coordinator
 
 type Coordinator struct {
 	LogLevel             string        `json:"log_level" toml:"log_level" yaml:"log_level"`
+	PrettyLogging        bool          `json:"pretty_logging" toml:"pretty_logging" yaml:"pretty_logging"`
 	QdbAddr              string        `json:"qdb_addr" toml:"qdb_addr" yaml:"qdb_addr"`
 	CoordinatorPort      string        `json:"coordinator_port" toml:"coordinator_port" yaml:"coordinator_port"`
 	GrpcApiPort          string        `json:"grpc_api_port" toml:"grpc_api_port" yaml:"grpc_api_port"`

--- a/pkg/spqrlog/zero.go
+++ b/pkg/spqrlog/zero.go
@@ -1,7 +1,7 @@
 package spqrlog
 
 import (
-	"fmt"
+	"log"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -23,7 +23,7 @@ var Zero = NewZeroLogger("", "info", true)
 func NewZeroLogger(filepath string, logLevel string, prettyLogging bool) *zerolog.Logger {
 	_, writer, err := newWriter(filepath)
 	if err != nil {
-		fmt.Printf("FAILED TO INITIALIZED LOGGER: %v", err)
+		log.Printf("failed to initialize logger: %v", err)
 	}
 
 	level := parseLevel(logLevel)
@@ -69,6 +69,7 @@ func parseLevel(level string) zerolog.Level {
 	case "fatal":
 		return zerolog.FatalLevel
 	default:
+		log.Printf("unknown log level: %s, defaulting to info", level)
 		return zerolog.InfoLevel
 	}
 }


### PR DESCRIPTION
This PR resolves several problems with coordinator logs.

1. Now you can specify log format using pretty-log flag:

```
➜  spqr git:(master) ✗ ./spqr-coordinator --config ./examples/coordinator.yaml --qdb-impl etcd --pretty-log     
2025/03/11 18:17:31 Running config: {
...
}
2025/03/11 18:17:31 unknown log level: ddebug, defaulting to info
6:17PM INF running coordinator app
6:17PM ERR qdb already taken, waiting for connection error="qdb is already in use."
6:17PM ERR qdb already taken, waiting for connection error="qdb is already in use."
6:17PM ERR qdb already taken, waiting for connection error="qdb is already in use."
```

2. Now it allows to specify log level:
```
➜  spqr git:(master) ✗ ./spqr-coordinator --config ./examples/coordinator.yaml --qdb-impl etcd --log-level debug --pretty-log 
2025/03/11 18:18:19 Running config: {
  "log_level": "info",
  "pretty_logging": false,
...
}
6:18PM DBG etcdqdb: NewEtcdQDB address=localhost:2379 client=1374393485664
6:18PM DBG etcdqdb: add shard hosts=["localhost:5550"] id=sh1
6:18PM DBG etcdqdb: add shard response={"header":{"cluster_id":14841639068965178418,"member_id":10276657743932975437,"raft_term":2,"revision":77}}
6:18PM DBG etcdqdb: add shard hosts=["localhost:5551"] id=sh2
6:18PM DBG etcdqdb: add shard response={"header":{"cluster_id":14841639068965178418,"member_id":10276657743932975437,"raft_term":2,"revision":78}}
6:18PM INF running coordinator app
6:18PM DBG etcdqdb: try coordinator lock address=localhost
6:18PM DBG etcdqdb: try coordinator lock address=localhost
6:18PM ERR qdb already taken, waiting for connection error="qdb is already in use."
```

3. You will see an error message if specified `log_level` does not exist:

```
➜  spqr git:(master) ✗ ./spqr-coordinator --config ./examples/coordinator.yaml --qdb-impl etcd --log-level ddebug
2025/03/11 18:17:18 Running config: {
  "log_level": "info",
  "pretty_logging": false,
...
}
2025/03/11 18:17:18 unknown log level: ddebug, defaulting to info
...
```

4. By default json format will be used:

```
➜  spqr git:(better-coordinator-logging) ✗ ./spqr-coordinator --config ./examples/coordinator.yaml --qdb-impl etcd                               
2025/03/11 18:25:46 Running config: {
  "log_level": "info",
  "pretty_logging": false,
...
}
{"level":"info","time":"2025-03-11T18:25:46+01:00","message":"running coordinator app"}
{"level":"error","error":"qdb is already in use.","time":"2025-03-11T18:25:47+01:00","message":"qdb already taken, waiting for connection"}
```
