### PR TITLE
MVP default shards

### DIFF
--- a/pkg/clientinteractor/interactor.go
+++ b/pkg/clientinteractor/interactor.go
@@ -71,6 +71,15 @@ type Interactor interface {
 	ProcClient(ctx context.Context, nconn net.Conn, pt port.RouterPortType) error
 }
 
+type SimpleResultRow struct {
+	Name  string
+	Value string
+}
+type SimpleResultMsg struct {
+	Header string
+	Rows   []SimpleResultRow
+}
+
 type PSQLInteractor struct {
 	cl client.Client
 }
@@ -1428,6 +1437,28 @@ func (pi *PSQLInteractor) AlterDistributedRelation(_ context.Context, id string,
 	}
 
 	return pi.CompleteMsg(0)
+}
+
+// MakeSimpleResponce generic function to return to client result as list of key-value.
+//
+// Parameters:
+// - _ (context.Context): The context for the operation. (Unused)
+// - msg (SimpleResultMsg): header and key-value rows
+//
+// Returns:
+// - error: An error if any occurred during the operation.
+func (pi *PSQLInteractor) MakeSimpleResponce(_ context.Context, msg SimpleResultMsg) error {
+	if err := pi.WriteHeader(msg.Header); err != nil {
+		spqrlog.Zero.Error().Err(err).Msg("")
+		return err
+	}
+	for _, info := range msg.Rows {
+		if err := pi.WriteDataRow(fmt.Sprintf("%s	-> %s", info.Name, info.Value)); err != nil {
+			spqrlog.Zero.Error().Err(err).Msg("")
+			return err
+		}
+	}
+	return pi.CompleteMsg(len(msg.Rows))
 }
 
 // TODO : unit tests

--- a/pkg/clientinteractor/interactor_test.go
+++ b/pkg/clientinteractor/interactor_test.go
@@ -2,6 +2,7 @@ package clientinteractor_test
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -415,4 +416,51 @@ func TestBackendConnectionsGroupByFail(t *testing.T) {
 	}
 	err := interactor.BackendConnections(ctx, shards, cmd)
 	assert.ErrorContains(err, "not found column 'someColumn' for group by statement")
+}
+
+func TestMakeSimpleResponceWithData(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	ca := mockcl.NewMockRouterClient(ctrl)
+	interactor := clientinteractor.NewPSQLInteractor(ca)
+	info := []clientinteractor.SimpleResultRow{
+		clientinteractor.SimpleResultRow{Name: "ttt1", Value: "ddd1"},
+		clientinteractor.SimpleResultRow{Name: "ttt2", Value: "ddd2"},
+	}
+	data := clientinteractor.SimpleResultMsg{Header: "test header", Rows: info}
+
+	desc := []pgproto3.FieldDescription{clientinteractor.TextOidFD("test header")}
+	firstRow := pgproto3.DataRow{
+		Values: [][]byte{[]byte(fmt.Sprintf("%s	-> %s", "ttt1", "ddd1"))},
+	}
+	secondRow := pgproto3.DataRow{
+		Values: [][]byte{[]byte(fmt.Sprintf("%s	-> %s", "ttt2", "ddd2"))},
+	}
+	gomock.InOrder(
+		ca.EXPECT().Send(&pgproto3.RowDescription{Fields: desc}),
+		ca.EXPECT().Send(&firstRow),
+		ca.EXPECT().Send(&secondRow),
+		ca.EXPECT().Send(&pgproto3.CommandComplete{CommandTag: []byte("SELECT 2")}),
+		ca.EXPECT().Send(&pgproto3.ReadyForQuery{TxStatus: byte(txstatus.TXIDLE)}),
+	)
+	err := interactor.MakeSimpleResponce(ctx, data)
+	assert.Nil(t, err)
+}
+
+func TestMakeSimpleResponceEmpty(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	ca := mockcl.NewMockRouterClient(ctrl)
+	interactor := clientinteractor.NewPSQLInteractor(ca)
+	info := []clientinteractor.SimpleResultRow{}
+	data := clientinteractor.SimpleResultMsg{Header: "test header", Rows: info}
+
+	desc := []pgproto3.FieldDescription{clientinteractor.TextOidFD("test header")}
+	gomock.InOrder(
+		ca.EXPECT().Send(&pgproto3.RowDescription{Fields: desc}),
+		ca.EXPECT().Send(&pgproto3.CommandComplete{CommandTag: []byte("SELECT 0")}),
+		ca.EXPECT().Send(&pgproto3.ReadyForQuery{TxStatus: byte(txstatus.TXIDLE)}),
+	)
+	err := interactor.MakeSimpleResponce(ctx, data)
+	assert.Nil(t, err)
 }

