### PR TITLE
fix locks

### DIFF
--- a/qdb/memqdb.go
+++ b/qdb/memqdb.go
@@ -330,6 +330,9 @@ func (q *MemQDB) TryLockKeyRange(lock *sync.RWMutex, id string, read bool) error
 	}
 	return nil
 }
+func (q *MemQDB) FastLockKeyRange(ctx context.Context, id string) (*KeyRange, error) {
+	return q.LockKeyRange(ctx, id)
+}
 
 // TODO : unit tests
 func (q *MemQDB) LockKeyRange(_ context.Context, id string) (*KeyRange, error) {

--- a/qdb/mock/qdb.go
+++ b/qdb/mock/qdb.go
@@ -596,6 +596,21 @@ func (mr *MockQDBMockRecorder) DropShard(ctx, shardID any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropShard", reflect.TypeOf((*MockQDB)(nil).DropShard), ctx, shardID)
 }
 
+// FastLockKeyRange mocks base method.
+func (m *MockQDB) FastLockKeyRange(ctx context.Context, id string) (*qdb.KeyRange, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FastLockKeyRange", ctx, id)
+	ret0, _ := ret[0].(*qdb.KeyRange)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FastLockKeyRange indicates an expected call of FastLockKeyRange.
+func (mr *MockQDBMockRecorder) FastLockKeyRange(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FastLockKeyRange", reflect.TypeOf((*MockQDB)(nil).FastLockKeyRange), ctx, id)
+}
+
 // GetBalancerTask mocks base method.
 func (m *MockQDB) GetBalancerTask(ctx context.Context) (*qdb.BalancerTask, error) {
 	m.ctrl.T.Helper()
@@ -1496,6 +1511,21 @@ func (m *MockXQDB) DropShard(ctx context.Context, shardID string) error {
 func (mr *MockXQDBMockRecorder) DropShard(ctx, shardID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DropShard", reflect.TypeOf((*MockXQDB)(nil).DropShard), ctx, shardID)
+}
+
+// FastLockKeyRange mocks base method.
+func (m *MockXQDB) FastLockKeyRange(ctx context.Context, id string) (*qdb.KeyRange, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FastLockKeyRange", ctx, id)
+	ret0, _ := ret[0].(*qdb.KeyRange)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FastLockKeyRange indicates an expected call of FastLockKeyRange.
+func (mr *MockXQDBMockRecorder) FastLockKeyRange(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FastLockKeyRange", reflect.TypeOf((*MockXQDB)(nil).FastLockKeyRange), ctx, id)
 }
 
 // GetBalancerTask mocks base method.

--- a/qdb/qdb.go
+++ b/qdb/qdb.go
@@ -53,6 +53,7 @@ type QDB interface {
 	DropKeyRangeAll(ctx context.Context) error
 	ListKeyRanges(_ context.Context, distribution string) ([]*KeyRange, error)
 	ListAllKeyRanges(_ context.Context) ([]*KeyRange, error)
+	FastLockKeyRange(ctx context.Context, id string) (*KeyRange, error)
 	LockKeyRange(ctx context.Context, id string) (*KeyRange, error)
 	UnlockKeyRange(ctx context.Context, id string) error
 	CheckLockedKeyRange(ctx context.Context, id string) (*KeyRange, error)

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -359,6 +359,16 @@ Feature: Coordinator test
     context deadline exceeded
     """
 
+    When I run SQL on host "coordinator"
+    """
+    LOCK KEY RANGE krid1NoExistS;
+    """
+    Then SQL error on host "coordinator" should match regexp
+    """
+    cant't lock non existent key range
+    """
+
+
   Scenario: Unite non-adjacent key ranges fails
     When I run SQL on host "coordinator"
     """

--- a/test/feature/spqr_test.go
+++ b/test/feature/spqr_test.go
@@ -1117,6 +1117,9 @@ func (tctx *testContext) stepQDBShouldNotContainKRMoves() error {
 	if len(txs) == 0 {
 		return nil
 	}
+	for _, v := range txs {
+		log.Printf("txs '%#v'", v)
+	}
 	return fmt.Errorf("key range moves present")
 }
 


### PR DESCRIPTION
 0) LockKeyRange has been made threadsafe and more consistent (by checking for the existence of the lock and key range in transaction).
 1) I propose FastLockKeyRange qdb function. I propose this function for using in Split, Unite, RenameKeyRange and others which make changes ONLY in qdb. PROPOSED BEHAVIOUR for them: If lock fails at the start of that functions then function fails fast without redundant waits. If anybody wants any waits he have to make it in business-logic level. If ok I'll use FastLockKeyRange in that funct