### PR TITLE
fixed func RelationFQNFromFullName params

### DIFF
--- a/router/rfqn/rfqn.go
+++ b/router/rfqn/rfqn.go
@@ -18,10 +18,10 @@ func RelationFQNFromRangeRangeVar(rv *lyx.RangeVar) *RelationFQN {
 		SchemaName:   rv.SchemaName,
 	}
 }
-func RelationFQNFromFullName(s string, t string) *RelationFQN {
+func RelationFQNFromFullName(schemaName string, tableName string) *RelationFQN {
 	return &RelationFQN{
-		RelationName: s,
-		SchemaName:   t,
+		RelationName: tableName,
+		SchemaName:   schemaName,
 	}
 }
 

--- a/router/rfqn/rfqn_test.go
+++ b/router/rfqn/rfqn_test.go
@@ -34,3 +34,10 @@ func TestParseQualifiedNameFail(t *testing.T) {
 	_, err6 := rfqn.ParseFQN(" .")
 	assert.Error(err6)
 }
+
+func TestRelationFQNFromFullName(t *testing.T) {
+	assert := assert.New(t)
+
+	fullName := rfqn.RelationFQNFromFullName("schema1", "table1")
+	assert.Equal("schema1.table1", fullName.String())
+}


### PR DESCRIPTION
fixed function "RelationFQNFromFullName" parametres which are mixed up:

```go
val, err := d.impl.ListRelationSequences(ctx, rfqn.RelationFQNFromFullName(req.SchemaName, req.Name))
...
func RelationFQNFromFullName(s string, t string) *RelationFQN {
	return &RelationFQN{
		RelationName: s,
		SchemaName:   t,
	}
}
```