### PR TITLE
Coordinator retake lock

### DIFF
--- a/qdb/memqdb.go
+++ b/qdb/memqdb.go
@@ -483,7 +483,7 @@ func (q *MemQDB) RemoveTransferTx(_ context.Context, key string) error {
 //	                           COORDINATOR LOCK
 // ==============================================================================
 
-func (q *MemQDB) TryCoordinatorLock(_ context.Context) error {
+func (q *MemQDB) TryCoordinatorLock(_ context.Context, _ string) error {
 	return nil
 }
 

--- a/qdb/mock/qdb.go
+++ b/qdb/mock/qdb.go
@@ -1898,17 +1898,17 @@ func (mr *MockXQDBMockRecorder) ShareKeyRange(id any) *gomock.Call {
 }
 
 // TryCoordinatorLock mocks base method.
-func (m *MockXQDB) TryCoordinatorLock(ctx context.Context) error {
+func (m *MockXQDB) TryCoordinatorLock(ctx context.Context, addr string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TryCoordinatorLock", ctx)
+	ret := m.ctrl.Call(m, "TryCoordinatorLock", ctx, addr)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // TryCoordinatorLock indicates an expected call of TryCoordinatorLock.
-func (mr *MockXQDBMockRecorder) TryCoordinatorLock(ctx any) *gomock.Call {
+func (mr *MockXQDBMockRecorder) TryCoordinatorLock(ctx, addr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryCoordinatorLock", reflect.TypeOf((*MockXQDB)(nil).TryCoordinatorLock), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryCoordinatorLock", reflect.TypeOf((*MockXQDB)(nil).TryCoordinatorLock), ctx, addr)
 }
 
 // UnlockKeyRange mocks base method.

--- a/qdb/qdb.go
+++ b/qdb/qdb.go
@@ -132,7 +132,7 @@ type XQDB interface {
 	ShardingSchemaKeeper
 	DistributedXactKepper
 
-	TryCoordinatorLock(ctx context.Context) error
+	TryCoordinatorLock(ctx context.Context, addr string) error
 }
 
 func NewXQDB(qdbType string) (XQDB, error) {

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -529,6 +529,18 @@ Feature: Coordinator test
     context deadline exceeded
     """
 
+  Scenario: QDB is restarted
+    Given host "coordinator2" is stopped
+    And host "qdb01" is stopped
+    And we wait for "5" seconds
+    And host "qdb01" is started
+    And we wait for "5" seconds
+    When I run SQL on host "coordinator"
+    """
+    CREATE KEY RANGE krid3 FROM 31 ROUTE to sh1 FOR DISTRIBUTION ds1
+    """
+    Then command return code should be "0"
+
   Scenario: Coordinator can restart
     #
     # Coordinator is Up

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -526,6 +526,16 @@ Feature: Coordinator test
     Then command return code should be "1"
     And SQL error on host "coordinator" should match regexp
     """
+    console is in read only mode
+    """
+
+    When I run SQL on host "coordinator"
+    """
+    SHOW ROUTERS
+    """
+    Then command return code should be "1"
+    And SQL error on host "coordinator" should match regexp
+    """
     context deadline exceeded
     """
 

--- a/test/feature/spqr_test.go
+++ b/test/feature/spqr_test.go
@@ -1088,9 +1088,9 @@ func InitializeScenario(s *godog.ScenarioContext, t *testing.T, debug bool) {
 	s.Step(`^I run SQL on host "([^"]*)" as user "([^"]*)"$`, tctx.stepIRunSQLOnHostAsUser)
 	s.Step(`^I execute SQL on host "([^"]*)"$`, tctx.stepIExecuteSql)
 	s.Step(`^SQL result should match (\w+)$`, tctx.stepSQLResultShouldMatch)
-	s.Step(`^sleep$`, func() error {
+	s.Step(`^we wait for "(\d+)" seconds$`, func(sleepFor int) error {
 
-		time.Sleep(time.Hour * 10)
+		time.Sleep(time.Duration(sleepFor) * time.Second)
 
 		return nil
 	})


### PR DESCRIPTION
Now if coordinator lose lock, it won't try to retake it and will keep acting like primary coordinator. This may happen due to etcd restart, for example. 