### PR TITLE
fix mismatch hash and nonhash types

### DIFF
--- a/pkg/coord/coord.go
+++ b/pkg/coord/coord.go
@@ -721,6 +721,9 @@ func (lc *Coordinator) AlterDistributionAttach(ctx context.Context, id string, r
 		if !r.ReplicatedRelation && len(r.DistributionKey) != len(ds.ColTypes) {
 			return fmt.Errorf("cannot attach relation %v to distribution %v: number of column mismatch", r.Name, ds.ID)
 		}
+		if err := distributions.CheckRelationKeys(ds, r); err != nil {
+			return err
+		}
 		if !r.ReplicatedRelation && len(r.ColumnSequenceMapping) > 0 {
 			return spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "sequence are supported for replicated relations only")
 		}

--- a/pkg/models/distributions/distribution.go
+++ b/pkg/models/distributions/distribution.go
@@ -331,3 +331,42 @@ func (r *DistributedRelation) GetSchema() string {
 func (r *DistributedRelation) GetFullName() string {
 	return fmt.Sprintf("%s.%s", r.GetSchema(), strings.ToLower(r.Name))
 }
+
+// CheckRelation checks dows it's keys match to distribution.
+// It takes a pointer to a Distribution struct (ds) as input and returns a pointer to a qdb.Distribution struct.
+//
+// Parameters:
+//   - ds: The Distribution
+//   - rel: The relation whitch we need attach to ds
+//
+// Returns:
+//   - error: error if a mismatch found.
+func CheckRelationKeys(ds *qdb.Distribution, rel *DistributedRelation) error {
+	if len(ds.ColTypes) != len(rel.DistributionKey) {
+		return fmt.Errorf("relation %v to distribution %v: number of column mismatch", rel.GetFullName(), ds.ID)
+	}
+	for i, colType := range ds.ColTypes {
+		switch colType {
+		case qdb.ColumnTypeVarcharHashed:
+			fallthrough
+		case qdb.ColumnTypeUinteger:
+			if len(rel.DistributionKey[i].HashFunction) < 1 {
+				return fmt.Errorf("hashed type %s of distributon %s needs hashfunction to attach %s", colType, ds.ID, rel.GetFullName())
+			}
+		case qdb.ColumnTypeInteger:
+			fallthrough
+		case qdb.ColumnTypeVarchar:
+			fallthrough
+		case qdb.ColumnTypeVarcharDeprecated:
+			fallthrough
+		case qdb.ColumnTypeUUID:
+			if len(rel.DistributionKey[i].HashFunction) > 0 {
+				return fmt.Errorf("type %s of distributon %s does not support hashfunction to attach relation %s", colType, ds.ID, rel.GetFullName())
+			}
+		default:
+			return fmt.Errorf("unknown type %s of distributon %s", colType, ds.ID)
+		}
+	}
+	return nil
+
+}

--- a/pkg/models/distributions/distribution_test.go
+++ b/pkg/models/distributions/distribution_test.go
@@ -1,10 +1,12 @@
 package distributions_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pg-sharding/spqr/pkg/models/distributions"
 	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
+	"github.com/pg-sharding/spqr/qdb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -135,5 +137,66 @@ func TestGetDistributionKeyColumns(t *testing.T) {
 			c.expected,
 			"test case %d", i,
 		)
+	}
+}
+
+func TestHashableKeyChecks(t *testing.T) {
+	assert := assert.New(t)
+	distribution1Hashed := qdb.NewDistribution("ds1", []string{qdb.ColumnTypeUinteger})
+	distribution2Hashed := qdb.NewDistribution("ds1", []string{qdb.ColumnTypeVarchar, qdb.ColumnTypeUinteger})
+	for i, tt := range []struct {
+		distribution *qdb.Distribution
+		rel          *distributions.DistributedRelation
+		err          error
+	}{
+		{
+			distribution: distribution1Hashed,
+			rel: &distributions.DistributedRelation{
+				Name: "r1",
+				DistributionKey: []distributions.DistributionKeyEntry{
+					{Column: "a", HashFunction: "ident"},
+				},
+			},
+			err: nil,
+		},
+		{
+			distribution: distribution1Hashed,
+			rel: &distributions.DistributedRelation{
+				Name: "r1",
+				DistributionKey: []distributions.DistributionKeyEntry{
+					{Column: "a"},
+				},
+			},
+			err: fmt.Errorf("hashed type uinteger of distributon ds1 needs hashfunction to attach public.r1"),
+		},
+		{
+			distribution: distribution2Hashed,
+			rel: &distributions.DistributedRelation{
+				Name: "r1",
+				DistributionKey: []distributions.DistributionKeyEntry{
+					{Column: "b"},
+					{Column: "a", HashFunction: "ident"},
+				},
+			},
+			err: nil,
+		},
+		{
+			distribution: distribution2Hashed,
+			rel: &distributions.DistributedRelation{
+				Name: "r1",
+				DistributionKey: []distributions.DistributionKeyEntry{
+					{Column: "b", HashFunction: "ident"},
+					{Column: "a"},
+				},
+			},
+			err: fmt.Errorf("type varchar of distributon ds1 does not support hashfunction to attach relation public.r1"),
+		},
+	} {
+		actual := distributions.CheckRelationKeys(tt.distribution, tt.rel)
+		if tt.err != nil {
+			assert.EqualError(actual, tt.err.Error(), fmt.Sprintf("case: %d", i))
+		} else {
+			assert.NoError(actual)
+		}
 	}
 }

--- a/test/feature/features/memqdb.feature
+++ b/test/feature/features/memqdb.feature
@@ -43,7 +43,7 @@ Feature: MemQDB save state into a file
     Given cluster is up and running
     When I execute SQL on host "router-admin"
     """
-    CREATE DISTRIBUTION ds1 COLUMN TYPES integer;
+    CREATE DISTRIBUTION ds1 COLUMN TYPES integer hash;
     CREATE DISTRIBUTION ds2 COLUMN TYPES varchar;
     ALTER DISTRIBUTION ds1 ATTACH RELATION a DISTRIBUTION KEY a_id HASH FUNCTION MURMUR;
     ALTER DISTRIBUTION ds1 ATTACH RELATION b DISTRIBUTION KEY b_id;


### PR DESCRIPTION
reproduce:
create distribution dsHash1 column types integer;
alter distribution dsHash1 aATTACH RELATION xMove DISTRIBUTION KEY w_id HASH FUNCTION murmur;

insert into xMove(w_id, s) values(12, '003') - crashes with panic

done:
- attach relation to hashed field of distributinon without hash function is forbidden
- attach relation to nonhashed field of distributinon with hash function is forbidden
