### PR TITLE
Use spqrerror.Newf instead of fmt.Errorf in meta.go

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -284,7 +284,6 @@ netconn
 Newf
 Nofity
 noid
-nolint
 nonexistentshard
 NOSHARD
 Noticef

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -122,7 +122,7 @@ func processDrop(ctx context.Context, dstmt spqrparser.Statement, isCascade bool
 		}
 
 		if len(krs) != 0 && !isCascade {
-			return fmt.Errorf("cannot drop distribution %s because other objects depend on it\nHINT: Use DROP ... CASCADE to drop the dependent objects too.", stmt.ID) //nolint:staticcheck
+			return spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "cannot drop distribution %s because other objects depend on it\nHINT: Use DROP ... CASCADE to drop the dependent objects too.", stmt.ID)
 		}
 
 		for _, kr := range krs {
@@ -138,7 +138,7 @@ func processDrop(ctx context.Context, dstmt spqrparser.Statement, isCascade bool
 				return err
 			}
 			if len(ds.Relations) != 0 && !isCascade {
-				return fmt.Errorf("cannot drop distribution %s because there are relations attached to it\nHINT: Use DROP ... CASCADE to detach relations automatically.", stmt.ID) //nolint:staticcheck
+				return spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "cannot drop distribution %s because there are relations attached to it\nHINT: Use DROP ... CASCADE to detach relations automatically.", stmt.ID)
 			}
 
 			for _, rel := range ds.Relations {
@@ -162,7 +162,7 @@ func processDrop(ctx context.Context, dstmt spqrparser.Statement, isCascade bool
 		for _, ds := range dss {
 			if ds.Id != "default" {
 				if len(ds.Relations) != 0 && !isCascade {
-					return fmt.Errorf("cannot drop distribution %s because there are relations attached to it\nHINT: Use DROP ... CASCADE to detach relations automatically.", ds.Id) //nolint:staticcheck
+					return spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "cannot drop distribution %s because there are relations attached to it\nHINT: Use DROP ... CASCADE to detach relations automatically.", ds.Id)
 				}
 				ret = append(ret, ds.ID())
 				err = mngr.DropDistribution(ctx, ds.Id)
@@ -185,7 +185,7 @@ func processDrop(ctx context.Context, dstmt spqrparser.Statement, isCascade bool
 			}
 		}
 		if len(shardKrs) != 0 && !isCascade {
-			return fmt.Errorf("cannot drop shard %s because other objects depend on it\nHINT: Use DROP ... CASCADE to drop the dependent objects too.", stmt.ID) //nolint:staticcheck
+			return spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "cannot drop shard %s because other objects depend on it\nHINT: Use DROP ... CASCADE to drop the dependent objects too.", stmt.ID)
 		}
 		for _, kr := range shardKrs {
 			if err := mngr.DropKeyRange(ctx, kr.ID); err != nil {


### PR DESCRIPTION
Able to get rid of the last `nolint` directives