--- a/pkg/coord/clocal.go
+++ b/pkg/coord/clocal.go
@@ -340,7 +340,15 @@ func (lc *LocalInstanceMetadataMgr) SyncRouterCoordinatorAddress(ctx context.Con
 // - *topology.DataShard: The retrieved DataShard, or nil if it doesn't exist.
 // - error: An error indicating the retrieval status, or ErrNotCoordinator if the operation is not supported by the LocalCoordinator.
 func (lc *LocalInstanceMetadataMgr) GetShard(ctx context.Context, shardID string) (*topology.DataShard, error) {
-	return nil, ErrNotCoordinator
+	if lc.qdb != nil {
+		sh, err := lc.qdb.GetShard(ctx, shardID)
+		if err != nil {
+			return nil, err
+		}
+		return topology.DataShardFromDB(sh), nil
+	} else {
+		return nil, ErrNotCoordinator
+	}
 }
 
 func (lc *LocalInstanceMetadataMgr) Cache() *cache.SchemaCache {

--- a/pkg/meta/default_shard_manager.go
+++ b/pkg/meta/default_shard_manager.go
@@ -1,0 +1,120 @@
+package meta
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/pg-sharding/spqr/pkg/clientinteractor"
+	"github.com/pg-sharding/spqr/pkg/models/distributions"
+	"github.com/pg-sharding/spqr/pkg/models/kr"
+	"github.com/pg-sharding/spqr/pkg/models/topology"
+	"github.com/pg-sharding/spqr/pkg/spqrlog"
+	"github.com/pg-sharding/spqr/qdb"
+	spqrparser "github.com/pg-sharding/spqr/yacc/console"
+)
+
+type DefaultShardManager struct {
+	distribution distributions.Distribution
+	mngr         EntityMgr
+}
+
+func NewDefaultShardManager(distribution distributions.Distribution, mngr EntityMgr) *DefaultShardManager {
+	return &DefaultShardManager{
+		distribution: distribution,
+		mngr:         mngr,
+	}
+}
+
+func TryNewDefaultShardManager(ctx context.Context,
+	distributionId string, mngr EntityMgr) (*DefaultShardManager, error) {
+	if distribution, err := mngr.GetDistribution(ctx, distributionId); err != nil {
+		return nil, fmt.Errorf("distribution id=%s not exists", distributionId)
+	} else {
+		return &DefaultShardManager{
+			distribution: *distribution,
+			mngr:         mngr,
+		}, nil
+	}
+}
+
+func (dsm *DefaultShardManager) DefaultKeyRangeId() string {
+	return dsm.distribution.Id + "." + spqrparser.DEFAULT_KEY_RANGE_SUFFIX
+}
+
+func DefaultRangeLowerBound(colTypes []string) (kr.KeyRangeBound, error) {
+	lowerBound := make(kr.KeyRangeBound, len(colTypes))
+	for i, colType := range colTypes {
+		switch colType {
+		case qdb.ColumnTypeVarchar:
+			lowerBound[i] = ""
+		case qdb.ColumnTypeInteger:
+			lowerBound[i] = int64(math.MinInt64)
+		default:
+			return nil, fmt.Errorf("unsuported type '%v' for default key range", colType)
+		}
+	}
+	return lowerBound, nil
+}
+
+func (dsm *DefaultShardManager) keyRangeDefault(DefaultShardId string) (*kr.KeyRange, error) {
+	if lowerBound, err := DefaultRangeLowerBound(dsm.distribution.ColTypes); err == nil {
+		keyRange := &kr.KeyRange{
+			ShardID:      DefaultShardId,
+			ID:           dsm.DefaultKeyRangeId(),
+			Distribution: dsm.distribution.Id,
+			ColumnTypes:  dsm.distribution.ColTypes,
+			LowerBound:   lowerBound,
+		}
+
+		return keyRange, nil
+	} else {
+		return nil, err
+	}
+}
+
+func (dsm *DefaultShardManager) CreateDefaultShard(ctx context.Context, defaultShardId string) error {
+	if defaultShard, err := dsm.mngr.GetShard(ctx, defaultShardId); err != nil {
+		return fmt.Errorf("Shard '%s' for default is not exists", defaultShard.ID)
+	} else {
+		return dsm.CreateDefaultShardNoCheck(ctx, defaultShard)
+	}
+}
+
+func (dsm *DefaultShardManager) CreateDefaultShardNoCheck(ctx context.Context, defaultShard *topology.DataShard) error {
+	req, err := dsm.keyRangeDefault(defaultShard.ID)
+	if err != nil {
+		spqrlog.Zero.Error().Err(err).Msg("Error (1) when adding default key range for: " + dsm.distribution.Id)
+		return err
+	}
+	if err := dsm.mngr.CreateKeyRange(ctx, req); err != nil {
+		spqrlog.Zero.Error().Err(err).Msg("Error (2) when adding default key range for: " + dsm.distribution.Id)
+		return err
+	}
+	return nil
+}
+
+func (dsm *DefaultShardManager) DropDefaultShard(ctx context.Context) (*string, error) {
+	if defaultKeyRange, err := dsm.mngr.GetKeyRange(ctx, dsm.DefaultKeyRangeId()); err != nil {
+		return nil, fmt.Errorf("distribution id=%s have not default shard", dsm.distribution.Id)
+	} else {
+		spqrlog.Zero.Debug().Str("default key range", defaultKeyRange.ID).Msg("parsed drop")
+		return &(defaultKeyRange.ShardID), dsm.mngr.DropKeyRange(ctx, defaultKeyRange.ID)
+	}
+}
+
+func (dsm *DefaultShardManager) SuccessDropResponce(defaultShard string) clientinteractor.SimpleResultMsg {
+	info := []clientinteractor.SimpleResultRow{
+		clientinteractor.SimpleResultRow{Name: "distribution id", Value: dsm.distribution.Id},
+		clientinteractor.SimpleResultRow{Name: "shard id", Value: defaultShard},
+	}
+	return clientinteractor.SimpleResultMsg{Header: "drop default shard", Rows: info}
+}
+
+func (dsm *DefaultShardManager) SuccessCreateResponce(defaultShard string) clientinteractor.SimpleResultMsg {
+	info := []clientinteractor.SimpleResultRow{
+		clientinteractor.SimpleResultRow{Name: "distribution id", Value: dsm.distribution.Id},
+		clientinteractor.SimpleResultRow{Name: "shard id", Value: defaultShard},
+	}
+	return clientinteractor.SimpleResultMsg{Header: "create default shard", Rows: info}
+}

--- a/pkg/meta/default_shard_manager_test.go
+++ b/pkg/meta/default_shard_manager_test.go
@@ -1,0 +1,152 @@
+package meta_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/pg-sharding/spqr/pkg/meta"
+	"github.com/pg-sharding/spqr/pkg/models/kr"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestDefaultRangeLowerBound(t *testing.T) {
+
+	type tcase struct {
+		colTypes    []string
+		expected    kr.KeyRangeBound
+		expectedErr error
+	}
+	for _, test := range []tcase{
+		{
+			colTypes: []string{"varchar",
+				"integer"},
+			expected:    kr.KeyRangeBound{"", int64(math.MinInt64)},
+			expectedErr: nil,
+		},
+		{
+			colTypes: []string{"varchar",
+				"integer",
+				"uuid",
+			},
+			expected:    nil,
+			expectedErr: fmt.Errorf("unsuported type '%v' for default key range", "uuid"),
+		},
+	} {
+		actual, actualErr := meta.DefaultRangeLowerBound(test.colTypes)
+
+		if test.expectedErr == nil {
+			assert.NoError(t, actualErr, "type set %v", test.colTypes)
+			assert.ElementsMatch(t, test.expected, actual)
+		} else {
+			assert.Error(t, actualErr, "type set %v", test.colTypes)
+			assert.Nil(t, actual)
+		}
+	}
+}
+
+func TestCmpRangesLess_Default(t *testing.T) {
+	defaultString, _ := meta.DefaultRangeLowerBound([]string{"varchar"})
+	defaultInteger, _ := meta.DefaultRangeLowerBound([]string{"integer"})
+	defaultMix1, _ := meta.DefaultRangeLowerBound([]string{"integer", "varchar"})
+	defaultMix2, _ := meta.DefaultRangeLowerBound([]string{"varchar", "integer"})
+	defaultMix3, _ := meta.DefaultRangeLowerBound([]string{"integer", "varchar", "integer"})
+	tests := []struct {
+		testName   string
+		leftBound  kr.KeyRangeBound
+		checkBound kr.KeyRangeBound
+		types      []string
+		expect     bool
+	}{
+		{
+			testName:   "10",
+			leftBound:  defaultInteger,
+			checkBound: kr.KeyRangeBound{int64(10)},
+			types:      []string{"integer"},
+			expect:     true,
+		},
+		{
+			testName:   "-10",
+			leftBound:  defaultInteger,
+			checkBound: kr.KeyRangeBound{int64(-10)},
+			types:      []string{"integer"},
+			expect:     true,
+		},
+		{
+			testName:   "-10 inverted test",
+			leftBound:  kr.KeyRangeBound{int64(-10)},
+			checkBound: defaultInteger,
+			types:      []string{"integer"},
+			expect:     false,
+		},
+		{
+			testName:   "-9223372036854775807",
+			leftBound:  defaultInteger,
+			checkBound: kr.KeyRangeBound{int64(math.MinInt64 + 1)},
+			types:      []string{"integer"},
+			expect:     true,
+		},
+		{
+			testName:   "empty too",
+			leftBound:  defaultString,
+			checkBound: kr.KeyRangeBound{""},
+			types:      []string{"varchar"},
+			expect:     false,
+		},
+		{
+			testName:   "tttttt1",
+			leftBound:  defaultString,
+			checkBound: kr.KeyRangeBound{"tttttt1"},
+			types:      []string{"varchar"},
+			expect:     true,
+		},
+		{
+			testName:   "minInt, tt",
+			leftBound:  defaultMix1,
+			checkBound: kr.KeyRangeBound{int64(math.MinInt64), "tttttt1"},
+			types:      []string{"integer", "varchar"},
+			expect:     true,
+		},
+		{
+			testName:   "minInt, <empty>",
+			leftBound:  defaultMix1,
+			checkBound: kr.KeyRangeBound{int64(math.MinInt64), ""},
+			types:      []string{"integer", "varchar"},
+			expect:     false,
+		},
+		{
+			testName:   "minInt+1, <empty>",
+			leftBound:  defaultMix1,
+			checkBound: kr.KeyRangeBound{int64(math.MinInt64 + 1), ""},
+			types:      []string{"integer", "varchar"},
+			expect:     true,
+		},
+		{
+			testName:   "<empty>,minInt+1",
+			leftBound:  defaultMix2,
+			checkBound: kr.KeyRangeBound{"", int64(math.MinInt64 + 1)},
+			types:      []string{"varchar", "integer"},
+			expect:     true,
+		},
+		{
+			testName:   "<empty>,minInt+1  inverted test",
+			leftBound:  kr.KeyRangeBound{"", int64(math.MinInt64 + 1)},
+			checkBound: defaultMix2,
+			types:      []string{"varchar", "integer"},
+			expect:     false,
+		},
+		{
+			testName:   "minInt+1,t, minInt",
+			leftBound:  defaultMix3,
+			checkBound: kr.KeyRangeBound{int64(math.MinInt64 + 1), "", int64(math.MinInt64)},
+			types:      []string{"integer", "varchar", "integer"},
+			expect:     true,
+		},
+	}
+
+	for _, test := range tests {
+		result := kr.CmpRangesLess(test.leftBound, test.checkBound, test.types)
+		assert.Equal(t, test.expect, result, test.testName)
+	}
+}

--- a/pkg/meta/meta_export_test.go
+++ b/pkg/meta/meta_export_test.go
@@ -1,0 +1,4 @@
+package meta
+
+var ProcessCreate = processCreate
+var CreateNonReplicatedDistribution = createNonReplicatedDistribution

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1,0 +1,119 @@
+package meta_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/pg-sharding/spqr/pkg/clientinteractor"
+	"github.com/pg-sharding/spqr/pkg/coord"
+	"github.com/pg-sharding/spqr/pkg/meta"
+	"github.com/pg-sharding/spqr/pkg/models/distributions"
+	"github.com/pg-sharding/spqr/pkg/txstatus"
+	"github.com/pg-sharding/spqr/qdb"
+	mockcl "github.com/pg-sharding/spqr/router/mock/client"
+	spqrparser "github.com/pg-sharding/spqr/yacc/console"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+const MemQDBPath = ""
+
+var mockShard1 = &qdb.Shard{
+	ID:       "sh1",
+	RawHosts: []string{"host1", "host2"},
+}
+var mockShard2 = &qdb.Shard{
+	ID:       "sh2",
+	RawHosts: []string{"host3", "host4"},
+}
+
+func prepareDB(ctx context.Context) (*qdb.MemQDB, error) {
+	memqdb, err := qdb.RestoreQDB(MemQDBPath)
+	if err != nil {
+		return nil, err
+	}
+	if err = memqdb.CreateDistribution(ctx, qdb.NewDistribution("ds1", nil)); err != nil {
+		return nil, err
+	}
+	if err = memqdb.AddShard(ctx, mockShard1); err != nil {
+		return nil, err
+	}
+	if err = memqdb.AddShard(ctx, mockShard2); err != nil {
+		return nil, err
+	}
+	return memqdb, nil
+}
+
+func TestNoManualCreateDefaultShardKeyRange(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	ca := mockcl.NewMockRouterClient(ctrl)
+	interactor := clientinteractor.NewPSQLInteractor(ca)
+	statement := spqrparser.KeyRangeDefinition{
+		ShardID:      "sh1",
+		KeyRangeID:   "ds1.DEFAULT",
+		Distribution: "ds1",
+		LowerBound: &spqrparser.KeyRangeBound{
+			Pivots: [][]byte{
+				{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+				[]byte("a"),
+			},
+		},
+	}
+	memqdb, err := prepareDB(ctx)
+	assert.NoError(t, err)
+	var mngr meta.EntityMgr = coord.NewLocalInstanceMetadataMgr(memqdb, nil)
+	gomock.InOrder(
+		ca.EXPECT().Send(&pgproto3.ErrorResponse{Severity: "ERROR",
+			Message: "Error kay range ds1.DEFAULT is reserved",
+		}),
+		ca.EXPECT().Send(&pgproto3.ReadyForQuery{TxStatus: byte(txstatus.TXIDLE)}),
+	)
+	res := meta.ProcessCreate(ctx, &statement, mngr, interactor)
+	assert.Nil(t, res)
+}
+
+func TestCreteDistrWithDefaultShardSuccess(t *testing.T) {
+	ctx := context.Background()
+	statement := spqrparser.DistributionDefinition{
+		ID:           "dbTestDefault",
+		ColTypes:     []string{"integer"},
+		DefaultShard: "sh1",
+	}
+	memqdb, err := prepareDB(ctx)
+	assert.NoError(t, err)
+	var mngr meta.EntityMgr = coord.NewLocalInstanceMetadataMgr(memqdb, nil)
+
+	expectedDistribution := distributions.NewDistribution("dbTestDefault", []string{"integer"})
+	actualDistribution, err := meta.CreateNonReplicatedDistribution(ctx, statement, mngr)
+	assert.Nil(t, err)
+	assert.Equal(t, actualDistribution, expectedDistribution)
+
+	expectedKr := &qdb.KeyRange{
+		LowerBound:     [][]byte{{255, 255, 255, 255, 255, 255, 255, 255, 255, 1}},
+		ShardID:        "sh1",
+		KeyRangeID:     "dbTestDefault.DEFAULT",
+		DistributionId: "dbTestDefault",
+	}
+	actualKr, errKr := memqdb.GetKeyRange(ctx, "dbTestDefault.DEFAULT")
+	assert.Nil(t, errKr)
+	assert.Equal(t, actualKr, expectedKr)
+}
+func TestCreteDistrWithDefaultShardFail1(t *testing.T) {
+	ctx := context.Background()
+	statement := spqrparser.DistributionDefinition{
+		ID:           "dbTestDefault",
+		ColTypes:     []string{"integer"},
+		DefaultShard: "notExistShard",
+	}
+	memqdb, err := prepareDB(ctx)
+	assert.NoError(t, err)
+	var mngr meta.EntityMgr = coord.NewLocalInstanceMetadataMgr(memqdb, nil)
+
+	actualDistribution, err := meta.CreateNonReplicatedDistribution(ctx, statement, mngr)
+	assert.Nil(t, actualDistribution)
+	assert.Equal(t, err, fmt.Errorf("Shard '%s' for default is not exists", "notExistShard"))
+
+}

--- a/test/feature/features/default_shard.feature
+++ b/test/feature/features/default_shard.feature
@@ -1,0 +1,97 @@
+Feature: default shards test
+  Background:
+    #
+    # Make host "coordinator" take control
+    #
+    Given cluster is up and running
+    And host "coordinator2" is stopped
+    And host "coordinator2" is started
+
+    When I execute SQL on host "coordinator"
+    """
+    REGISTER ROUTER r1 ADDRESS regress_router:7000;
+    CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
+    ALTER DISTRIBUTION ds1 ATTACH RELATION xMove DISTRIBUTION KEY w_id;
+    ADD SHARD sh1 WITH HOSTS 'postgresql://regress@spqr_shard_1:6432/regress';
+    ADD SHARD sh2 WITH HOSTS 'postgresql://regress@spqr_shard_2:6432/regress';
+    """
+    Then command return code should be "0"
+
+  Scenario: default shard happy path
+    When I execute SQL on host "coordinator"
+    """
+    CREATE KEY RANGE kr1 FROM 0 ROUTE TO sh1 FOR DISTRIBUTION ds1;
+    ALTER DISTRIBUTION ds1 DEFAULT SHARD sh1;
+    """
+    Then command return code should be "0"
+
+    When I run SQL on host "coordinator"
+    """
+    SHOW key_ranges;
+    """
+    Then command return code should be "0"
+
+    And SQL result should match json
+    """
+    [{
+      "Key range ID":"ds1.DEFAULT",
+      "Distribution ID":"ds1",
+      "Lower bound":"-9223372036854775808",
+      "Shard ID":"sh1"
+    }]
+    """
+
+    And SQL result should match json
+    """
+    [{
+      "Key range ID":"kr1",
+      "Distribution ID":"ds1",
+      "Lower bound":"0",
+      "Shard ID":"sh1"
+    }]
+    """
+    When I run SQL on host "coordinator"
+    """
+    ALTER DISTRIBUTION ds1 DROP DEFAULT SHARD;
+    """
+    Then command return code should be "0"
+
+    When I run SQL on host "coordinator"
+    """
+    SHOW key_ranges;
+    """
+    And SQL result should match json_exactly
+    """
+    [{
+      "Key range ID":"kr1",
+      "Distribution ID":"ds1",
+      "Lower bound":"0",
+      "Shard ID":"sh1"
+    }]
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    ALTER DISTRIBUTION ds1 DEFAULT SHARD sh1;
+    """
+    Then command return code should be "0"
+
+    When I run SQL on host "coordinator"
+    """
+    SHOW key_ranges;
+    """
+    And SQL result should match json_exactly
+    """
+    [{
+      "Key range ID":"ds1.DEFAULT",
+      "Distribution ID":"ds1",
+      "Lower bound":"-9223372036854775808",
+      "Shard ID":"sh1"
+    },
+    {
+      "Key range ID":"kr1",
+      "Distribution ID":"ds1",
+      "Lower bound":"0",
+      "Shard ID":"sh1"
+    }]
+    """

--- a/yacc/console/ast.go
+++ b/yacc/console/ast.go
@@ -106,6 +106,7 @@ type DistributionDefinition struct {
 	ColTypes             []string
 	Replicated           bool
 	AutoIncrementEntries []AutoIncrementEntry
+	DefaultShard         string
 }
 
 type ShardingRuleDefinition struct {
@@ -304,6 +305,23 @@ func (*DetachRelation) iStatement()         {}
 func (*DetachRelation) iAlter()             {}
 func (*DetachRelation) iAlterDistribution() {}
 
+type AlterDefaultShard struct {
+	Distribution *DistributionSelector
+	Shard        string
+}
+
+func (*AlterDefaultShard) iStatement()         {}
+func (*AlterDefaultShard) iAlter()             {}
+func (*AlterDefaultShard) iAlterDistribution() {}
+
+type DropDefaultShard struct {
+	Distribution *DistributionSelector
+}
+
+func (*DropDefaultShard) iStatement()         {}
+func (*DropDefaultShard) iAlter()             {}
+func (*DropDefaultShard) iAlterDistribution() {}
+
 type SequenceSelector struct {
 	Name string
 }
@@ -341,6 +359,11 @@ const (
 
 const (
 	ClientStr = "client"
+)
+
+const (
+	//key range for default shard
+	DEFAULT_KEY_RANGE_SUFFIX = "DEFAULT"
 )
 
 // Statement represents a statement.

--- a/yacc/console/lx_test.go
+++ b/yacc/console/lx_test.go
@@ -254,12 +254,63 @@ func TestSimpleLex(t *testing.T) {
 				spqrparser.IDENT,
 			},
 		},
+		{
+			query: "CREATE DISTRIBUTION db1 DEFAULT shard1",
+			exp: []int{
+				spqrparser.CREATE,
+				spqrparser.DISTRIBUTION,
+				spqrparser.IDENT,
+				spqrparser.DEFAULT,
+				spqrparser.IDENT,
+			},
+		},
 	} {
 		tmp := spqrparser.NewStringTokenizer(tt.query)
 
 		act := spqrparser.LexString(tmp)
 
 		assert.Equal(tt.exp, act, tt.query)
+	}
+}
+
+
+func TestDefaultShard(t *testing.T) {
+	assert := assert.New(t)
+
+	type tcase struct {
+		query string
+		exp   []int
+		err   error
+	}
+
+	for _, tt := range []tcase{
+		{
+			query: "CREATE DISTRIBUTION db1 DEFAULT shard1",
+			exp: []int{
+				spqrparser.CREATE,
+				spqrparser.DISTRIBUTION,
+				spqrparser.IDENT,
+				spqrparser.DEFAULT,
+				spqrparser.IDENT,
+			},
+		},
+		{
+			query: "ALTER DISTRIBUTION distr1 DROP DEFAULT SHARD",
+			exp: []int{
+				spqrparser.ALTER,
+				spqrparser.DISTRIBUTION,
+				spqrparser.IDENT,
+				spqrparser.DROP,
+				spqrparser.DEFAULT,
+				spqrparser.SHARD,
+			},
+		},
+	} {
+		tmp := spqrparser.NewStringTokenizer(tt.query)
+
+		act := spqrparser.LexString(tmp)
+
+		assert.Equal(tt.exp, act)
 	}
 }
 

--- a/yacc/console/reserved_keyword.go
+++ b/yacc/console/reserved_keyword.go
@@ -82,4 +82,5 @@ var reservedWords = map[string]int{
 	"schema":       SCHEMA,
 	"retry":        RETRY,
 	"sync":         SYNC,
+	"default":      DEFAULT,
 }

--- a/yacc/console/yx_test.go
+++ b/yacc/console/yx_test.go
@@ -1265,3 +1265,70 @@ func TestRetryMoveTaskGroup(t *testing.T) {
 		assert.Equal(tt.exp, tmp, "query %s", tt.query)
 	}
 }
