### PR TITLE
fixed show routers for regress with coordinator

### DIFF
--- a/pkg/coord/clocal_inner_test.go
+++ b/pkg/coord/clocal_inner_test.go
@@ -1,0 +1,45 @@
+package coord
+
+import (
+	"testing"
+
+	"github.com/pg-sharding/spqr/pkg/models/topology"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListRoutersInner(t *testing.T) {
+	t.Run("no host", func(t *testing.T) {
+		is := assert.New(t)
+		actual := listRoutersInner("", "7000")
+		is.Equal(topology.Router{
+			ID:    "local",
+			State: DefaultLocalRouterState,
+		}, *actual)
+	})
+	t.Run("no port", func(t *testing.T) {
+		is := assert.New(t)
+		actual := listRoutersInner("test_addr", "")
+		is.Equal(topology.Router{
+			ID:    "local",
+			State: DefaultLocalRouterState,
+		}, *actual)
+	})
+	t.Run("address without bracket", func(t *testing.T) {
+		is := assert.New(t)
+		actual := listRoutersInner("test_addr", "7000")
+		is.Equal(topology.Router{
+			ID:      DefaultRouterId,
+			Address: "[test_addr]:7000",
+			State:   DefaultLocalRouterState,
+		}, *actual)
+	})
+	t.Run("address with bracket", func(t *testing.T) {
+		is := assert.New(t)
+		actual := listRoutersInner("[test_addr]", "7000")
+		is.Equal(topology.Router{
+			ID:      DefaultRouterId,
+			Address: "[test_addr]:7000",
+			State:   DefaultLocalRouterState,
+		}, *actual)
+	})
+}

--- a/test/regress/tests/console/expected/show_routers.out
+++ b/test/regress/tests/console/expected/show_routers.out
@@ -1,6 +1,6 @@
 SHOW routers;
- router | status | client_connections |    version    | metadata_version 
---------+--------+--------------------+---------------+------------------
- local- |        | 0                  | devel-0-devel | 0
+          router          | status | client_connections |    version    | metadata_version 
+--------------------------+--------+--------------------+---------------+------------------
+ r1-[regress_router]:7000 | OPENED | 0                  | devel-0-devel | 0
 (1 row)
 


### PR DESCRIPTION
issue #1725 
"Show routers" command is unified for cluster and "single-router" installation
fixed:

regress_tests_coord   |  SHOW routers;
regress_tests_coord   | - router | status | client_connections |    version    | metadata_version 
regress_tests_coord   | ---------+--------+--------------------+---------------+------------------
regress_tests_coord   | - local- |        | 0                  | devel-0-devel | 0
regress_tests_coord   | +          router          | status | client_connections |    version    | metadata_version 
regress_tests_coord   | +--------------------------+--------+--------------------+---------------+------------------
regress_tests_coord   | + r1-[regress_router]:7000 | OPENED | 0                  | devel-0-devel | 0
regress_tests_coord   |  (1 row)



current state of regress test "console" "regress_router" with clustered installation is in attached file
[regress_20260223.log](https://github.com/user-attachments/files/25483190/regress_20260223.log)
