### PR TITLE
GetSequenceRelations implemented in adapter

### DIFF
--- a/coordinator/provider/distributions.go
+++ b/coordinator/provider/distributions.go
@@ -155,6 +155,18 @@ func (d *DistributionsServer) ListRelationSequences(ctx context.Context, req *pr
 	return &protos.ListRelationSequencesReply{ColumnSequences: val}, nil
 }
 
+func (d *DistributionsServer) GetSequenceRelations(ctx context.Context, req *protos.GetSequenceRelationsRequest) (*protos.GetSequenceRelationsReply, error) {
+	relations, err := d.impl.GetSequenceRelations(ctx, req.GetName())
+	if err != nil {
+		return nil, err
+	}
+	protoRel := make([]*protos.QualifiedName, 0, len(relations))
+	for _, rel := range relations {
+		protoRel = append(protoRel, rfqn.RelationFQNToProto(rel))
+	}
+	return &protos.GetSequenceRelationsReply{RelNames: protoRel}, nil
+}
+
 func (d *DistributionsServer) AlterSequenceDetachRelation(ctx context.Context, req *protos.AlterSequenceDetachRelationRequest) (*emptypb.Empty, error) {
 	return nil, d.impl.AlterSequenceDetachRelation(ctx, rfqn.RelationFQNFromProto(req.GetRelationName()))
 }

