### PR TITLE
Revert to default max etcd retries and increase backoff

### DIFF
--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -38,7 +38,7 @@ func NewEtcdQDB(addr string, maxCallSendMsgSize int) (*EtcdQDB, error) {
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		},
 		MaxCallSendMsgSize: maxCallSendMsgSize,
-		MaxUnaryRetries:    3,
+		BackoffWaitBetween: 500 * time.Millisecond,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Default max retries number was actually 100, so restore default setting.