### PR TITLE
fix intersection key ranges

### DIFF
--- a/qdb/ops/ops.go
+++ b/qdb/ops/ops.go
@@ -40,7 +40,7 @@ func CreateKeyRangeWithChecks(ctx context.Context, qdb qdb.QDB, keyRange *kr.Key
 		}
 	}
 
-	if nearestKr != nil && nearestKr.ShardID != keyRange.ShardID {
+	if nearestKr != nil && nearestKr.ShardID == keyRange.ShardID {
 		return spqrerror.Newf(spqrerror.SPQR_KEYRANGE_ERROR, "key range %v intersects with key range %v in QDB", keyRange.ID, nearestKr.ID)
 	}
 

--- a/qdb/ops/ops_test.go
+++ b/qdb/ops/ops_test.go
@@ -1,0 +1,87 @@
+package ops_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pg-sharding/spqr/pkg/models/kr"
+	"github.com/pg-sharding/spqr/qdb"
+	"github.com/pg-sharding/spqr/qdb/ops"
+	"github.com/stretchr/testify/assert"
+)
+
+const MemQDBPath = ""
+
+var mockShard = &qdb.Shard{
+	ID:       "sh1",
+	RawHosts: []string{"host1", "host2"},
+}
+
+var kr1 = &kr.KeyRange{
+	ID:           "kr1",
+	ShardID:      "sh1",
+	Distribution: "ds1",
+	LowerBound:   []interface{}{int64(0)},
+	ColumnTypes:  []string{qdb.ColumnTypeInteger},
+}
+
+var kr1_double = &kr.KeyRange{
+	ID:           "kr1DOUBLE",
+	ShardID:      "sh1",
+	Distribution: "ds1",
+	LowerBound:   []interface{}{int64(0)},
+	ColumnTypes:  []string{qdb.ColumnTypeInteger},
+}
+
+var kr2 = &kr.KeyRange{
+	ID:           "kr2",
+	ShardID:      "sh1",
+	Distribution: "ds1",
+	LowerBound:   []interface{}{int64(10)},
+	ColumnTypes:  []string{qdb.ColumnTypeInteger},
+}
+
+func prepareDB(ctx context.Context) (*qdb.MemQDB, error) {
+	memqdb, err := qdb.RestoreQDB(MemQDBPath)
+	if err != nil {
+		return nil, err
+	}
+	if err = memqdb.CreateDistribution(ctx, qdb.NewDistribution("ds1", nil)); err != nil {
+		return nil, err
+	}
+	if err = memqdb.AddShard(ctx, mockShard); err != nil {
+		return nil, err
+	}
+	return memqdb, nil
+}
+
+func TestCreateKeyRangeWithChecks_happyPath(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.TODO()
+	memqdb, err := prepareDB(ctx)
+	assert.NoError(err)
+
+	assert.NoError(ops.CreateKeyRangeWithChecks(ctx, memqdb, kr2))
+	assert.NoError(ops.CreateKeyRangeWithChecks(ctx, memqdb, kr1))
+}
+func TestCreateKeyRangeWithChecks_intersectWithExists(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.TODO()
+	memqdb, err := prepareDB(ctx)
+	assert.NoError(err)
+
+	assert.NoError(ops.CreateKeyRangeWithChecks(ctx, memqdb, kr1))
+	assert.Error(ops.CreateKeyRangeWithChecks(ctx, memqdb, kr2),
+		"key range kr2 intersects with key range kr1 in QDB")
+}
+
+func TestCreateKeyRangeWithChecks_equalBound(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.TODO()
+	memqdb, err := prepareDB(ctx)
+	assert.NoError(err)
+
+	assert.NoError(ops.CreateKeyRangeWithChecks(ctx, memqdb, kr1))
+	assert.Error(ops.CreateKeyRangeWithChecks(ctx, memqdb, kr1_double),
+		"key range kr1DOUBLE intersects with key range kr1 in QDB")
+}


### PR DESCRIPTION
incorrect check of intersection for key_range which lets create doubles
example:
3 runs init2shards.sql gets memqdb_with_doubles.json  
[init2shards.txt](https://github.com/user-attachments/files/20692054/init2shards.txt)
[memqdb_with_doubles.json](https://github.com/user-attachments/files/20692055/memqdb_with_doubles.json)