+
+func TestDistributionDefaultShard(t *testing.T) {
+
+	assert := assert.New(t)
+
+	type tcase struct {
+		query string
+		exp   spqrparser.Statement
+		err   error
+	}
+
+	for _, tt := range []tcase{
+		{
+			query: "CREATE DISTRIBUTION db1 DEFAULT SHARD shard1;",
+			exp: &spqrparser.Create{
+				Element: &spqrparser.DistributionDefinition{
+					ID:           "db1",
+					DefaultShard: "shard1",
+				},
+			},
+			err: nil,
+		},
+		{
+			query: "CREATE DISTRIBUTION db1 COLUMN TYPES integer DEFAULT SHARD shard1;",
+			exp: &spqrparser.Create{
+				Element: &spqrparser.DistributionDefinition{
+					ID: "db1",
+					ColTypes: []string{
+						"integer",
+					},
+					DefaultShard: "shard1",
+				},
+			},
+			err: nil,
+		},
+		{
+			query: "ALTER DISTRIBUTION distr1 DEFAULT SHARD sh1;",
+			exp: &spqrparser.Alter{
+				Element: &spqrparser.AlterDistribution{
+					Element: &spqrparser.AlterDefaultShard{
+						Shard:        "sh1",
+						Distribution: &spqrparser.DistributionSelector{ID: "distr1"},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			query: "ALTER DISTRIBUTION distr1 DROP DEFAULT SHARD;",
+			exp: &spqrparser.Alter{
+				Element: &spqrparser.AlterDistribution{
+					Element: &spqrparser.DropDefaultShard{
+						Distribution: &spqrparser.DistributionSelector{ID: "distr1"},
+					},
+				},
+			},
+			err: nil,
+		},
+	} {
+
+		tmp, err := spqrparser.Parse(tt.query)
+
+		assert.NoError(err, "query %s", tt.query)
+
+		assert.Equal(tt.exp, tmp, "query %s", tt.query)
+	}
+}


### PR DESCRIPTION
Default shards MVP
The main idea of default shard realization is creating key range with minimal value for distribution's column set.
Supported commands:
- create distribution with default shard: CREATE DISTRIBUTION testWithDefault COLUMN TYPES integer DEFAULT SHARD sh2;
- drop default shard of distribution: ALTER DISTRIBUTION testWithDefault DROP DEFAULT SHARD;
- add default shard to existed distribution: ALTER DISTRIBUTION testWithDefault DEFAULT SHARD sh2;