### PR TITLE
fix error message for regress in clustered mode

### DIFF
--- a/coordinator/provider/rrelations.go
+++ b/coordinator/provider/rrelations.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pg-sharding/spqr/coordinator"
 	protos "github.com/pg-sharding/spqr/pkg/protos"
@@ -43,8 +42,4 @@ func (rr *ReferenceRelationServer) DropReferenceRelations(ctx context.Context, r
 		}
 	}
 	return nil, nil
-}
-
-func (rr *ReferenceRelationServer) SyncReferenceRelations(_ context.Context, _ *protos.SyncReferenceRelationsRequest) (*emptypb.Empty, error) {
-	return nil, fmt.Errorf("request is unprocessable in router")
 }

--- a/pkg/coord/adapter.go
+++ b/pkg/coord/adapter.go
@@ -100,18 +100,7 @@ func (a *Adapter) GetSequenceRelations(ctx context.Context, seqName string) ([]*
 
 // SyncReferenceRelations implements meta.EntityMgr.
 func (a *Adapter) SyncReferenceRelations(ctx context.Context, ids []*rfqn.RelationFQN, destShard string) error {
-	c := proto.NewReferenceRelationsServiceClient(a.conn)
-
-	qRels := []*proto.QualifiedName{}
-	for _, r := range ids {
-		qRels = append(qRels, rfqn.RelationFQNToProto(r))
-	}
-
-	_, err := c.SyncReferenceRelations(ctx, &proto.SyncReferenceRelationsRequest{
-		Relations: qRels,
-		ShardId:   destShard,
-	})
-	return spqrerror.CleanGrpcError(err)
+	return fmt.Errorf("request is unprocessable in router")
 }
 
 // AlterReferenceRelationStorage implements meta.EntityMgr.


### PR DESCRIPTION
issue #1725
fixed
```
regress_tests_coord   | not ok 18    - reference_table                           110 ms
...
regress_tests_coord   |  SYNC REFERENCE TABLES ON sh1;
regress_tests_coord   |  ERROR:  SYNC REFERENCE TABLES/RELATIONS currently unsupported
regress_tests_coord   |  SYNC REFERENCE TABLE zz2 ON sh1;
regress_tests_coord   | -ERROR:  request is unprocessable in router
regress_tests_coord   | +ERROR:  method SyncReferenceRelations not implemented
```