### PR TITLE
fix buf size for PutVarint

### DIFF
--- a/pkg/coord/cqdb.go
+++ b/pkg/coord/cqdb.go
@@ -1269,14 +1269,14 @@ ORDER BY (%s) %s;
 				if err != nil {
 					return nil, err
 				}
-				bound[i] = make([]byte, 8)
+				bound[i] = make([]byte, binary.MaxVarintLen64)
 				binary.PutUvarint(bound[i], number)
 			case qdb.ColumnTypeInteger:
 				number, err := strconv.ParseInt(values[i], 10, 64)
 				if err != nil {
 					return nil, err
 				}
-				bound[i] = make([]byte, 8)
+				bound[i] = make([]byte, binary.MaxVarintLen64)
 				binary.PutVarint(bound[i], number)
 			}
 		}

--- a/pkg/mock/meta/mock_meta.go
+++ b/pkg/mock/meta/mock_meta.go
@@ -159,17 +159,17 @@ func (mr *MockEntityMgrMockRecorder) CreateDistribution(ctx, ds any) *gomock.Cal
 }
 
 // CreateKeyRange mocks base method.
-func (m *MockEntityMgr) CreateKeyRange(ctx context.Context, kr *kr.KeyRange) error {
+func (m *MockEntityMgr) CreateKeyRange(ctx context.Context, arg1 *kr.KeyRange) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateKeyRange", ctx, kr)
+	ret := m.ctrl.Call(m, "CreateKeyRange", ctx, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateKeyRange indicates an expected call of CreateKeyRange.
-func (mr *MockEntityMgrMockRecorder) CreateKeyRange(ctx, kr any) *gomock.Call {
+func (mr *MockEntityMgrMockRecorder) CreateKeyRange(ctx, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyRange", reflect.TypeOf((*MockEntityMgr)(nil).CreateKeyRange), ctx, kr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyRange", reflect.TypeOf((*MockEntityMgr)(nil).CreateKeyRange), ctx, arg1)
 }
 
 // DropDistribution mocks base method.

--- a/pkg/models/kr/keyrange.go
+++ b/pkg/models/kr/keyrange.go
@@ -83,13 +83,13 @@ func (kr *KeyRange) InFunc(attribInd int, raw []byte) {
 func (kr *KeyRange) OutFunc(attribInd int) []byte {
 	switch kr.ColumnTypes[attribInd] {
 	case qdb.ColumnTypeInteger:
-		raw := make([]byte, 8)
+		raw := make([]byte, binary.MaxVarintLen64)
 		_ = binary.PutVarint(raw, kr.LowerBound[attribInd].(int64))
 		return raw
 	case qdb.ColumnTypeVarcharHashed:
 		fallthrough
 	case qdb.ColumnTypeUinteger:
-		raw := make([]byte, 8)
+		raw := make([]byte, binary.MaxVarintLen64)
 		_ = binary.PutUvarint(raw, kr.LowerBound[attribInd].(uint64))
 		return raw
 	case qdb.ColumnTypeVarcharDeprecated:

--- a/router/mock/client/mock_client.go
+++ b/router/mock/client/mock_client.go
@@ -699,17 +699,17 @@ func (mr *MockRouterClientMockRecorder) ReplyParseComplete() *gomock.Call {
 }
 
 // ReplyRFQ mocks base method.
-func (m *MockRouterClient) ReplyRFQ(txstatus txstatus.TXStatus) error {
+func (m *MockRouterClient) ReplyRFQ(arg0 txstatus.TXStatus) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplyRFQ", txstatus)
+	ret := m.ctrl.Call(m, "ReplyRFQ", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReplyRFQ indicates an expected call of ReplyRFQ.
-func (mr *MockRouterClientMockRecorder) ReplyRFQ(txstatus any) *gomock.Call {
+func (mr *MockRouterClientMockRecorder) ReplyRFQ(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplyRFQ", reflect.TypeOf((*MockRouterClient)(nil).ReplyRFQ), txstatus)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplyRFQ", reflect.TypeOf((*MockRouterClient)(nil).ReplyRFQ), arg0)
 }
 
 // ReplyWarningMsg mocks base method.

--- a/router/mock/poolmgr/mock_pool_mgr.go
+++ b/router/mock/poolmgr/mock_pool_mgr.go
@@ -190,31 +190,31 @@ func (mr *MockPoolMgrMockRecorder) TXEndCB(rst any) *gomock.Call {
 }
 
 // UnRouteCB mocks base method.
-func (m *MockPoolMgr) UnRouteCB(client client.RouterClient, sh []kr.ShardKey) error {
+func (m *MockPoolMgr) UnRouteCB(arg0 client.RouterClient, sh []kr.ShardKey) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnRouteCB", client, sh)
+	ret := m.ctrl.Call(m, "UnRouteCB", arg0, sh)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnRouteCB indicates an expected call of UnRouteCB.
-func (mr *MockPoolMgrMockRecorder) UnRouteCB(client, sh any) *gomock.Call {
+func (mr *MockPoolMgrMockRecorder) UnRouteCB(arg0, sh any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnRouteCB", reflect.TypeOf((*MockPoolMgr)(nil).UnRouteCB), client, sh)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnRouteCB", reflect.TypeOf((*MockPoolMgr)(nil).UnRouteCB), arg0, sh)
 }
 
 // UnRouteWithError mocks base method.
-func (m *MockPoolMgr) UnRouteWithError(client client.RouterClient, sh []kr.ShardKey, errmsg error) error {
+func (m *MockPoolMgr) UnRouteWithError(arg0 client.RouterClient, sh []kr.ShardKey, errmsg error) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnRouteWithError", client, sh, errmsg)
+	ret := m.ctrl.Call(m, "UnRouteWithError", arg0, sh, errmsg)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UnRouteWithError indicates an expected call of UnRouteWithError.
-func (mr *MockPoolMgrMockRecorder) UnRouteWithError(client, sh, errmsg any) *gomock.Call {
+func (mr *MockPoolMgrMockRecorder) UnRouteWithError(arg0, sh, errmsg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnRouteWithError", reflect.TypeOf((*MockPoolMgr)(nil).UnRouteWithError), client, sh, errmsg)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnRouteWithError", reflect.TypeOf((*MockPoolMgr)(nil).UnRouteWithError), arg0, sh, errmsg)
 }
 
 // ValidateReRoute mocks base method.

--- a/router/mock/server/mock_server.go
+++ b/router/mock/server/mock_server.go
@@ -48,17 +48,17 @@ func (m *MockServer) EXPECT() *MockServerMockRecorder {
 }
 
 // AddDataShard mocks base method.
-func (m *MockServer) AddDataShard(clid uint, shardKey kr.ShardKey, tsa tsa.TSA) error {
+func (m *MockServer) AddDataShard(clid uint, shardKey kr.ShardKey, arg2 tsa.TSA) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddDataShard", clid, shardKey, tsa)
+	ret := m.ctrl.Call(m, "AddDataShard", clid, shardKey, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddDataShard indicates an expected call of AddDataShard.
-func (mr *MockServerMockRecorder) AddDataShard(clid, shardKey, tsa any) *gomock.Call {
+func (mr *MockServerMockRecorder) AddDataShard(clid, shardKey, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDataShard", reflect.TypeOf((*MockServer)(nil).AddDataShard), clid, shardKey, tsa)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDataShard", reflect.TypeOf((*MockServer)(nil).AddDataShard), clid, shardKey, arg2)
 }
 
 // Cancel mocks base method.
@@ -104,17 +104,17 @@ func (mr *MockServerMockRecorder) Datashards() *gomock.Call {
 }
 
 // ExpandDataShard mocks base method.
-func (m *MockServer) ExpandDataShard(clid uint, shkey kr.ShardKey, tsa tsa.TSA, deployTX bool) error {
+func (m *MockServer) ExpandDataShard(clid uint, shkey kr.ShardKey, arg2 tsa.TSA, deployTX bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExpandDataShard", clid, shkey, tsa, deployTX)
+	ret := m.ctrl.Call(m, "ExpandDataShard", clid, shkey, arg2, deployTX)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ExpandDataShard indicates an expected call of ExpandDataShard.
-func (mr *MockServerMockRecorder) ExpandDataShard(clid, shkey, tsa, deployTX any) *gomock.Call {
+func (mr *MockServerMockRecorder) ExpandDataShard(clid, shkey, arg2, deployTX any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpandDataShard", reflect.TypeOf((*MockServer)(nil).ExpandDataShard), clid, shkey, tsa, deployTX)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExpandDataShard", reflect.TypeOf((*MockServer)(nil).ExpandDataShard), clid, shkey, arg2, deployTX)
 }
 
 // HasPrepareStatement mocks base method.

--- a/yacc/console/gram.go
+++ b/yacc/console/gram.go
@@ -1700,7 +1700,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 //line gram.y:863
 		{
-			buf := make([]byte, 8)
+			buf := make([]byte, binary.MaxVarintLen64)
 			binary.PutVarint(buf, int64(yyDollar[1].uinteger))
 			yyVAL.bytes = buf
 		}

--- a/yacc/console/gram.y
+++ b/yacc/console/gram.y
@@ -861,7 +861,7 @@ key_range_bound_elem:
 		$$ = []byte($1)
 	}
 	| any_uint {
-		buf := make([]byte, 8)
+		buf := make([]byte, binary.MaxVarintLen64)
 		binary.PutVarint(buf, int64($1))
 		$$ = buf
 	}

--- a/yacc/console/lex.go
+++ b/yacc/console/lex.go
@@ -10,7 +10,7 @@ import (
 
 
 
-//line lex.go:14
+//line lex.go:12
 const lexer_start int = 4
 const lexer_first_final int = 4
 const lexer_error int = 0
@@ -36,7 +36,7 @@ func NewLexer(data []byte) *Lexer {
         pe: len(data),
     }
     
-//line lex.go:40
+//line lex.go:36
 	{
 	 lex.cs = lexer_start
 	 lex.ts = 0
@@ -52,7 +52,7 @@ func ResetLexer(lex *Lexer, data []byte) {
     lex.pe = len(data)
     lex.data = data
     
-//line lex.go:56
+//line lex.go:50
 	{
 	 lex.cs = lexer_start
 	 lex.ts = 0
@@ -73,7 +73,7 @@ func (lex *Lexer) Lex(lval *yySymType) int {
     var tok int
 
     
-//line lex.go:77
+//line lex.go:69
 	{
 	if ( lex.p) == ( lex.pe) {
 		goto _test_eof
@@ -212,7 +212,7 @@ tr24:
 //line NONE:1
  lex.ts = ( lex.p)
 
-//line lex.go:216
+//line lex.go:208
 		switch  lex.data[( lex.p)] {
 		case 32:
 			goto st5
@@ -307,7 +307,7 @@ tr17:
 			goto _test_eof6
 		}
 	st_case_6:
-//line lex.go:311
+//line lex.go:303
 		switch  lex.data[( lex.p)] {
 		case 33:
 			goto tr8
@@ -356,7 +356,7 @@ tr19:
 			goto _test_eof7
 		}
 	st_case_7:
-//line lex.go:360
+//line lex.go:352
 		switch  lex.data[( lex.p)] {
 		case 34:
 			goto tr19
@@ -511,7 +511,7 @@ tr15:
 			goto _test_eof12
 		}
 	st_case_12:
-//line lex.go:515
+//line lex.go:507
 		switch  lex.data[( lex.p)] {
 		case 34:
 			goto st8
@@ -572,7 +572,7 @@ tr5:
 			goto _test_eof13
 		}
 	st_case_13:
-//line lex.go:576
+//line lex.go:568
 		if  lex.data[( lex.p)] == 42 {
 			goto st3
 		}

--- a/yacc/console/yx_test.go
+++ b/yacc/console/yx_test.go
@@ -351,14 +351,29 @@ func TestKeyRange(t *testing.T) {
 					Distribution: "ds1",
 					LowerBound: &spqrparser.KeyRangeBound{
 						Pivots: [][]byte{
-							{2, 0, 0, 0, 0, 0, 0, 0},
+							{2, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 						},
 					},
 				},
 			},
 			err: nil,
 		},
-
+		{
+			query: "CREATE KEY RANGE krid2 FROM 4611686018427387904 ROUTE TO sh2 FOR DISTRIBUTION ds1;",
+			exp: &spqrparser.Create{
+				Element: &spqrparser.KeyRangeDefinition{
+					ShardID:      "sh2",
+					KeyRangeID:   "krid2",
+					Distribution: "ds1",
+					LowerBound: &spqrparser.KeyRangeBound{
+						Pivots: [][]byte{
+							{128, 128, 128, 128, 128, 128, 128, 128, 128, 1},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
 		{
 			query: "CREATE KEY RANGE krid2 FROM 88888888-8888-8888-8888-888888888889 ROUTE TO sh2 FOR DISTRIBUTION ds1;",
 			exp: &spqrparser.Create{
@@ -387,7 +402,7 @@ func TestKeyRange(t *testing.T) {
 					Distribution: "ds1",
 					LowerBound: &spqrparser.KeyRangeBound{
 						Pivots: [][]byte{
-							{0, 0, 0, 0, 0, 0, 0, 0},
+							{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 							[]byte("a"),
 						},
 					},
@@ -468,7 +483,7 @@ func TestSplitKeyRange(t *testing.T) {
 			exp: &spqrparser.SplitKeyRange{
 				Border: &spqrparser.KeyRangeBound{
 					Pivots: [][]byte{
-						{10, 0, 0, 0, 0, 0, 0, 0},
+						{10, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 					},
 				},
 				KeyRangeFromID: "krid1",


### PR DESCRIPTION
issue 1154. PutVarint needs buf[binary.MaxVarintLen64=10] to avoid panic in case big numbers
(https://pkg.go.dev/encoding/binary#PutVarint)