### PR TITLE
Balancer: add unit tests, fix getAdjacentShards, make fit coefficient configurable

### DIFF
--- a/balancer/provider/balancer.go
+++ b/balancer/provider/balancer.go
@@ -25,11 +25,12 @@ type BalancerImpl struct {
 	coordinatorConn *grpc.ClientConn
 	threshold       []float64
 
-	shardConns    *config.DatatransferConnections
-	dsToKeyRanges map[string][]*kr.KeyRange
-	dsToKrIdx     map[string]map[string]int
-	shardKr       map[string][]string
-	krToDs        map[string]string
+	shardConns        *config.DatatransferConnections
+	dsToKeyRanges     map[string][]*kr.KeyRange
+	dsToKrIdx         map[string]map[string]int
+	shardKr           map[string][]string
+	krToDs            map[string]string
+	maxFitCoefficient float64
 }
 
 // NewBalancer creates new instance of BalancerImpl.
@@ -53,13 +54,14 @@ func NewBalancer() (*BalancerImpl, error) {
 		return nil, err
 	}
 	return &BalancerImpl{
-		shardConns:      shards,
-		coordinatorConn: conn,
-		threshold:       threshold,
-		dsToKeyRanges:   map[string][]*kr.KeyRange{},
-		dsToKrIdx:       map[string]map[string]int{},
-		shardKr:         map[string][]string{},
-		krToDs:          map[string]string{},
+		shardConns:        shards,
+		coordinatorConn:   conn,
+		threshold:         threshold,
+		dsToKeyRanges:     map[string][]*kr.KeyRange{},
+		dsToKrIdx:         map[string]map[string]int{},
+		shardKr:           map[string][]string{},
+		krToDs:            map[string]string{},
+		maxFitCoefficient: config.BalancerConfig().MaxFitCoefficient,
 	}, nil
 }
 
@@ -404,8 +406,6 @@ func (b *BalancerImpl) getKRRelations(ctx context.Context, kRange *kr.KeyRange) 
 // Returns:
 //   - string: the ID of the shard to move the data to.
 //   - error: an error if any occurred.
