### PR TITLE
Fix for shard feedback during executor top-slice init phase.

### DIFF
--- a/router/relay/executor.go
+++ b/router/relay/executor.go
@@ -1039,6 +1039,8 @@ func (s *QueryStateExecutorImpl) executeSliceGuts(qd *QueryDesc, topPlan plan.Pl
 			}
 		case *pgproto3.ParameterStatus:
 			/* do not resent this to client */
+		case *pgproto3.NoticeResponse:
+			/* do not resent this to client */
 		default:
 			return fmt.Errorf("unexpected %T message type in executor slice deploy", msg)
 		}


### PR DESCRIPTION
swallow notice responces