--- a/pkg/coord/adapter.go
+++ b/pkg/coord/adapter.go
@@ -86,7 +86,16 @@ func (a *Adapter) GetSequenceColumns(ctx context.Context, seqName string) ([]str
 
 // GetSequenceColumns implements meta.EntityMgr.
 func (a *Adapter) GetSequenceRelations(ctx context.Context, seqName string) ([]*rfqn.RelationFQN, error) {
-	return nil, spqrerror.New(spqrerror.SPQR_NOT_IMPLEMENTED, "GetSequenceRelations not implemented")
+	c := proto.NewDistributionServiceClient(a.conn)
+	resp, err := c.GetSequenceRelations(ctx, &proto.GetSequenceRelationsRequest{Name: seqName})
+	if err != nil {
+		return nil, spqrerror.CleanGrpcError(err)
+	}
+	result := make([]*rfqn.RelationFQN, 0, len(resp.GetRelNames()))
+	for _, relName := range resp.GetRelNames() {
+		result = append(result, rfqn.RelationFQNFromProto(relName))
+	}
+	return result, nil
 }
 
 // SyncReferenceRelations implements meta.EntityMgr.

--- a/pkg/protos/distribution.pb.go
+++ b/pkg/protos/distribution.pb.go
@@ -1314,6 +1314,94 @@ func (x *AlterSequenceDetachRelationRequest) GetRelationName() *QualifiedName {
 	return nil
 }
 
+type GetSequenceRelationsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSequenceRelationsRequest) Reset() {
+	*x = GetSequenceRelationsRequest{}
+	mi := &file_protos_distribution_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSequenceRelationsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSequenceRelationsRequest) ProtoMessage() {}
+
+func (x *GetSequenceRelationsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_protos_distribution_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSequenceRelationsRequest.ProtoReflect.Descriptor instead.
+func (*GetSequenceRelationsRequest) Descriptor() ([]byte, []int) {
+	return file_protos_distribution_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *GetSequenceRelationsRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type GetSequenceRelationsReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RelNames      []*QualifiedName       `protobuf:"bytes,1,rep,name=relNames,proto3" json:"relNames,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSequenceRelationsReply) Reset() {
+	*x = GetSequenceRelationsReply{}
+	mi := &file_protos_distribution_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSequenceRelationsReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSequenceRelationsReply) ProtoMessage() {}
+
+func (x *GetSequenceRelationsReply) ProtoReflect() protoreflect.Message {
+	mi := &file_protos_distribution_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSequenceRelationsReply.ProtoReflect.Descriptor instead.
+func (*GetSequenceRelationsReply) Descriptor() ([]byte, []int) {
+	return file_protos_distribution_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *GetSequenceRelationsReply) GetRelNames() []*QualifiedName {
+	if x != nil {
+		return x.RelNames
+	}
+	return nil
+}
+
 var File_protos_distribution_proto protoreflect.FileDescriptor
 
 const file_protos_distribution_proto_rawDesc = "" +
@@ -1397,7 +1485,11 @@ const file_protos_distribution_proto_rawDesc = "" +
 	" ListRelationUniqueIndexesRequest\x12\"\n" +
 	"\frelationName\x18\x01 \x01(\tR\frelationName\"]\n" +
 	"\"AlterSequenceDetachRelationRequest\x127\n" +
-	"\frelationName\x18\x01 \x01(\v2\x13.spqr.QualifiedNameR\frelationName2\xaf\x0e\n" +
+	"\frelationName\x18\x01 \x01(\v2\x13.spqr.QualifiedNameR\frelationName\"1\n" +
+	"\x1bGetSequenceRelationsRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"L\n" +
+	"\x19GetSequenceRelationsReply\x12/\n" +
+	"\brelNames\x18\x01 \x03(\v2\x13.spqr.QualifiedNameR\brelNames2\x8d\x0f\n" +
 	"\x13DistributionService\x12V\n" +
 	"\x12CreateDistribution\x12\x1f.spqr.CreateDistributionRequest\x1a\x1d.spqr.CreateDistributionReply\"\x00\x12K\n" +
 	"\x10DropDistribution\x12\x1d.spqr.DropDistributionRequest\x1a\x16.google.protobuf.Empty\"\x00\x12K\n" +
@@ -1414,7 +1506,8 @@ const file_protos_distribution_proto_rawDesc = "" +
 	"\rListSequences\x12\x16.google.protobuf.Empty\x1a\x18.spqr.ListSequencesReply\"\x00\x12_\n" +
 	"\x15ListRelationSequences\x12\".spqr.ListRelationSequencesRequest\x1a .spqr.ListRelationSequencesReply\"\x00\x12C\n" +
 	"\fDropSequence\x12\x19.spqr.DropSequenceRequest\x1a\x16.google.protobuf.Empty\"\x00\x12a\n" +
-	"\x1bAlterSequenceDetachRelation\x12(.spqr.AlterSequenceDetachRelationRequest\x1a\x16.google.protobuf.Empty\"\x00\x12K\n" +
+	"\x1bAlterSequenceDetachRelation\x12(.spqr.AlterSequenceDetachRelationRequest\x1a\x16.google.protobuf.Empty\"\x00\x12\\\n" +
+	"\x14GetSequenceRelations\x12!.spqr.GetSequenceRelationsRequest\x1a\x1f.spqr.GetSequenceRelationsReply\"\x00\x12K\n" +
 	"\x11ListUniqueIndexes\x12\x16.google.protobuf.Empty\x1a\x1c.spqr.ListUniqueIndexesReply\"\x00\x12k\n" +
 	"\x1dListDistributionUniqueIndexes\x12*.spqr.ListDistributionUniqueIndexesRequest\x1a\x1c.spqr.ListUniqueIndexesReply\"\x00\x12M\n" +
 	"\x11CreateUniqueIndex\x12\x1e.spqr.CreateUniqueIndexRequest\x1a\x16.google.protobuf.Empty\"\x00\x12I\n" +
@@ -1434,7 +1527,7 @@ func file_protos_distribution_proto_rawDescGZIP() []byte {
 	return file_protos_distribution_proto_rawDescData
 }
 
-var file_protos_distribution_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_protos_distribution_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_protos_distribution_proto_goTypes = []any{
 	(*CreateDistributionRequest)(nil),                      // 0: spqr.CreateDistributionRequest
 	(*CreateDistributionReply)(nil),                        // 1: spqr.CreateDistributionReply
@@ -1463,78 +1556,83 @@ var file_protos_distribution_proto_goTypes = []any{
 	(*ListUniqueIndexesReply)(nil),                         // 24: spqr.ListUniqueIndexesReply
 	(*ListRelationUniqueIndexesRequest)(nil),               // 25: spqr.ListRelationUniqueIndexesRequest
 	(*AlterSequenceDetachRelationRequest)(nil),             // 26: spqr.AlterSequenceDetachRelationRequest
-	nil,                                  // 27: spqr.ListRelationSequencesReply.ColumnSequencesEntry
-	nil,                                  // 28: spqr.ListUniqueIndexesReply.IndexesEntry
-	(*Distribution)(nil),                 // 29: spqr.Distribution
-	(*MetaTransactionGossipCommand)(nil), // 30: spqr.MetaTransactionGossipCommand
-	(*DistributedRelation)(nil),          // 31: spqr.DistributedRelation
-	(*QualifiedName)(nil),                // 32: spqr.QualifiedName
-	(*DistributionKeyEntry)(nil),         // 33: spqr.DistributionKeyEntry
-	(*UniqueIndex)(nil),                  // 34: spqr.UniqueIndex
-	(*emptypb.Empty)(nil),                // 35: google.protobuf.Empty
+	(*GetSequenceRelationsRequest)(nil),                    // 27: spqr.GetSequenceRelationsRequest
+	(*GetSequenceRelationsReply)(nil),                      // 28: spqr.GetSequenceRelationsReply
+	nil,                                                    // 29: spqr.ListRelationSequencesReply.ColumnSequencesEntry
+	nil,                                                    // 30: spqr.ListUniqueIndexesReply.IndexesEntry
+	(*Distribution)(nil),                                   // 31: spqr.Distribution
+	(*MetaTransactionGossipCommand)(nil),                   // 32: spqr.MetaTransactionGossipCommand
+	(*DistributedRelation)(nil),                            // 33: spqr.DistributedRelation
+	(*QualifiedName)(nil),                                  // 34: spqr.QualifiedName
+	(*DistributionKeyEntry)(nil),                           // 35: spqr.DistributionKeyEntry
+	(*UniqueIndex)(nil),                                    // 36: spqr.UniqueIndex
+	(*emptypb.Empty)(nil),                                  // 37: google.protobuf.Empty
 }
 var file_protos_distribution_proto_depIdxs = []int32{
-	29, // 0: spqr.CreateDistributionRequest.distributions:type_name -> spqr.Distribution
-	30, // 1: spqr.CreateDistributionReply.metaCmdList:type_name -> spqr.MetaTransactionGossipCommand
-	29, // 2: spqr.ListDistributionsReply.distributions:type_name -> spqr.Distribution
-	31, // 3: spqr.AlterDistributionAttachRequest.relations:type_name -> spqr.DistributedRelation
-	32, // 4: spqr.AlterDistributionDetachRequest.relNames:type_name -> spqr.QualifiedName
-	33, // 5: spqr.AlterDistributedRelationDistributionKeyRequest.distributionKey:type_name -> spqr.DistributionKeyEntry
-	31, // 6: spqr.AlterDistributedRelationRequest.relation:type_name -> spqr.DistributedRelation
-	29, // 7: spqr.GetDistributionReply.distribution:type_name -> spqr.Distribution
-	29, // 8: spqr.GetRelationDistributionReply.distribution:type_name -> spqr.Distribution
-	27, // 9: spqr.ListRelationSequencesReply.columnSequences:type_name -> spqr.ListRelationSequencesReply.ColumnSequencesEntry
-	34, // 10: spqr.CreateUniqueIndexRequest.idx:type_name -> spqr.UniqueIndex
-	28, // 11: spqr.ListUniqueIndexesReply.indexes:type_name -> spqr.ListUniqueIndexesReply.IndexesEntry
-	32, // 12: spqr.AlterSequenceDetachRelationRequest.relationName:type_name -> spqr.QualifiedName
-	34, // 13: spqr.ListUniqueIndexesReply.IndexesEntry.value:type_name -> spqr.UniqueIndex
-	0,  // 14: spqr.DistributionService.CreateDistribution:input_type -> spqr.CreateDistributionRequest
-	3,  // 15: spqr.DistributionService.DropDistribution:input_type -> spqr.DropDistributionRequest
-	35, // 16: spqr.DistributionService.ListDistributions:input_type -> google.protobuf.Empty
-	4,  // 17: spqr.DistributionService.AlterDistributionAttach:input_type -> spqr.AlterDistributionAttachRequest
-	5,  // 18: spqr.DistributionService.AlterDistributionDetach:input_type -> spqr.AlterDistributionDetachRequest
-	8,  // 19: spqr.DistributionService.AlterDistributedRelation:input_type -> spqr.AlterDistributedRelationRequest
-	6,  // 20: spqr.DistributionService.AlterDistributedRelationSchema:input_type -> spqr.AlterDistributedRelationSchemaRequest
-	7,  // 21: spqr.DistributionService.AlterDistributedRelationDistributionKey:input_type -> spqr.AlterDistributedRelationDistributionKeyRequest
-	9,  // 22: spqr.DistributionService.GetDistribution:input_type -> spqr.GetDistributionRequest
-	11, // 23: spqr.DistributionService.GetRelationDistribution:input_type -> spqr.GetRelationDistributionRequest
-	13, // 24: spqr.DistributionService.NextRange:input_type -> spqr.NextRangeRequest
-	15, // 25: spqr.DistributionService.CurrVal:input_type -> spqr.CurrValRequest
-	35, // 26: spqr.DistributionService.ListSequences:input_type -> google.protobuf.Empty
-	19, // 27: spqr.DistributionService.ListRelationSequences:input_type -> spqr.ListRelationSequencesRequest
-	18, // 28: spqr.DistributionService.DropSequence:input_type -> spqr.DropSequenceRequest
-	26, // 29: spqr.DistributionService.AlterSequenceDetachRelation:input_type -> spqr.AlterSequenceDetachRelationRequest
-	35, // 30: spqr.DistributionService.ListUniqueIndexes:input_type -> google.protobuf.Empty
-	23, // 31: spqr.DistributionService.ListDistributionUniqueIndexes:input_type -> spqr.ListDistributionUniqueIndexesRequest
-	21, // 32: spqr.DistributionService.CreateUniqueIndex:input_type -> spqr.CreateUniqueIndexRequest
-	22, // 33: spqr.DistributionService.DropUniqueIndex:input_type -> spqr.DropUniqueIndexRequest
-	25, // 34: spqr.DistributionService.ListRelationUniqueIndexes:input_type -> spqr.ListRelationUniqueIndexesRequest
-	1,  // 35: spqr.DistributionService.CreateDistribution:output_type -> spqr.CreateDistributionReply
-	35, // 36: spqr.DistributionService.DropDistribution:output_type -> google.protobuf.Empty
-	2,  // 37: spqr.DistributionService.ListDistributions:output_type -> spqr.ListDistributionsReply
-	35, // 38: spqr.DistributionService.AlterDistributionAttach:output_type -> google.protobuf.Empty
-	35, // 39: spqr.DistributionService.AlterDistributionDetach:output_type -> google.protobuf.Empty
-	35, // 40: spqr.DistributionService.AlterDistributedRelation:output_type -> google.protobuf.Empty
-	35, // 41: spqr.DistributionService.AlterDistributedRelationSchema:output_type -> google.protobuf.Empty
-	35, // 42: spqr.DistributionService.AlterDistributedRelationDistributionKey:output_type -> google.protobuf.Empty
-	10, // 43: spqr.DistributionService.GetDistribution:output_type -> spqr.GetDistributionReply
-	12, // 44: spqr.DistributionService.GetRelationDistribution:output_type -> spqr.GetRelationDistributionReply
-	14, // 45: spqr.DistributionService.NextRange:output_type -> spqr.NextRangeReply
-	16, // 46: spqr.DistributionService.CurrVal:output_type -> spqr.CurrValReply
-	17, // 47: spqr.DistributionService.ListSequences:output_type -> spqr.ListSequencesReply
-	20, // 48: spqr.DistributionService.ListRelationSequences:output_type -> spqr.ListRelationSequencesReply
-	35, // 49: spqr.DistributionService.DropSequence:output_type -> google.protobuf.Empty
-	35, // 50: spqr.DistributionService.AlterSequenceDetachRelation:output_type -> google.protobuf.Empty
-	24, // 51: spqr.DistributionService.ListUniqueIndexes:output_type -> spqr.ListUniqueIndexesReply
-	24, // 52: spqr.DistributionService.ListDistributionUniqueIndexes:output_type -> spqr.ListUniqueIndexesReply
-	35, // 53: spqr.DistributionService.CreateUniqueIndex:output_type -> google.protobuf.Empty
-	35, // 54: spqr.DistributionService.DropUniqueIndex:output_type -> google.protobuf.Empty
-	24, // 55: spqr.DistributionService.ListRelationUniqueIndexes:output_type -> spqr.ListUniqueIndexesReply
-	35, // [35:56] is the sub-list for method output_type
-	14, // [14:35] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	31, // 0: spqr.CreateDistributionRequest.distributions:type_name -> spqr.Distribution
+	32, // 1: spqr.CreateDistributionReply.metaCmdList:type_name -> spqr.MetaTransactionGossipCommand
+	31, // 2: spqr.ListDistributionsReply.distributions:type_name -> spqr.Distribution
+	33, // 3: spqr.AlterDistributionAttachRequest.relations:type_name -> spqr.DistributedRelation
+	34, // 4: spqr.AlterDistributionDetachRequest.relNames:type_name -> spqr.QualifiedName
+	35, // 5: spqr.AlterDistributedRelationDistributionKeyRequest.distributionKey:type_name -> spqr.DistributionKeyEntry
+	33, // 6: spqr.AlterDistributedRelationRequest.relation:type_name -> spqr.DistributedRelation
+	31, // 7: spqr.GetDistributionReply.distribution:type_name -> spqr.Distribution
+	31, // 8: spqr.GetRelationDistributionReply.distribution:type_name -> spqr.Distribution
+	29, // 9: spqr.ListRelationSequencesReply.columnSequences:type_name -> spqr.ListRelationSequencesReply.ColumnSequencesEntry
+	36, // 10: spqr.CreateUniqueIndexRequest.idx:type_name -> spqr.UniqueIndex
+	30, // 11: spqr.ListUniqueIndexesReply.indexes:type_name -> spqr.ListUniqueIndexesReply.IndexesEntry
+	34, // 12: spqr.AlterSequenceDetachRelationRequest.relationName:type_name -> spqr.QualifiedName
+	34, // 13: spqr.GetSequenceRelationsReply.relNames:type_name -> spqr.QualifiedName
+	36, // 14: spqr.ListUniqueIndexesReply.IndexesEntry.value:type_name -> spqr.UniqueIndex
+	0,  // 15: spqr.DistributionService.CreateDistribution:input_type -> spqr.CreateDistributionRequest
+	3,  // 16: spqr.DistributionService.DropDistribution:input_type -> spqr.DropDistributionRequest
+	37, // 17: spqr.DistributionService.ListDistributions:input_type -> google.protobuf.Empty
+	4,  // 18: spqr.DistributionService.AlterDistributionAttach:input_type -> spqr.AlterDistributionAttachRequest
+	5,  // 19: spqr.DistributionService.AlterDistributionDetach:input_type -> spqr.AlterDistributionDetachRequest
+	8,  // 20: spqr.DistributionService.AlterDistributedRelation:input_type -> spqr.AlterDistributedRelationRequest
+	6,  // 21: spqr.DistributionService.AlterDistributedRelationSchema:input_type -> spqr.AlterDistributedRelationSchemaRequest
+	7,  // 22: spqr.DistributionService.AlterDistributedRelationDistributionKey:input_type -> spqr.AlterDistributedRelationDistributionKeyRequest
+	9,  // 23: spqr.DistributionService.GetDistribution:input_type -> spqr.GetDistributionRequest
+	11, // 24: spqr.DistributionService.GetRelationDistribution:input_type -> spqr.GetRelationDistributionRequest
+	13, // 25: spqr.DistributionService.NextRange:input_type -> spqr.NextRangeRequest
+	15, // 26: spqr.DistributionService.CurrVal:input_type -> spqr.CurrValRequest
+	37, // 27: spqr.DistributionService.ListSequences:input_type -> google.protobuf.Empty
+	19, // 28: spqr.DistributionService.ListRelationSequences:input_type -> spqr.ListRelationSequencesRequest
+	18, // 29: spqr.DistributionService.DropSequence:input_type -> spqr.DropSequenceRequest
+	26, // 30: spqr.DistributionService.AlterSequenceDetachRelation:input_type -> spqr.AlterSequenceDetachRelationRequest
+	27, // 31: spqr.DistributionService.GetSequenceRelations:input_type -> spqr.GetSequenceRelationsRequest
+	37, // 32: spqr.DistributionService.ListUniqueIndexes:input_type -> google.protobuf.Empty
+	23, // 33: spqr.DistributionService.ListDistributionUniqueIndexes:input_type -> spqr.ListDistributionUniqueIndexesRequest
+	21, // 34: spqr.DistributionService.CreateUniqueIndex:input_type -> spqr.CreateUniqueIndexRequest
+	22, // 35: spqr.DistributionService.DropUniqueIndex:input_type -> spqr.DropUniqueIndexRequest
+	25, // 36: spqr.DistributionService.ListRelationUniqueIndexes:input_type -> spqr.ListRelationUniqueIndexesRequest
+	1,  // 37: spqr.DistributionService.CreateDistribution:output_type -> spqr.CreateDistributionReply
+	37, // 38: spqr.DistributionService.DropDistribution:output_type -> google.protobuf.Empty
+	2,  // 39: spqr.DistributionService.ListDistributions:output_type -> spqr.ListDistributionsReply
+	37, // 40: spqr.DistributionService.AlterDistributionAttach:output_type -> google.protobuf.Empty
+	37, // 41: spqr.DistributionService.AlterDistributionDetach:output_type -> google.protobuf.Empty
+	37, // 42: spqr.DistributionService.AlterDistributedRelation:output_type -> google.protobuf.Empty
+	37, // 43: spqr.DistributionService.AlterDistributedRelationSchema:output_type -> google.protobuf.Empty
+	37, // 44: spqr.DistributionService.AlterDistributedRelationDistributionKey:output_type -> google.protobuf.Empty
+	10, // 45: spqr.DistributionService.GetDistribution:output_type -> spqr.GetDistributionReply
+	12, // 46: spqr.DistributionService.GetRelationDistribution:output_type -> spqr.GetRelationDistributionReply
+	14, // 47: spqr.DistributionService.NextRange:output_type -> spqr.NextRangeReply
+	16, // 48: spqr.DistributionService.CurrVal:output_type -> spqr.CurrValReply
+	17, // 49: spqr.DistributionService.ListSequences:output_type -> spqr.ListSequencesReply
+	20, // 50: spqr.DistributionService.ListRelationSequences:output_type -> spqr.ListRelationSequencesReply
+	37, // 51: spqr.DistributionService.DropSequence:output_type -> google.protobuf.Empty
+	37, // 52: spqr.DistributionService.AlterSequenceDetachRelation:output_type -> google.protobuf.Empty
+	28, // 53: spqr.DistributionService.GetSequenceRelations:output_type -> spqr.GetSequenceRelationsReply
+	24, // 54: spqr.DistributionService.ListUniqueIndexes:output_type -> spqr.ListUniqueIndexesReply
+	24, // 55: spqr.DistributionService.ListDistributionUniqueIndexes:output_type -> spqr.ListUniqueIndexesReply
+	37, // 56: spqr.DistributionService.CreateUniqueIndex:output_type -> google.protobuf.Empty
+	37, // 57: spqr.DistributionService.DropUniqueIndex:output_type -> google.protobuf.Empty
+	24, // 58: spqr.DistributionService.ListRelationUniqueIndexes:output_type -> spqr.ListUniqueIndexesReply
+	37, // [37:59] is the sub-list for method output_type
+	15, // [15:37] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_protos_distribution_proto_init() }
@@ -1551,7 +1649,7 @@ func file_protos_distribution_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_protos_distribution_proto_rawDesc), len(file_protos_distribution_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   29,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/protos/distribution_grpc.pb.go
+++ b/pkg/protos/distribution_grpc.pb.go
@@ -36,6 +36,7 @@ const (
 	DistributionService_ListRelationSequences_FullMethodName                   = "/spqr.DistributionService/ListRelationSequences"
 	DistributionService_DropSequence_FullMethodName                            = "/spqr.DistributionService/DropSequence"
 	DistributionService_AlterSequenceDetachRelation_FullMethodName             = "/spqr.DistributionService/AlterSequenceDetachRelation"
+	DistributionService_GetSequenceRelations_FullMethodName                    = "/spqr.DistributionService/GetSequenceRelations"
 	DistributionService_ListUniqueIndexes_FullMethodName                       = "/spqr.DistributionService/ListUniqueIndexes"
 	DistributionService_ListDistributionUniqueIndexes_FullMethodName           = "/spqr.DistributionService/ListDistributionUniqueIndexes"
 	DistributionService_CreateUniqueIndex_FullMethodName                       = "/spqr.DistributionService/CreateUniqueIndex"
@@ -63,6 +64,7 @@ type DistributionServiceClient interface {
 	ListRelationSequences(ctx context.Context, in *ListRelationSequencesRequest, opts ...grpc.CallOption) (*ListRelationSequencesReply, error)
 	DropSequence(ctx context.Context, in *DropSequenceRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	AlterSequenceDetachRelation(ctx context.Context, in *AlterSequenceDetachRelationRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	GetSequenceRelations(ctx context.Context, in *GetSequenceRelationsRequest, opts ...grpc.CallOption) (*GetSequenceRelationsReply, error)
 	ListUniqueIndexes(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListUniqueIndexesReply, error)
 	ListDistributionUniqueIndexes(ctx context.Context, in *ListDistributionUniqueIndexesRequest, opts ...grpc.CallOption) (*ListUniqueIndexesReply, error)
 	CreateUniqueIndex(ctx context.Context, in *CreateUniqueIndexRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
@@ -238,6 +240,16 @@ func (c *distributionServiceClient) AlterSequenceDetachRelation(ctx context.Cont
 	return out, nil
 }
 
+func (c *distributionServiceClient) GetSequenceRelations(ctx context.Context, in *GetSequenceRelationsRequest, opts ...grpc.CallOption) (*GetSequenceRelationsReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetSequenceRelationsReply)
+	err := c.cc.Invoke(ctx, DistributionService_GetSequenceRelations_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *distributionServiceClient) ListUniqueIndexes(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*ListUniqueIndexesReply, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListUniqueIndexesReply)
@@ -308,6 +320,7 @@ type DistributionServiceServer interface {
 	ListRelationSequences(context.Context, *ListRelationSequencesRequest) (*ListRelationSequencesReply, error)
 	DropSequence(context.Context, *DropSequenceRequest) (*emptypb.Empty, error)
 	AlterSequenceDetachRelation(context.Context, *AlterSequenceDetachRelationRequest) (*emptypb.Empty, error)
+	GetSequenceRelations(context.Context, *GetSequenceRelationsRequest) (*GetSequenceRelationsReply, error)
 	ListUniqueIndexes(context.Context, *emptypb.Empty) (*ListUniqueIndexesReply, error)
 	ListDistributionUniqueIndexes(context.Context, *ListDistributionUniqueIndexesRequest) (*ListUniqueIndexesReply, error)
 	CreateUniqueIndex(context.Context, *CreateUniqueIndexRequest) (*emptypb.Empty, error)
@@ -370,6 +383,9 @@ func (UnimplementedDistributionServiceServer) DropSequence(context.Context, *Dro
 }
 func (UnimplementedDistributionServiceServer) AlterSequenceDetachRelation(context.Context, *AlterSequenceDetachRelationRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method AlterSequenceDetachRelation not implemented")
+}
+func (UnimplementedDistributionServiceServer) GetSequenceRelations(context.Context, *GetSequenceRelationsRequest) (*GetSequenceRelationsReply, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSequenceRelations not implemented")
 }
 func (UnimplementedDistributionServiceServer) ListUniqueIndexes(context.Context, *emptypb.Empty) (*ListUniqueIndexesReply, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListUniqueIndexes not implemented")
@@ -695,6 +711,24 @@ func _DistributionService_AlterSequenceDetachRelation_Handler(srv interface{}, c
 	return interceptor(ctx, in, info, handler)
 }
 
+func _DistributionService_GetSequenceRelations_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSequenceRelationsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(DistributionServiceServer).GetSequenceRelations(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: DistributionService_GetSequenceRelations_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(DistributionServiceServer).GetSequenceRelations(ctx, req.(*GetSequenceRelationsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _DistributionService_ListUniqueIndexes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(emptypb.Empty)
 	if err := dec(in); err != nil {
@@ -855,6 +889,10 @@ var DistributionService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AlterSequenceDetachRelation",
 			Handler:    _DistributionService_AlterSequenceDetachRelation_Handler,
+		},
+		{
+			MethodName: "GetSequenceRelations",
+			Handler:    _DistributionService_GetSequenceRelations_Handler,
 		},
 		{
 			MethodName: "ListUniqueIndexes",

--- a/protos/distribution.proto
+++ b/protos/distribution.proto
@@ -130,6 +130,14 @@ message AlterSequenceDetachRelationRequest {
   QualifiedName relationName = 1;
 }
 
+message GetSequenceRelationsRequest {
+  string name  = 1;
+}
+
+message GetSequenceRelationsReply {
+  repeated QualifiedName relNames = 1;
+}
+
 service DistributionService {
   rpc CreateDistribution(CreateDistributionRequest) returns (CreateDistributionReply) {}
   rpc DropDistribution(DropDistributionRequest) returns (google.protobuf.Empty) {}
@@ -152,6 +160,7 @@ service DistributionService {
   rpc ListRelationSequences(ListRelationSequencesRequest) returns (ListRelationSequencesReply) {}
   rpc DropSequence(DropSequenceRequest) returns (google.protobuf.Empty) {}
   rpc AlterSequenceDetachRelation(AlterSequenceDetachRelationRequest) returns (google.protobuf.Empty) {}
+  rpc GetSequenceRelations(GetSequenceRelationsRequest) returns (GetSequenceRelationsReply) {}
 
   rpc ListUniqueIndexes(google.protobuf.Empty) returns (ListUniqueIndexesReply) {}
   rpc ListDistributionUniqueIndexes(ListDistributionUniqueIndexesRequest) returns (ListUniqueIndexesReply) {}


### PR DESCRIPTION
issue #1725

fixed in regress with coordinator setup:
```
regress_tests_coord   |  DROP SEQUENCE t1_id;
regress_tests_coord   | - name  
regress_tests_coord   | --------
regress_tests_coord   | - t1_id
regress_tests_coord   | -(1 row)
regress_tests_coord   | -
regress_tests_coord   | +ERROR:  GetSequenceRelations not implemented
regress_tests_coord   |  DROP SEQUENCE t2_id CASCADE;
regress_tests_coord   | - name  
regress_tests_coord   | --------
regress_tests_coord   | - t2_id
```

There is only one error left in the first step of the regression test. See attached file.
[regress_20260303.log](https://github.com/user-attachments/files/25720748/regress_20260303.log)
