### PR TITLE
Add default batch size value for RedistributeKeyRange 

### DIFF
--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -15,11 +15,12 @@ import (
 )
 
 var (
-	cfgPath       string
-	qdbImpl       string
-	gomaxprocs    int
-	prettyLogging bool
-	logLevel      string
+	cfgPath          string
+	qdbImpl          string
+	gomaxprocs       int
+	prettyLogging    bool
+	logLevel         string
+	defaultBatchSize int
 )
 
 var rootCmd = &cobra.Command{
@@ -106,7 +107,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&gomaxprocs, "gomaxprocs", "", 0, "GOMAXPROCS value")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "", "overload for `log_level` option in router config")
 	rootCmd.PersistentFlags().BoolVarP(&prettyLogging, "pretty-log", "P", false, "enables pretty logging")
-
+	rootCmd.PersistentFlags().IntVarP(&defaultBatchSize, "defaultBatchSize", "", 500, "default Batch Size for RedistributeKeyRangeRequest")
 	rootCmd.AddCommand(testCmd)
 }
 

--- a/examples/coordinator.yaml
+++ b/examples/coordinator.yaml
@@ -4,4 +4,4 @@ grpc_api_port: 7003
 qdb_addr: 'localhost:2379'
 log_level: info
 shard_data: 'examples/shard_data.yaml'
-
+defaultBatchSize: 500

--- a/yacc/console/gram.go
+++ b/yacc/console/gram.go
@@ -1856,7 +1856,7 @@ yydefault:
 		yyDollar = yyS[yypt-0 : yypt+1]
 //line gram.y:992
 		{
-			yyVAL.opt_batch_size = -1
+			yyVAL.opt_batch_size = 500
 		}
 	case 150:
 		yyDollar = yyS[yypt-4 : yypt+1]

--- a/yacc/console/gram.y
+++ b/yacc/console/gram.y
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/binary"
 	"strings"
-	"strconv"
+	"strconv"	
 )
 
 
@@ -989,7 +989,7 @@ redistribute_key_range_stmt:
 	}
 
 opt_batch_size: BATCH SIZE any_uint			{ $$ = int($3) }
-			| /*EMPTY*/						{ $$ = -1 }
+			| /*EMPTY*/						{ $$ = 500}
 
 unite_key_range_stmt:
 	UNITE key_range_stmt WITH any_id

--- a/yacc/console/yx_test.go
+++ b/yacc/console/yx_test.go
@@ -13,7 +13,7 @@ func TestSimpleTrace(t *testing.T) {
 	assert := assert.New(t)
 
 	type tcase struct {
-		query string
+		query string 
 		exp   spqrparser.Statement
 		err   error
 	}
@@ -261,11 +261,11 @@ func TestRedistribute(t *testing.T) {
 
 	for _, tt := range []tcase{
 		{
-			query: "REDISTRIBUTE KEY RANGE kr1 TO sh2 BATCH SIZE 500",
+			query: "REDISTRIBUTE KEY RANGE kr1 TO sh2 BATCH SIZE 1000",
 			exp: &spqrparser.RedistributeKeyRange{
 				KeyRangeID:  "kr1",
 				DestShardID: "sh2",
-				BatchSize:   500,
+				BatchSize:   1000,
 				Check:       true,
 				Apply:       true,
 			},
@@ -281,7 +281,7 @@ func TestRedistribute(t *testing.T) {
 			exp: &spqrparser.RedistributeKeyRange{
 				KeyRangeID:  "kr1",
 				DestShardID: "sh2",
-				BatchSize:   -1,
+				BatchSize:   500,
 				Check:       true,
 				Apply:       true,
 			},
@@ -292,7 +292,7 @@ func TestRedistribute(t *testing.T) {
 			exp: &spqrparser.RedistributeKeyRange{
 				KeyRangeID:  "kr1",
 				DestShardID: "sh2",
-				BatchSize:   -1,
+				BatchSize:   500,
 				Check:       true,
 				Apply:       false,
 			},
@@ -303,7 +303,7 @@ func TestRedistribute(t *testing.T) {
 			exp: &spqrparser.RedistributeKeyRange{
 				KeyRangeID:  "kr1",
 				DestShardID: "sh2",
-				BatchSize:   -1,
+				BatchSize:   500,
 				Check:       false,
 				Apply:       true,
 			},


### PR DESCRIPTION
Solve #807
Set the default `BATCH SIZE` to `500`, now it can work like this 
`REDISTRIBUTE KEY RANGE kr1 TO sh2`
Rewrote the tests for the `REDISTRIBUTE `command. 
Unfortunately, I couldn't figure out how to work with the coordinator configuration file, but as far as I understood, this was a secondary task.