### PR TITLE
fix panic: unknown column type

### DIFF
--- a/pkg/models/kr/keyrange.go
+++ b/pkg/models/kr/keyrange.go
@@ -141,7 +141,7 @@ func (kr *KeyRange) RecvFunc(attribInd int, val string) error {
 	case qdb.ColumnTypeUUID:
 		kr.LowerBound[attribInd] = strings.ToLower(val)
 		if err := uuid.Validate(strings.ToLower(val)); err != nil {
-			return nil, err
+			return err
 		}
 
 	default:

--- a/pkg/models/kr/keyrange.go
+++ b/pkg/models/kr/keyrange.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/pg-sharding/spqr/pkg/models/distributions"
 	"github.com/pg-sharding/spqr/pkg/models/hashfunction"
 	proto "github.com/pg-sharding/spqr/pkg/protos"
@@ -137,8 +138,14 @@ func (kr *KeyRange) RecvFunc(attribInd int, val string) error {
 		if err != nil {
 			return err
 		}
+	case qdb.ColumnTypeUUID:
+		kr.LowerBound[attribInd] = strings.ToLower(val)
+		if err := uuid.Validate(strings.ToLower(val)); err != nil {
+			return nil, err
+		}
+
 	default:
-		panic("unknown column type")
+		return fmt.Errorf("unknown column type %s", kr.ColumnTypes[attribInd])
 	}
 	return nil
 }


### PR DESCRIPTION
```
7:49AM DBG closing client client-id=824636656896
7:49AM DBG failed to close netconn error="close tcp 192.168.107.3:6432->192.168.107.1:53678: use of closed network connection"
panic: unknown column type

goroutine 87 [running]:
github.com/pg-sharding/spqr/pkg/models/kr.(*KeyRange).RecvFunc(0xc0000cd2a0, 0x0, {0xc000045a10, 0x24})
	/spqr/pkg/models/kr/keyrange.go:141 +0x457
github.com/pg-sharding/spqr/pkg/models/kr.(*KeyRange).RecvRaw(0xc0000cd2a0, {0xc0000cd620, 0x1, 0x1})
	/spqr/pkg/models/kr/keyrange.go:170 +0x134
github.com/pg-sharding/spqr/pkg/models/kr.KeyRangeBoundFromStrings({0xc000616690, 0x1, 0x1}, {0xc0000cd620, 0x1, 0x1})
	/spqr/pkg/models/kr/keyrange.go:184 +0x14a
github.com/pg-sharding/spqr/router/rmeta.(*RoutingMetadataContext).ResolveRouteHint(0xc00040c180, {0x1c474b8, 0x25b2ba0})
	/spqr/router/rmeta/rmeta.go:293 +0x634
github.com/pg-sharding/spqr/router/qrouter.(*ProxyQrouter).RouteWithRules(0xc000948180, {0x1c474b8, 0x25b2ba0}, 0xc00040c180, {0x1c372e0, 0xc0002d3a70}, {0xc000127b80, 0xa})
	/spqr/router/qrouter/proxy_routing.go:1362 +0xad
github.com/pg-sharding/spqr/router/qrouter.(*ProxyQrouter).PlanQuery(0xc000948180, {0x1c474b8, 0x25b2ba0}, {0x1c372e0, 0xc0002d3a70}, {0x7fffb064e590, 0xc0002ccd00})
	/spqr/router/qrouter/proxy_routing.go:1789 +0x1f4
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).CreateSlicePlan(0xc0002d8820)
	/spqr/router/relay/relay.go:369 +0x647
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).PrepareExecutionSlice(0xc0002d8820, {0x1c43760, 0xc00093aa50})
	/spqr/router/relay/relay.go:984 +0x225
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).ProcessSimpleQuery(0xc0002d8820, 0xc0003076c0, 0x1)
	/spqr/router/relay/relay.go:1116 +0xf0
github.com/pg-sharding/spqr/router/frontend.ProcessMessage.func1()
	/spqr/router/frontend/frontend.go:76 +0x4e
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).queryProc(0xc0002d8820, {0x0, 0x0}, 0xc000920c60)
	/spqr/router/relay/qstate.go:196 +0x10d4
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).ProcQueryAdvanced(0xc0002d8820, {0xc000294d80, 0xcb1}, {0x19c0440, 0xc000307e50}, {0x0, 0x0}, 0xc000920c60, 0x0)
	/spqr/router/relay/qstate.go:473 +0x4418
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).ProcQueryAdvancedTx(0xc0002d8820, {0xc000294d80, 0xcb1}, 0xc000920c60, 0x0, 0x1)
	/spqr/router/relay/qstate.go:85 +0x7b2
github.com/pg-sharding/spqr/router/frontend.ProcessMessage({0x1c4cfc0, 0xc000948180}, {0x1c5f8c8, 0xc0002d8820}, {0x1c422b8, 0xc0002f5640})
	/spqr/router/frontend/frontend.go:74 +0x4a2
github.com/pg-sharding/spqr/router/frontend.Frontend({0x1c4cfc0, 0xc000948180}, {0x1c65020, 0xc0002ccd00}, {0x1c486d8, 0x25b2ba0}, {0x1c49980, 0xc0000d2230})
	/spqr/router/frontend/frontend.go:131 +0x934
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).serv(0xc000374080, {0x1c4bf58, 0xc0001d8018}, 0x0)
	/spqr/router/instance/instance.go:201 +0xb5e
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run.func4()
	/spqr/router/instance/instance.go:256 +0x65
created by github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run in goroutine 50
	/spqr/router/instance/instance.go:255 +0x945
```