### PR TITLE
Temporary disable mdb tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,9 @@ jobs:
     strategy:
       matrix:
         os-version: ['jammy', 'noble']
-        version: ['13', '14', '15', '16', '17', '13-mdb', '14-mdb', '15-mdb', '16-mdb', '17-mdb']
+        version: ['13', '14', '15', '16', '17']
+        # temporary solution due to problems with yandex registry
+        # version: ['13', '14', '15', '16', '17', '13-mdb', '14-mdb', '15-mdb', '16-mdb', '17-mdb']
 
     steps:
 


### PR DESCRIPTION
Example

```
#12 23.45 E: Failed to fetch http://mirror.yandex.ru/ubuntu/pool/main/p/pam/libpam0g-dev_1.4.0-11ubuntu2.6_amd64.deb  Hash Sum mismatch
failed to solve: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends     git     sudo postgresql-$POSTGRES_VERSION     build-essential     cmake     gcc     gdb     libpam0g-dev     valgrind     libpq5     libpq-dev     vim     postgresql-common     postgresql-server-dev-$POSTGRES_VERSION     postgresql-${POSTGRES_VERSION}-pg-stat-kcache     git     python3-docutils" did not complete successfully: exit code: 100
#12 23.45    Hashes of expected file:
#12 23.45     - SHA512:8b8a2d7a7e3fb4b3e37471b1900de582b9d28c7dd3ac2a3aadae072aa4c50438d666bb92c9801f8bbbc5161352fc679f66efe87fe1abfe20250508887d3f0fb6
#12 23.45     - SHA256:94089ae55ef8088d752ef14a5839d866b66aa6a2b3a83e43c3fe5559a68b1847
#12 23.45     - SHA1:319af8e5ea28603ac1554974675499639a90295f [weak]
#12 23.45     - MD5Sum:92505dd54f31b14e5848db6f501f6805 [weak]
#12 23.45     - Filesize:116552 [weak]
#12 23.45    Hashes of received file:
#12 23.45     - SHA512:4989a661145745769903dbd2667bb6e2c0fa7a358536335d73a7c04153c601edf5a42[812](https://github.com/pg-sharding/spqr/actions/runs/16043628444/job/45270940049#step:3:813)40ac35558c31af4b3754c1d378d5fb8746fd02af3df3f661e4e77f7a
#12 23.45     - SHA256:a5e5cbe7f1d76d27b0bdf69a3bc6e88f5df0b6b737870856e0e9c3acf2dbbb1b
#12 23.45     - SHA1:99ad319b31da34715abadf638ea61d483e429073 [weak]
#12 23.45     - MD5Sum:d1a1bb331be217fb29e7b243568e6b21 [weak]
#12 23.45     - Filesize:116552 [weak]
#12 23.45    Last modification reported: Wed, 18 Jun 2025 16:28:43 +0000
#12 23.45 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
#12 ERROR: process "/bin/sh -c apt-get update && apt-get install -y --no-install-recommends     git     sudo postgresql-$POSTGRES_VERSION     build-essential     cmake     gcc     gdb     libpam0g-dev     valgrind     libpq5     libpq-dev     vim     postgresql-common     postgresql-server-dev-$POSTGRES_VERSION     postgresql-${POSTGRES_VERSION}-pg-stat-kcache     git     python3-docutils" did not complete successfully: exit code: 100
```