### PR TITLE
dbpool renamings + documentation

### DIFF
--- a/cmd/worldmock/worldmock.go
+++ b/cmd/worldmock/worldmock.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jackc/pgx/v5/pgproto3"
 
 	"github.com/pg-sharding/spqr/pkg/config"
-	"github.com/pg-sharding/spqr/pkg/pool"
 	"github.com/pg-sharding/spqr/pkg/shard"
 	"github.com/pg-sharding/spqr/pkg/spqrlog"
 	"github.com/pg-sharding/spqr/pkg/txstatus"
@@ -96,9 +95,7 @@ func (w *WorldMock) serv(netconn net.Conn) error {
 		return err
 	}
 
-	r := route.NewRoute(&config.BackendRule{
-		AlivenessRecheckInterval: pool.DisableAlivenessRecheck,
-	}, nil, nil)
+	r := route.NewRoute(nil, nil, nil)
 	r.SetParams(shard.ParameterSet{})
 	if err := cl.Auth(r); err != nil {
 		return err

--- a/docs/configuration/router.mdx
+++ b/docs/configuration/router.mdx
@@ -56,17 +56,21 @@ Refer to the `FrontendRule` struct in the [pkg/config/rules.go](https://github.c
 
 Backend Rule is a global setting that determines how the router connects to every shard.
 
-Refer to the `BackendRule` struct in the [pkg/config/router.go](https://github.com/pg-sharding/spqr/blob/master/pkg/config/router.go) and [pkg/config/auth_backend.go](https://github.com/pg-sharding/spqr/blob/master/pkg/config/auth_backend.go) file for the most up-to-date configuration options.
+Refer to the `BackendRule` struct in the [pkg/config/rules.go](https://github.com/pg-sharding/spqr/blob/master/pkg/config/rules.go)  and [pkg/config/auth_backend.go](https://github.com/pg-sharding/spqr/blob/master/pkg/config/auth_backend.go) file for the most up-to-date configuration options.
 
-| Setting              | Description                                                       | Possible Values            |
-|----------------------|-------------------------------------------------------------------|----------------------------|
-| `db`                 | The database name to connect to.                                  | Any valid database name    |
-| `usr`                | The username for database authentication.                         | Any valid username         |
-| `auth_rules`         | A map of authentication rules for backend connections.            | Map of string keys to `AuthBackendCfg` objects. |
-| `auth_rule`          | The default auth rule. On object with `usr` and `password` fields | An `AuthBackendCfg` object |
-| `pool_default`       | Indicates if the connection should use the default pool settings. | `true` or `false`          |
-| `connection_limit`   | The maximum number of connections allowed to the backend.         | Any integer value          |
-| `connection_retries` | The number of retries for a failed connection attempt.            | Any integer value          |
+| Setting                  | Description                                                            | Possible Values                        |
+|--------------------------|------------------------------------------------------------------------|----------------------------------------|
+| `db`                     | The database name to connect to.                                       | Any valid database name                |
+| `usr`                    | The username for database authentication.                              | Any valid username                     |
+| `auth_rules`             | A map of authentication rules for backend connections.                 | Map of string keys to `AuthBackendCfg` objects |
+| `auth_rule`              | The default auth rule. An object with `usr` and `password` fields      | An `AuthBackendCfg` object             |
+| `pool_default`           | Indicates if the connection should use the default pool settings.      | `true`, `false`                        |
+| `connection_limit`       | The maximum number of connections allowed to the backend (host shard). | Any integer value                      |
+| `connection_retries`     | The number of retries for a failed connection attempt.                 | Any integer value                      |
+| `connection_timeout`     | The timeout duration for establishing connections to the backend.      | Any valid duration (e.g., `30s`, `1m`) |
+| `keep_alive`             | The duration for keeping connections alive.                            | Any valid duration (e.g., `30s`, `1m`) |
+| `tcp_user_timeout`       | The TCP user timeout for backend connections.                          | Any valid duration (e.g., `30s`, `1m`) |
+| `health_check_interval`  | The interval between health checks for backend connections.            | Any valid duration (e.g., `30s`, `1m`) |
 
 ## Shards
 

--- a/pkg/config/rules.go
+++ b/pkg/config/rules.go
@@ -9,13 +9,12 @@ type BackendRule struct {
 	DefaultAuthRule *AuthBackendCfg            `json:"auth_rule" yaml:"auth_rule" toml:"auth_rule"`
 	PoolDefault     bool                       `json:"pool_default" yaml:"pool_default" toml:"pool_default"`
 
-	ConnectionLimit   int           `json:"connection_limit" yaml:"connection_limit" toml:"connection_limit"`
-	ConnectionRetries int           `json:"connection_retries" yaml:"connection_retries" toml:"connection_retries"`
-	ConnectionTimeout time.Duration `json:"connection_timeout" yaml:"connection_timeout" toml:"connection_timeout"`
-	KeepAlive         time.Duration `json:"keep_alive" yaml:"keep_alive" toml:"keep_alive"`
-	TcpUserTimeout    time.Duration `json:"tcp_user_timeout" yaml:"tcp_user_timeout" toml:"tcp_user_timeout"`
-
-	AlivenessRecheckInterval time.Duration `json:"aliveness_recheck_interval" yaml:"aliveness_recheck_interval" toml:"aliveness_recheck_interval"`
+	ConnectionLimit     int           `json:"connection_limit" yaml:"connection_limit" toml:"connection_limit"`
+	ConnectionRetries   int           `json:"connection_retries" yaml:"connection_retries" toml:"connection_retries"`
+	ConnectionTimeout   time.Duration `json:"connection_timeout" yaml:"connection_timeout" toml:"connection_timeout"`
+	KeepAlive           time.Duration `json:"keep_alive" yaml:"keep_alive" toml:"keep_alive"`
+	TcpUserTimeout      time.Duration `json:"tcp_user_timeout" yaml:"tcp_user_timeout" toml:"tcp_user_timeout"`
+	HealthCheckInterval time.Duration `json:"health_check_interval" yaml:"health_check_interval" toml:"health_check_interval"`
 }
 
 type FrontendRule struct {

--- a/pkg/coord/clustered_coord.go
+++ b/pkg/coord/clustered_coord.go
@@ -1746,9 +1746,7 @@ func (qc *ClusteredCoordinator) PrepareClient(nconn net.Conn, pt port.RouterPort
 		return nil, err
 	}
 
-	r := route.NewRoute(&config.BackendRule{
-		AlivenessRecheckInterval: pool.DisableAlivenessRecheck,
-	}, nil, nil)
+	r := route.NewRoute(nil, nil, nil)
 
 	params := map[string]string{
 		"client_encoding": "UTF8",

--- a/pkg/pool/dbpool.go
+++ b/pkg/pool/dbpool.go
@@ -417,7 +417,7 @@ func (s *DBPool) StopCacheWatchdog() {
 //
 // Returns:
 //   - DBPool: A DBPool interface that represents the created pool.
-func NewDBPool(mapping map[string]*config.Shard, startupParams *startup.StartupParams, preferAZ string, recheckInterval time.Duration) MultiShardTSAPool {
+func NewDBPool(mapping map[string]*config.Shard, startupParams *startup.StartupParams, preferAZ string, hostCheckInterval time.Duration) MultiShardTSAPool {
 	allocator := func(shardKey kr.ShardKey, host config.Host, rule *config.BackendRule) (shard.ShardHostInstance, error) {
 		shardConfig := mapping[shardKey.Name]
 		hostname, _, _ := net.SplitHostPort(host.Address) // TODO try to remove this
@@ -447,8 +447,8 @@ func NewDBPool(mapping map[string]*config.Shard, startupParams *startup.StartupP
 	}
 
 	// Create cache with cleanup functionality (5 minute max age)
-	/* XXX: take defaultMaxCheckAge from config */
-	dbPool.cache = NewDbpoolCacheWithCleanup(defaultMaxCheckAge, recheckInterval)
+	/* XXX: take HealthCheckInterval from config */
+	dbPool.cache = NewDbpoolCacheWithCleanup(defaultCacheTTL, hostCheckInterval)
 
 	return dbPool
 }

--- a/pkg/pool/dbpool_cache_cleanup_test.go
+++ b/pkg/pool/dbpool_cache_cleanup_test.go
@@ -23,7 +23,7 @@ func TestDBPool_CacheCleanupBasic(t *testing.T) {
 	defer dbPool.StopCacheWatchdog()
 
 	// Create a cache with a short max age for testing
-	shortCache := NewDbpoolCacheWithCleanup(100*time.Millisecond, DefaultRecheckInterval)
+	shortCache := NewDbpoolCacheWithCleanup(100*time.Millisecond, DefaultCheckInterval)
 	defer shortCache.StopWatchdog()
 
 	// Add some entries to cache

--- a/pkg/pool/dbpool_helpers.go
+++ b/pkg/pool/dbpool_helpers.go
@@ -21,7 +21,7 @@ func NewDBPoolFromMultiPool(mapping map[string]*config.Shard, sp *startup.Startu
 	}
 
 	// Create cache with cleanup functionality (5 minute max age)
-	dbPool.cache = NewDbpoolCacheWithCleanup(defaultMaxCheckAge, DefaultRecheckInterval)
+	dbPool.cache = NewDbpoolCacheWithCleanup(defaultCacheTTL, DefaultCheckInterval)
 
 	return dbPool
 }
@@ -35,7 +35,7 @@ func NewDBPoolWithAllocator(mapping map[string]*config.Shard, startupParams *sta
 	}
 
 	// Create cache with cleanup functionality (5 minute max age)
-	dbPool.cache = NewDbpoolCacheWithCleanup(defaultMaxCheckAge, DefaultRecheckInterval)
+	dbPool.cache = NewDbpoolCacheWithCleanup(defaultCacheTTL, DefaultCheckInterval)
 
 	return dbPool
 }

--- a/pkg/pool/multidbpool.go
+++ b/pkg/pool/multidbpool.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"time"
 
 	"github.com/pg-sharding/spqr/pkg/config"
 	"github.com/pg-sharding/spqr/pkg/models/kr"
@@ -65,7 +66,13 @@ func (p *MultiDBPool) Connection(db string) (shard.ShardHostInstance, error) {
 	if !exist {
 		beRule := *p.be
 		beRule.DB = db
-		pool = NewDBPool(p.mapping, &startup.StartupParams{}, "", DisableAlivenessRecheck)
+
+		/* Create a new DBPool with the given mapping and backend rule
+		 * PreferAZ is set to "", so it will not prefer any AZ
+		 * HostCheckInterval is set to 0, so it will not check host aliveness
+		 */
+
+		pool = NewDBPool(p.mapping, &startup.StartupParams{}, "", time.Duration(0))
 		pool.SetRule(&beRule)
 		p.dbs.Store(db, pool)
 	} else {

--- a/router/frontend/frontend_test.go
+++ b/router/frontend/frontend_test.go
@@ -66,10 +66,6 @@ func TestFrontendSimple(t *testing.T) {
 		Usr: "user1",
 	}
 
-	beRule := &config.BackendRule{
-		AlivenessRecheckInterval: pool.DisableAlivenessRecheck,
-	}
-
 	qr.EXPECT().Mgr().Return(mmgr).AnyTimes()
 	qr.EXPECT().SetQuery(gomock.Any()).AnyTimes()
 
@@ -127,7 +123,7 @@ func TestFrontendSimple(t *testing.T) {
 		},
 	}, nil).Times(1)
 
-	route := route.NewRoute(beRule, frrule, map[string]*config.Shard{
+	route := route.NewRoute(&config.BackendRule{}, frrule, map[string]*config.Shard{
 		"sh1": {},
 	})
 
@@ -187,10 +183,6 @@ func TestFrontendXProto(t *testing.T) {
 
 	qr.EXPECT().Mgr().Return(mmgr).AnyTimes()
 
-	beRule := &config.BackendRule{
-		AlivenessRecheckInterval: pool.DisableAlivenessRecheck,
-	}
-
 	qr.EXPECT().Mgr().Return(mmgr).AnyTimes()
 	qr.EXPECT().SelectRandomRoute(gomock.Any()).AnyTimes().Return(plan.ShardDispatchPlan{
 		ExecTarget: &kr.ShardKey{
@@ -246,7 +238,7 @@ func TestFrontendXProto(t *testing.T) {
 
 	cmngr.EXPECT().TXEndCB(gomock.Any()).AnyTimes()
 
-	route := route.NewRoute(beRule, frrule, map[string]*config.Shard{
+	route := route.NewRoute(&config.BackendRule{}, frrule, map[string]*config.Shard{
 		"sh1": {},
 	})
 

--- a/router/route/route.go
+++ b/router/route/route.go
@@ -58,10 +58,9 @@ func NewRoute(beRule *config.BackendRule, frRule *config.FrontendRule, mapping m
 		sp.SearchPath = frRule.SearchPath
 	}
 
-	recheckInterval := pool.DefaultRecheckInterval
-
+	healthCheckInterval := pool.DefaultCheckInterval
 	if beRule != nil {
-		recheckInterval = beRule.AlivenessRecheckInterval
+		healthCheckInterval = beRule.HealthCheckInterval
 	}
 
 	var preferAZ string
@@ -72,7 +71,7 @@ func NewRoute(beRule *config.BackendRule, frRule *config.FrontendRule, mapping m
 	route := &Route{
 		beRule:   beRule,
 		frRule:   frRule,
-		servPool: pool.NewDBPool(mapping, sp, preferAZ, recheckInterval),
+		servPool: pool.NewDBPool(mapping, sp, preferAZ, healthCheckInterval),
 		clPool:   client.NewClientPool(),
 		params:   shard.ParameterSet{},
 	}


### PR DESCRIPTION
I would like to suggest minor dbpool.go renaming. 
- `AlivenessRecheckInterval -> HealhCheckInterval` It sound like more convenient name.
- `DisableCheckIntervals -> remove + comments` Using zero is a common pattern.
- `maxAge -> cacheTTL` This is more descriptive.

+ update the configuration docs. What do you think?
