### PR TITLE
fix: shards healthcheck (docker-compose sample)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
         &shard-common
         image: spqr-shard-image
         healthcheck:
-            test: 'pg_isready -U postgres --dbname=postgres'
+            test: 'pg_isready -U postgres --dbname=postgres -p 6432'
             interval: 10s
             timeout: 5s
             retries: 5


### PR DESCRIPTION
Hi!

It seems there was a typo. Postgres shards listening port 6543, but pg_isready expecting by default 5432. Because of that shards always in state `unhealthy` in docker. With this fix containers eventually become `healthy`