### PR TITLE
Introduce priority-based host selection logic.

### DIFF
--- a/pkg/pool/dbpool_test.go
+++ b/pkg/pool/dbpool_test.go
@@ -469,8 +469,8 @@ func TestBuildHostOrder(t *testing.T) {
 			shuffleHosts:       false,
 			preferAZ:           "klg",
 			expectedHosts: []string{
-				"klg-234.db.yandex.net:6432",
 				"klg-123.db.yandex.net:6432",
+				"klg-234.db.yandex.net:6432",
 				"sas-123.db.yandex.net:6432",
 				"sas-234.db.yandex.net:6432",
 				"vla-123.db.yandex.net:6432",


### PR DESCRIPTION
The main purpose is to rearrange host selection logic to convert all backend feedback (aliveness, replication lag, etc) into single priority number, and run selection algorithm on numbers.

This is just an preparational patch; no behavioural changes is expected/intended