### PR TITLE
Support QdbAddrs with multiple choice in Coordinator config

### DIFF
--- a/cmd/mover/main.go
+++ b/cmd/mover/main.go
@@ -156,7 +156,7 @@ func main() {
 		return
 	}
 
-	db, err := qdb.NewEtcdQDB(*etcdAddr, 0)
+	db, err := qdb.NewEtcdQDB([]string{*etcdAddr}, 0)
 	if err != nil {
 		spqrlog.Zero.Error().Err(err).Msg("")
 		return

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -367,7 +367,7 @@ var runCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			e := instance.NewEtcdMetadataBootstrapper(config.CoordinatorConfig().QdbAddr)
+			e := instance.NewEtcdMetadataBootstrapper(config.CoordinatorConfig().QdbAddrs)
 			if err := e.InitializeMetadata(ctx, router); err != nil {
 				return err
 			}

--- a/pkg/config/coordinator.go
+++ b/pkg/config/coordinator.go
@@ -15,10 +15,12 @@ import (
 var cfgCoordinator Coordinator
 
 type Coordinator struct {
-	LogFileName          string          `json:"log_filename" toml:"log_filename" yaml:"log_filename"`
-	LogLevel             string          `json:"log_level" toml:"log_level" yaml:"log_level"`
-	PrettyLogging        bool            `json:"pretty_logging" toml:"pretty_logging" yaml:"pretty_logging"`
+	LogFileName   string `json:"log_filename" toml:"log_filename" yaml:"log_filename"`
+	LogLevel      string `json:"log_level" toml:"log_level" yaml:"log_level"`
+	PrettyLogging bool   `json:"pretty_logging" toml:"pretty_logging" yaml:"pretty_logging"`
+	// QdbAddr is deprecated, use QdbAddrs instead
 	QdbAddr              string          `json:"qdb_addr" toml:"qdb_addr" yaml:"qdb_addr"`
+	QdbAddrs             []string        `json:"qdb_addrs" toml:"qdb_addrs" yaml:"qdb_addrs"`
 	CoordinatorPort      string          `json:"coordinator_port" toml:"coordinator_port" yaml:"coordinator_port"`
 	GrpcApiPort          string          `json:"grpc_api_port" toml:"grpc_api_port" yaml:"grpc_api_port"`
 	Host                 string          `json:"host" toml:"host" yaml:"host"`
@@ -73,6 +75,10 @@ func LoadCoordinatorCfg(cfgPath string) (string, error) {
 
 	if err := initCoordinatorConfig(file, cfgPath, &cCfg); err != nil {
 		return "", err
+	}
+
+	if cCfg.QdbAddr != "" && cCfg.QdbAddrs == nil {
+		cCfg.QdbAddrs = []string{cCfg.QdbAddr}
 	}
 
 	configBytes, err := json.MarshalIndent(&cCfg, "", "  ")

--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -31,9 +31,9 @@ type EtcdQDB struct {
 
 var _ XQDB = &EtcdQDB{}
 
-func NewEtcdQDB(addr string, maxCallSendMsgSize int) (*EtcdQDB, error) {
+func NewEtcdQDB(addrs []string, maxCallSendMsgSize int) (*EtcdQDB, error) {
 	cli, err := clientv3.New(clientv3.Config{
-		Endpoints: []string{addr},
+		Endpoints: addrs,
 		DialOptions: []grpc.DialOption{
 			grpc.WithTransportCredentials(insecure.NewCredentials()),
 		},
@@ -45,7 +45,7 @@ func NewEtcdQDB(addr string, maxCallSendMsgSize int) (*EtcdQDB, error) {
 	}
 
 	spqrlog.Zero.Debug().
-		Str("address", addr).
+		Strs("addresses", addrs).
 		Uint("client", spqrlog.GetPointer(cli)).
 		Msg("etcdqdb: NewEtcdQDB")
 

--- a/qdb/qdb.go
+++ b/qdb/qdb.go
@@ -208,7 +208,7 @@ type XQDB interface {
 func NewXQDB(qdbType string) (XQDB, error) {
 	switch qdbType {
 	case "etcd":
-		return NewEtcdQDB(config.CoordinatorConfig().QdbAddr, config.CoordinatorConfig().EtcdMaxSendBytes)
+		return NewEtcdQDB(config.CoordinatorConfig().QdbAddrs, config.CoordinatorConfig().EtcdMaxSendBytes)
 	case "mem":
 		return GetMemQDB()
 	default:

--- a/router/instance/etcd.go
+++ b/router/instance/etcd.go
@@ -16,13 +16,13 @@ import (
 )
 
 type EtcdMetadataBootstrapper struct {
-	QdbAddr string
+	QdbAddrs []string
 }
 
 // InitializeMetadata implements RouterMetadataBootstrapper.
 // TODO: pack TranEntityManager commands to batches
 func (e *EtcdMetadataBootstrapper) InitializeMetadata(ctx context.Context, r RouterInstance) error {
-	etcdConn, err := qdb.NewEtcdQDB(e.QdbAddr, 0)
+	etcdConn, err := qdb.NewEtcdQDB(e.QdbAddrs, 0)
 	if err != nil {
 		return err
 	}
@@ -165,6 +165,6 @@ func (e *EtcdMetadataBootstrapper) InitializeMetadata(ctx context.Context, r Rou
 	return nil
 }
 
-func NewEtcdMetadataBootstrapper(QdbAddr string) RouterMetadataBootstrapper {
-	return &EtcdMetadataBootstrapper{QdbAddr: QdbAddr}
+func NewEtcdMetadataBootstrapper(QdbAddrs []string) RouterMetadataBootstrapper {
+	return &EtcdMetadataBootstrapper{QdbAddrs: QdbAddrs}
 }

--- a/test/etcdqdb_integration/etcdqdb_test.go
+++ b/test/etcdqdb_integration/etcdqdb_test.go
@@ -61,7 +61,7 @@ func cleanupDb(ctx context.Context, db *qdb.EtcdQDB) error {
 }
 
 func setupSubTest(ctx context.Context) (*qdb.EtcdQDB, error) {
-	db, err := qdb.NewEtcdQDB(fmt.Sprintf("http://localhost:%d", EtcdPort), 0)
+	db, err := qdb.NewEtcdQDB([]string{fmt.Sprintf("http://localhost:%d", EtcdPort)}, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to SPQR QDB: %s", err)
 	}

--- a/test/feature/spqr_test.go
+++ b/test/feature/spqr_test.go
@@ -700,7 +700,7 @@ func (tctx *testContext) stepClusterIsUpAndRunning() error {
 				return fmt.Errorf("failed to connect to SPQR QDB %s: %s", service, err)
 			}
 
-			db, err := qdb.NewEtcdQDB(addr, 0)
+			db, err := qdb.NewEtcdQDB([]string{addr}, 0)
 			if err != nil {
 				return fmt.Errorf("failed to connect to SPQR QDB %s: %s", service, err)
 			}
@@ -847,7 +847,7 @@ func (tctx *testContext) stepHostIsStarted(service string) error {
 			return fmt.Errorf("failed to connect to SPQR QDB %s: %s", service, err)
 		}
 
-		db, err := qdb.NewEtcdQDB(addr, 0)
+		db, err := qdb.NewEtcdQDB([]string{addr}, 0)
 		if err != nil {
 			return fmt.Errorf("failed to connect to SPQR QDB %s: %s", service, err)
 		}
@@ -855,7 +855,7 @@ func (tctx *testContext) stepHostIsStarted(service string) error {
 
 		log.Println("wait for QDB be ready")
 		retryRes := testutil.Retry(func() bool {
-			db, err := qdb.NewEtcdQDB(addr, 0)
+			db, err := qdb.NewEtcdQDB([]string{addr}, 0)
 			if err != nil {
 				return false
 			}


### PR DESCRIPTION
Deprecate `QdbAddr` with single endpoint in coordinator config, use `QdbAddrs` with multiple choice instead.

If both keys provided in a config, `QdbAddr` will be ignored.