-//
-// TODO unit tests
 func (b *BalancerImpl) getShardToMoveTo(shardMetrics []*ShardMetrics, shardIdToMetrics map[string]*ShardMetrics, krId string, krShardId string, keyCountToMove int) (string, bool) {
 	krKeyCount := int(shardIdToMetrics[krShardId].KeyCountKR[krId])
 	shardToMetrics := shardIdToMetrics[krShardId].MetricsKR[krId]
@@ -437,8 +437,6 @@ func (b *BalancerImpl) getShardToMoveTo(shardMetrics []*ShardMetrics, shardIdToM
 // Returns:
 //   - shardId (string): the ID of the shard to move the data to.
 //   - maxKeyCount (int): the maximal possible amount of keys to move.
-//
-// TODO unit tests
 func (b *BalancerImpl) moveMaxPossible(shardMetrics []*ShardMetrics, shardIdToMetrics map[string]*ShardMetrics, krId string, krShardId string) (shardId string, maxKeyCount int) {
 	maxKeyCount = -1
 	for i := len(shardMetrics) - 1; i >= 0; i-- {
@@ -462,8 +460,6 @@ func (b *BalancerImpl) moveMaxPossible(shardMetrics []*ShardMetrics, shardIdToMe
 //
 // Returns:
 //   - bool: determines whether keys will overload the shard.
-//
-// TODO unit tests
 func (b *BalancerImpl) fitsOnShard(krMetrics []float64, keyCountToMove int, krKeyCount int, shard *ShardMetrics) bool {
 	for kind, metric := range shard.MetricsTotal {
 		meanKeyMetric := krMetrics[kind] / float64(krKeyCount)
@@ -484,14 +480,11 @@ func (b *BalancerImpl) fitsOnShard(krMetrics []float64, keyCountToMove int, krKe
 //
 // Returns:
 //   - maxCount (int): the maximal amount of keys that can be fit on the shard.
-//
-// TODO unit tests
 func (b *BalancerImpl) maxFitOnShard(krMetrics []float64, krKeyCount int64, shard *ShardMetrics) (maxCount int) {
 	maxCount = -1
 	for kind, metric := range shard.MetricsTotal {
-		// TODO move const to config
 		krMeanMetricKey := krMetrics[kind] / float64(krKeyCount)
-		count := int(0.8 * ((b.threshold[kind] - metric) / krMeanMetricKey))
+		count := int(b.maxFitCoefficient * ((b.threshold[kind] - metric) / krMeanMetricKey))
 		if count > maxCount {
 			maxCount = count
 		}
@@ -513,7 +506,7 @@ func (b *BalancerImpl) getAdjacentShards(krId string) map[string]struct{} {
 	if krIdx != 0 {
 		res[b.dsToKeyRanges[ds][krIdx-1].ShardID] = struct{}{}
 	}
-	if krIdx < len(b.dsToKeyRanges)-1 {
+	if krIdx < len(b.dsToKeyRanges[ds])-1 {
 		res[b.dsToKeyRanges[ds][krIdx+1].ShardID] = struct{}{}
 	}
 	// do not include the shard containing key range itself

--- a/balancer/provider/balancer_test.go
+++ b/balancer/provider/balancer_test.go
@@ -1,0 +1,440 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/pg-sharding/spqr/pkg/models/kr"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestBalancer() *BalancerImpl {
+	return &BalancerImpl{
+		threshold:         []float64{100.0, 1000.0, 100.0, 1000.0},
+		maxFitCoefficient: 0.8,
+		dsToKeyRanges: map[string][]*kr.KeyRange{
+			"ds1": {
+				{ID: "kr1", ShardID: "sh1"},
+				{ID: "kr2", ShardID: "sh2"},
+				{ID: "kr3", ShardID: "sh3"},
+			},
+		},
+		dsToKrIdx: map[string]map[string]int{
+			"ds1": {
+				"kr1": 0,
+				"kr2": 1,
+				"kr3": 2,
+			},
+		},
+		krToDs: map[string]string{
+			"kr1": "ds1",
+			"kr2": "ds1",
+			"kr3": "ds1",
+		},
+	}
+}
+
+func TestFitsOnShard(t *testing.T) {
+	b := createTestBalancer()
+
+	tests := []struct {
+		name           string
+		krMetrics      []float64
+		keyCountToMove int
+		krKeyCount     int
+		shard          *ShardMetrics
+		expected       bool
+	}{
+		{
+			name:           "keys fit on shard - low load",
+			krMetrics:      []float64{50.0, 500.0, 50.0, 500.0},
+			keyCountToMove: 10,
+			krKeyCount:     100,
+			shard: &ShardMetrics{
+				ShardId:      "sh1",
+				MetricsTotal: []float64{20.0, 200.0, 20.0, 200.0},
+			},
+			expected: true,
+		},
+		{
+			name:           "keys do not fit - would exceed CPU threshold",
+			krMetrics:      []float64{100.0, 500.0, 100.0, 500.0},
+			keyCountToMove: 50,
+			krKeyCount:     100,
+			shard: &ShardMetrics{
+				ShardId:      "sh2",
+				MetricsTotal: []float64{60.0, 200.0, 60.0, 200.0},
+			},
+			expected: false,
+		},
+		{
+			name:           "keys do not fit - would exceed space threshold",
+			krMetrics:      []float64{50.0, 1000.0, 50.0, 1000.0},
+			keyCountToMove: 20,
+			krKeyCount:     100,
+			shard: &ShardMetrics{
+				ShardId:      "sh3",
+				MetricsTotal: []float64{30.0, 900.0, 30.0, 900.0},
+			},
+			expected: false,
+		},
+		{
+			name:           "empty shard can accept keys",
+			krMetrics:      []float64{80.0, 800.0, 80.0, 800.0},
+			keyCountToMove: 10,
+			krKeyCount:     100,
+			shard: &ShardMetrics{
+				ShardId:      "sh4",
+				MetricsTotal: []float64{0.0, 0.0, 0.0, 0.0},
+			},
+			expected: true,
+		},
+		{
+			name:           "keys fit exactly at threshold",
+			krMetrics:      []float64{100.0, 1000.0, 100.0, 1000.0},
+			keyCountToMove: 10,
+			krKeyCount:     100,
+			shard: &ShardMetrics{
+				ShardId:      "sh5",
+				MetricsTotal: []float64{90.0, 900.0, 90.0, 900.0},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := b.fitsOnShard(tt.krMetrics, tt.keyCountToMove, tt.krKeyCount, tt.shard)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMaxFitOnShard(t *testing.T) {
+	b := createTestBalancer()
+	b.threshold = []float64{100.0, 1000.0, 100.0, 1000.0}
+
+	tests := []struct {
+		name         string
+		krMetrics    []float64
+		krKeyCount   int64
+		shard        *ShardMetrics
+		expectedMin  int
+		expectedMax  int
+		checkExact   bool
+		expectedKeys int
+	}{
+		{
+			name:       "shard can fit some keys based on CPU",
+			krMetrics:  []float64{50.0, 500.0, 50.0, 500.0},
+			krKeyCount: 100,
+			shard: &ShardMetrics{
+				ShardId:      "sh1",
+				MetricsTotal: []float64{20.0, 200.0, 20.0, 200.0},
+			},
+
+			expectedMin: 128,
+			expectedMax: 128,
+		},
+		{
+			name:       "space is limiting factor",
+			krMetrics:  []float64{10.0, 900.0, 10.0, 900.0},
+			krKeyCount: 100,
+			shard: &ShardMetrics{
+				ShardId:      "sh2",
+				MetricsTotal: []float64{10.0, 100.0, 10.0, 100.0},
+			},
+
+			expectedMin: 720,
+			expectedMax: 720,
+		},
+		{
+			name:       "shard is full",
+			krMetrics:  []float64{100.0, 1000.0, 100.0, 1000.0},
+			krKeyCount: 100,
+			shard: &ShardMetrics{
+				ShardId:      "sh3",
+				MetricsTotal: []float64{100.0, 1000.0, 100.0, 1000.0},
+			},
+			checkExact:   true,
+			expectedKeys: 0,
+		},
+		{
+			name:       "empty shard with low per-key metrics",
+			krMetrics:  []float64{10.0, 100.0, 10.0, 100.0},
+			krKeyCount: 1000,
+			shard: &ShardMetrics{
+				ShardId:      "sh4",
+				MetricsTotal: []float64{0.0, 0.0, 0.0, 0.0},
+			},
+
+			expectedMin: 8000,
+			expectedMax: 8000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := b.maxFitOnShard(tt.krMetrics, tt.krKeyCount, tt.shard)
+			if tt.checkExact {
+				assert.Equal(t, tt.expectedKeys, result)
+			} else {
+				assert.GreaterOrEqual(t, result, tt.expectedMin)
+				assert.LessOrEqual(t, result, tt.expectedMax)
+			}
+		})
+	}
+}
+
+func TestGetAdjacentShards(t *testing.T) {
+	b := createTestBalancer()
+
+	tests := []struct {
+		name     string
+		krId     string
+		expected map[string]struct{}
+	}{
+		{
+			name: "first key range has one adjacent",
+			krId: "kr1",
+			expected: map[string]struct{}{
+				"sh2": {},
+			},
+		},
+		{
+			name: "middle key range has two adjacent",
+			krId: "kr2",
+			expected: map[string]struct{}{
+				"sh1": {},
+				"sh3": {},
+			},
+		},
+		{
+			name: "last key range has one adjacent",
+			krId: "kr3",
+			expected: map[string]struct{}{
+				"sh2": {},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := b.getAdjacentShards(tt.krId)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetShardToMoveTo(t *testing.T) {
+	b := createTestBalancer()
+
+	tests := []struct {
+		name             string
+		shardMetrics     []*ShardMetrics
+		shardIdToMetrics map[string]*ShardMetrics
+		krId             string
+		krShardId        string
+		keyCountToMove   int
+		expectedShard    string
+		expectedOk       bool
+	}{
+		{
+			name: "move to adjacent shard with capacity",
+			shardMetrics: []*ShardMetrics{
+				{ShardId: "sh3", MetricsTotal: []float64{10.0, 100.0, 10.0, 100.0}},
+				{ShardId: "sh2", MetricsTotal: []float64{20.0, 200.0, 20.0, 200.0}},
+				{ShardId: "sh1", MetricsTotal: []float64{80.0, 800.0, 80.0, 800.0}},
+			},
+			shardIdToMetrics: map[string]*ShardMetrics{
+				"sh1": {
+					ShardId:      "sh1",
+					MetricsTotal: []float64{80.0, 800.0, 80.0, 800.0},
+					MetricsKR:    map[string][]float64{"kr1": {50.0, 500.0, 50.0, 500.0}},
+					KeyCountKR:   map[string]int64{"kr1": 100},
+				},
+				"sh2": {
+					ShardId:      "sh2",
+					MetricsTotal: []float64{20.0, 200.0, 20.0, 200.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+				"sh3": {
+					ShardId:      "sh3",
+					MetricsTotal: []float64{10.0, 100.0, 10.0, 100.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+			},
+			krId:           "kr1",
+			krShardId:      "sh1",
+			keyCountToMove: 10,
+			expectedShard:  "sh2",
+			expectedOk:     true,
+		},
+		{
+			name: "no shard with enough capacity",
+			shardMetrics: []*ShardMetrics{
+				{ShardId: "sh2", MetricsTotal: []float64{95.0, 950.0, 95.0, 950.0}},
+				{ShardId: "sh3", MetricsTotal: []float64{95.0, 950.0, 95.0, 950.0}},
+				{ShardId: "sh1", MetricsTotal: []float64{99.0, 990.0, 99.0, 990.0}},
+			},
+			shardIdToMetrics: map[string]*ShardMetrics{
+				"sh1": {
+					ShardId:      "sh1",
+					MetricsTotal: []float64{99.0, 990.0, 99.0, 990.0},
+					MetricsKR:    map[string][]float64{"kr1": {100.0, 1000.0, 100.0, 1000.0}},
+					KeyCountKR:   map[string]int64{"kr1": 100},
+				},
+				"sh2": {
+					ShardId:      "sh2",
+					MetricsTotal: []float64{95.0, 950.0, 95.0, 950.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+				"sh3": {
+					ShardId:      "sh3",
+					MetricsTotal: []float64{95.0, 950.0, 95.0, 950.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+			},
+			krId:           "kr1",
+			krShardId:      "sh1",
+			keyCountToMove: 50,
+			expectedShard:  "",
+			expectedOk:     false,
+		},
+		{
+			name: "prefer non-adjacent shard with more capacity",
+			shardMetrics: []*ShardMetrics{
+				{ShardId: "sh3", MetricsTotal: []float64{5.0, 50.0, 5.0, 50.0}},
+				{ShardId: "sh2", MetricsTotal: []float64{85.0, 850.0, 85.0, 850.0}},
+				{ShardId: "sh1", MetricsTotal: []float64{80.0, 800.0, 80.0, 800.0}},
+			},
+			shardIdToMetrics: map[string]*ShardMetrics{
+				"sh1": {
+					ShardId:      "sh1",
+					MetricsTotal: []float64{80.0, 800.0, 80.0, 800.0},
+					MetricsKR:    map[string][]float64{"kr1": {40.0, 400.0, 40.0, 400.0}},
+					KeyCountKR:   map[string]int64{"kr1": 100},
+				},
+				"sh2": {
+					ShardId:      "sh2",
+					MetricsTotal: []float64{85.0, 850.0, 85.0, 850.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+				"sh3": {
+					ShardId:      "sh3",
+					MetricsTotal: []float64{5.0, 50.0, 5.0, 50.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+			},
+			krId:           "kr1",
+			krShardId:      "sh1",
+			keyCountToMove: 15,
+			expectedShard:  "sh2",
+			expectedOk:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shard, ok := b.getShardToMoveTo(tt.shardMetrics, tt.shardIdToMetrics, tt.krId, tt.krShardId, tt.keyCountToMove)
+			assert.Equal(t, tt.expectedOk, ok)
+			if tt.expectedOk {
+				assert.Equal(t, tt.expectedShard, shard)
+			}
+		})
+	}
+}
+
+func TestMoveMaxPossible(t *testing.T) {
+	b := createTestBalancer()
+
+	tests := []struct {
+		name             string
+		shardMetrics     []*ShardMetrics
+		shardIdToMetrics map[string]*ShardMetrics
+		krId             string
+		krShardId        string
+		expectedShard    string
+		minKeyCount      int
+	}{
+		{
+			name: "find shard with maximum capacity",
+			shardMetrics: []*ShardMetrics{
+				{ShardId: "sh3", MetricsTotal: []float64{5.0, 50.0, 5.0, 50.0}},
+				{ShardId: "sh2", MetricsTotal: []float64{50.0, 500.0, 50.0, 500.0}},
+				{ShardId: "sh1", MetricsTotal: []float64{80.0, 800.0, 80.0, 800.0}},
+			},
+			shardIdToMetrics: map[string]*ShardMetrics{
+				"sh1": {
+					ShardId:      "sh1",
+					MetricsTotal: []float64{80.0, 800.0, 80.0, 800.0},
+					MetricsKR:    map[string][]float64{"kr1": {50.0, 500.0, 50.0, 500.0}},
+					KeyCountKR:   map[string]int64{"kr1": 100},
+				},
+				"sh2": {
+					ShardId:      "sh2",
+					MetricsTotal: []float64{50.0, 500.0, 50.0, 500.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+				"sh3": {
+					ShardId:      "sh3",
+					MetricsTotal: []float64{5.0, 50.0, 5.0, 50.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+			},
+			krId:          "kr1",
+			krShardId:     "sh1",
+			expectedShard: "sh3",
+			minKeyCount:   1,
+		},
+		{
+			name: "all shards full - return 0",
+			shardMetrics: []*ShardMetrics{
+				{ShardId: "sh2", MetricsTotal: []float64{100.0, 1000.0, 100.0, 1000.0}},
+				{ShardId: "sh3", MetricsTotal: []float64{100.0, 1000.0, 100.0, 1000.0}},
+				{ShardId: "sh1", MetricsTotal: []float64{100.0, 1000.0, 100.0, 1000.0}},
+			},
+			shardIdToMetrics: map[string]*ShardMetrics{
+				"sh1": {
+					ShardId:      "sh1",
+					MetricsTotal: []float64{100.0, 1000.0, 100.0, 1000.0},
+					MetricsKR:    map[string][]float64{"kr1": {100.0, 1000.0, 100.0, 1000.0}},
+					KeyCountKR:   map[string]int64{"kr1": 100},
+				},
+				"sh2": {
+					ShardId:      "sh2",
+					MetricsTotal: []float64{100.0, 1000.0, 100.0, 1000.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+				"sh3": {
+					ShardId:      "sh3",
+					MetricsTotal: []float64{100.0, 1000.0, 100.0, 1000.0},
+					MetricsKR:    map[string][]float64{},
+					KeyCountKR:   map[string]int64{},
+				},
+			},
+			krId:          "kr1",
+			krShardId:     "sh1",
+			expectedShard: "",
+			minKeyCount:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shard, keyCount := b.moveMaxPossible(tt.shardMetrics, tt.shardIdToMetrics, tt.krId, tt.krShardId)
+			assert.GreaterOrEqual(t, keyCount, tt.minKeyCount)
+			if tt.expectedShard != "" {
+				assert.Equal(t, tt.expectedShard, shard)
+			}
+		})
+	}
+}

--- a/pkg/config/balancer.go
+++ b/pkg/config/balancer.go
@@ -29,6 +29,8 @@ type Balancer struct {
 	MaxMoveCount int `json:"max_move_count" yaml:"max_move_count" toml:"max_move_count"`
 	KeysPerMove  int `json:"keys_per_move" yaml:"keys_per_move" toml:"keys_per_move"`
 
+	MaxFitCoefficient float64 `json:"max_fit_coefficient" yaml:"max_fit_coefficient" toml:"max_fit_coefficient"`
+
 	TimeoutSec int `json:"timeout" yaml:"timeout" toml:"timeout"`
 }
 
@@ -60,6 +62,10 @@ func LoadBalancerCfg(cfgPath string) (string, error) {
 
 	if cfgBalancer.TimeoutSec == 0 {
 		cfgBalancer.TimeoutSec = defaultBalancerTimeout
+	}
+
+	if cfgBalancer.MaxFitCoefficient == 0 {
+		cfgBalancer.MaxFitCoefficient = 0.8
 	}
 
 	configBytes, err := json.MarshalIndent(cfgBalancer, "", "  ")


### PR DESCRIPTION
- Normal operations with available capacity
- Shards at or exceeding thresholds
- Adjacent shard preference (leveraging key range locality)
- Fallback to non-adjacent shards when necessary
- Multiple metric evaluation (CPU and space)