### PR TITLE
Improve shard-not-found errors in console.

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -142,6 +142,7 @@ enim
 epn
 errcounter
 errdefs
+errdetails
 errtype
 eshkere
 etcdctl
@@ -173,6 +174,7 @@ frules
 ftts
 fugiat
 gcflags
+genproto
 getconn
 gettime
 gitmodules
@@ -429,7 +431,6 @@ qdb
 QDBKR
 QDBRe
 QDBTx
-Qdocker
 qlogger
 qlogprovider
 qname

--- a/coordinator/app/app.go
+++ b/coordinator/app/app.go
@@ -196,7 +196,7 @@ func (app *App) ServeGrpcAPI(wg *sync.WaitGroup) error {
 func spqrErrorUnaryServerInterceptor(
 	ctx context.Context,
 	req any,
-	info *grpc.UnaryServerInfo,
+	_ *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (any, error) {
 	resp, err := handler(ctx, req)

--- a/coordinator/app/app.go
+++ b/coordinator/app/app.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"buf.build/go/protovalidate"
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	"github.com/pg-sharding/spqr/pkg/spqrlog"
 	"github.com/pg-sharding/spqr/router/port"
 
@@ -150,7 +151,8 @@ func (app *App) ServeGrpcAPI(wg *sync.WaitGroup) error {
 	}
 
 	serv := grpc.NewServer(
-		grpc.UnaryInterceptor(
+		grpc.ChainUnaryInterceptor(
+			spqrErrorUnaryServerInterceptor,
 			protovalidate_middleware.UnaryServerInterceptor(validator),
 		),
 	)
@@ -189,6 +191,19 @@ func (app *App) ServeGrpcAPI(wg *sync.WaitGroup) error {
 		Msg("serve grpc coordinator service")
 
 	return serv.Serve(listener)
+}
+
+func spqrErrorUnaryServerInterceptor(
+	ctx context.Context,
+	req any,
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (any, error) {
+	resp, err := handler(ctx, req)
+	if err != nil {
+		return resp, spqrerror.ToGrpcError(err)
+	}
+	return resp, nil
 }
 
 func (app *App) ServeUnixSocket(wg *sync.WaitGroup) error {

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,6 @@ require (
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9
 	gotest.tools/v3 v3.5.1 // indirect
 )

--- a/pkg/clientinteractor/interactor.go
+++ b/pkg/clientinteractor/interactor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/engine"
 	"github.com/pg-sharding/spqr/pkg/models/kr"
 	"github.com/pg-sharding/spqr/pkg/models/rrelation"
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	"github.com/pg-sharding/spqr/pkg/models/tasks"
 	"github.com/pg-sharding/spqr/pkg/spqrlog"
 	"github.com/pg-sharding/spqr/pkg/tupleslot"
@@ -237,7 +238,8 @@ func (pi *PSQLInteractor) ReportError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if err := pi.cl.ReplyErrMsgPure(err); err != nil {
+
+	if err := pi.cl.ReplyErrMsgPure(spqrerror.CleanGrpcError(err)); err != nil {
 		return err
 	}
 	for _, msg := range []pgproto3.BackendMessage{

--- a/pkg/clientinteractor/interactor_test.go
+++ b/pkg/clientinteractor/interactor_test.go
@@ -590,11 +590,10 @@ func TestReportErrorIncludesHintFromSpqrError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ca := mockcl.NewMockRouterClient(ctrl)
 
-	spErr := spqrerror.NewWithHint(
+	spErr := spqrerror.New(
 		spqrerror.SPQR_NO_DATASHARD,
 		"Shard \"shard2\" not found.",
-		"Run 'SHOW shards' to see all configured shards.",
-	)
+	).Hint("Run 'SHOW shards' to see all configured shards.")
 
 	gomock.InOrder(
 		ca.EXPECT().ReplyErrMsgPure(spErr),

--- a/pkg/clientinteractor/interactor_test.go
+++ b/pkg/clientinteractor/interactor_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/pg-sharding/spqr/router/client"
 	mockcl "github.com/pg-sharding/spqr/router/mock/client"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pg-sharding/spqr/pkg/clientinteractor"
 	spqrparser "github.com/pg-sharding/spqr/yacc/console"
@@ -583,6 +585,25 @@ func TestBackendConnectionsGroupByFail(t *testing.T) {
 	_, err = engine.GroupBy(ftts, cmd.GroupBy)
 
 	assert.ErrorContains(err, "failed to resolve 'someColumn' column offset")
+}
+
+func TestReportErrorCleansGrpcPrefix(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ca := mockcl.NewMockRouterClient(ctrl)
+
+	gomock.InOrder(
+		ca.EXPECT().Send(&pgproto3.ErrorResponse{
+			Severity: "ERROR",
+			Message:  "shard \"shard2\" not found",
+		}),
+		ca.EXPECT().Send(&pgproto3.ReadyForQuery{
+			TxStatus: byte(txstatus.TXIDLE),
+		}),
+	)
+
+	interactor := clientinteractor.NewPSQLInteractor(ca)
+	err := interactor.ReportError(status.Error(codes.Unknown, "shard \"shard2\" not found"))
+	assert.NoError(t, err)
 }
 
 func TestKeyRangesSuccess(t *testing.T) {

--- a/pkg/clientinteractor/interactor_test.go
+++ b/pkg/clientinteractor/interactor_test.go
@@ -24,10 +24,9 @@ import (
 	"github.com/pg-sharding/spqr/router/client"
 	mockcl "github.com/pg-sharding/spqr/router/mock/client"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/pg-sharding/spqr/pkg/clientinteractor"
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	spqrparser "github.com/pg-sharding/spqr/yacc/console"
 )
 
@@ -587,22 +586,25 @@ func TestBackendConnectionsGroupByFail(t *testing.T) {
 	assert.ErrorContains(err, "failed to resolve 'someColumn' column offset")
 }
 
-func TestReportErrorCleansGrpcPrefix(t *testing.T) {
+func TestReportErrorIncludesHintFromSpqrError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ca := mockcl.NewMockRouterClient(ctrl)
 
+	spErr := spqrerror.NewWithHint(
+		spqrerror.SPQR_NO_DATASHARD,
+		"Shard \"shard2\" not found.",
+		"Run 'SHOW shards' to see all configured shards.",
+	)
+
 	gomock.InOrder(
-		ca.EXPECT().Send(&pgproto3.ErrorResponse{
-			Severity: "ERROR",
-			Message:  "shard \"shard2\" not found",
-		}),
+		ca.EXPECT().ReplyErrMsgPure(spErr),
 		ca.EXPECT().Send(&pgproto3.ReadyForQuery{
 			TxStatus: byte(txstatus.TXIDLE),
 		}),
 	)
 
 	interactor := clientinteractor.NewPSQLInteractor(ca)
-	err := interactor.ReportError(status.Error(codes.Unknown, "shard \"shard2\" not found"))
+	err := interactor.ReportError(spErr)
 	assert.NoError(t, err)
 }
 

--- a/pkg/clientinteractor/interactor_test.go
+++ b/pkg/clientinteractor/interactor_test.go
@@ -615,11 +615,12 @@ func TestReportErrorIncludesHintFromGrpcSpqrError(t *testing.T) {
 		ca.EXPECT().
 			ReplyErrMsgPure(gomock.Any()).
 			DoAndReturn(func(err error) error {
-				spErr, ok := err.(*spqrerror.SpqrError)
-				assert.True(t, ok)
-				assert.Equal(t, spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
-				assert.Equal(t, "Shard \"shard2\" not found.", spErr.Error())
-				assert.Equal(t, "Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+				var spErr *spqrerror.SpqrError
+				if assert.ErrorAs(t, err, &spErr) {
+					assert.Equal(t, spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
+					assert.Equal(t, "Shard \"shard2\" not found.", spErr.Error())
+					assert.Equal(t, "Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+				}
 				return nil
 			}),
 		ca.EXPECT().Send(&pgproto3.ReadyForQuery{

--- a/pkg/clientinteractor/interactor_test.go
+++ b/pkg/clientinteractor/interactor_test.go
@@ -607,6 +607,31 @@ func TestReportErrorIncludesHintFromSpqrError(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestReportErrorIncludesHintFromGrpcSpqrError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ca := mockcl.NewMockRouterClient(ctrl)
+
+	gomock.InOrder(
+		ca.EXPECT().
+			ReplyErrMsgPure(gomock.Any()).
+			DoAndReturn(func(err error) error {
+				spErr, ok := err.(*spqrerror.SpqrError)
+				assert.True(t, ok)
+				assert.Equal(t, spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
+				assert.Equal(t, "Shard \"shard2\" not found.", spErr.Error())
+				assert.Equal(t, "Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+				return nil
+			}),
+		ca.EXPECT().Send(&pgproto3.ReadyForQuery{
+			TxStatus: byte(txstatus.TXIDLE),
+		}),
+	)
+
+	interactor := clientinteractor.NewPSQLInteractor(ca)
+	err := interactor.ReportError(spqrerror.ToGrpcError(spqrerror.ShardNotFound("shard2")))
+	assert.NoError(t, err)
+}
+
 func TestKeyRangesSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ca := mockcl.NewMockRouterClient(ctrl)

--- a/pkg/meta/key_range_meta.go
+++ b/pkg/meta/key_range_meta.go
@@ -2,8 +2,8 @@ package meta
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -20,52 +20,35 @@ const (
 	LockRetryStep = 500 * time.Millisecond
 )
 
-func validateTargetShardExists(ctx context.Context, mngr EntityMgrReader, shardID string) error {
-	shards, err := mngr.ListShards(ctx)
-	if err != nil {
-		return err
+func rewriteMissingShardError(err error, shardID string) error {
+	var spErr *spqrerror.SpqrError
+	if errors.As(err, &spErr) && spErr.ErrorCode == spqrerror.SPQR_NO_DATASHARD {
+		return spqrerror.NewWithHint(
+			spqrerror.SPQR_NO_DATASHARD,
+			fmt.Sprintf("Shard %q not found.", shardID),
+			"Run 'SHOW shards' to see all configured shards.",
+		)
 	}
 
-	shardIDs := make([]string, 0, len(shards))
-	exists := false
-	for _, shard := range shards {
-		if shard == nil {
-			continue
-		}
-		shardIDs = append(shardIDs, shard.ID)
-		if shard.ID == shardID {
-			exists = true
-		}
+	cleanErr := strings.ToLower(spqrerror.CleanGrpcError(err).Error())
+	if strings.Contains(cleanErr, "unknown shard") || strings.Contains(cleanErr, "shard") && strings.Contains(cleanErr, "not found") {
+		return spqrerror.NewWithHint(
+			spqrerror.SPQR_NO_DATASHARD,
+			fmt.Sprintf("Shard %q not found.", shardID),
+			"Run 'SHOW shards' to see all configured shards.",
+		)
 	}
 
-	if exists {
-		return nil
-	}
-
-	sort.Strings(shardIDs)
-	availableShards := "none"
-	if len(shardIDs) > 0 {
-		availableShards = strings.Join(shardIDs, ", ")
-	}
-
-	return spqrerror.Newf(
-		spqrerror.SPQR_NO_DATASHARD,
-		"Shard %q not found.\n\nAvailable shards: %s\nHint: Run 'SHOW SHARDS' to see all configured shards.\n      Run 'ADD SHARD %s WITH HOSTS ...' to create it.",
-		shardID,
-		availableShards,
-		shardID,
-	)
+	return err
 }
 
-// ValidateKeyRangeForCreate validates key range before create
-//
-// Parameters:
-// - ctx: the context of the operation.
-// - mngr (meta.EntityMgr): this entity manager gets data about meta for validating key range
-// - keyRange (*kr.KeyRange): key range for validating
-//
-// Returns:
-// - error: an error if validation is not passed
+func validateTargetShardExists(ctx context.Context, mngr EntityMgrReader, shardID string) error {
+	if _, err := mngr.GetShard(ctx, shardID); err != nil {
+		return rewriteMissingShardError(err, shardID)
+	}
+	return nil
+}
+
 func ValidateKeyRangeForCreate(ctx context.Context, mngr EntityMgrReader, keyRange *kr.KeyRange) error {
 	if err := validateTargetShardExists(ctx, mngr, keyRange.ShardID); err != nil {
 		return err

--- a/pkg/meta/key_range_meta.go
+++ b/pkg/meta/key_range_meta.go
@@ -3,6 +3,8 @@ package meta
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/pg-sharding/spqr/coordinator/statistics"
@@ -18,6 +20,43 @@ const (
 	LockRetryStep = 500 * time.Millisecond
 )
 
+func validateTargetShardExists(ctx context.Context, mngr EntityMgrReader, shardID string) error {
+	shards, err := mngr.ListShards(ctx)
+	if err != nil {
+		return err
+	}
+
+	shardIDs := make([]string, 0, len(shards))
+	exists := false
+	for _, shard := range shards {
+		if shard == nil {
+			continue
+		}
+		shardIDs = append(shardIDs, shard.ID)
+		if shard.ID == shardID {
+			exists = true
+		}
+	}
+
+	if exists {
+		return nil
+	}
+
+	sort.Strings(shardIDs)
+	availableShards := "none"
+	if len(shardIDs) > 0 {
+		availableShards = strings.Join(shardIDs, ", ")
+	}
+
+	return spqrerror.Newf(
+		spqrerror.SPQR_NO_DATASHARD,
+		"Shard %q not found.\n\nAvailable shards: %s\nHint: Run 'SHOW SHARDS' to see all configured shards.\n      Run 'ADD SHARD %s WITH HOSTS ...' to create it.",
+		shardID,
+		availableShards,
+		shardID,
+	)
+}
+
 // ValidateKeyRangeForCreate validates key range before create
 //
 // Parameters:
@@ -28,7 +67,7 @@ const (
 // Returns:
 // - error: an error if validation is not passed
 func ValidateKeyRangeForCreate(ctx context.Context, mngr EntityMgrReader, keyRange *kr.KeyRange) error {
-	if _, err := mngr.GetShard(ctx, keyRange.ShardID); err != nil {
+	if err := validateTargetShardExists(ctx, mngr, keyRange.ShardID); err != nil {
 		return err
 	}
 
@@ -84,7 +123,7 @@ func ValidateKeyRangeForModify(ctx context.Context, mngr EntityMgrReader, keyRan
 		return spqrerror.Newf(spqrerror.SPQR_KEYRANGE_ERROR, "key range %v not locked", keyRange.ID)
 	}
 
-	if _, err := mngr.GetShard(ctx, keyRange.ShardID); err != nil {
+	if err := validateTargetShardExists(ctx, mngr, keyRange.ShardID); err != nil {
 		return err
 	}
 

--- a/pkg/meta/key_range_meta.go
+++ b/pkg/meta/key_range_meta.go
@@ -23,20 +23,20 @@ const (
 func rewriteMissingShardError(err error, shardID string) error {
 	var spErr *spqrerror.SpqrError
 	if errors.As(err, &spErr) && spErr.ErrorCode == spqrerror.SPQR_NO_DATASHARD {
-		return spqrerror.NewWithHint(
+		return spqrerror.New(
 			spqrerror.SPQR_NO_DATASHARD,
 			fmt.Sprintf("Shard %q not found.", shardID),
-			"Run 'SHOW shards' to see all configured shards.",
-		)
+		).Hint("Run 'SHOW shards' to see all configured shards.")
 	}
 
 	cleanErr := strings.ToLower(spqrerror.CleanGrpcError(err).Error())
-	if strings.Contains(cleanErr, "unknown shard") || strings.Contains(cleanErr, "shard") && strings.Contains(cleanErr, "not found") {
-		return spqrerror.NewWithHint(
+	hasUnknownShard := strings.Contains(cleanErr, "unknown shard")
+	hasShardNotFound := strings.Contains(cleanErr, "shard") && strings.Contains(cleanErr, "not found")
+	if hasUnknownShard || hasShardNotFound {
+		return spqrerror.New(
 			spqrerror.SPQR_NO_DATASHARD,
 			fmt.Sprintf("Shard %q not found.", shardID),
-			"Run 'SHOW shards' to see all configured shards.",
-		)
+		).Hint("Run 'SHOW shards' to see all configured shards.")
 	}
 
 	return err

--- a/pkg/meta/key_range_meta.go
+++ b/pkg/meta/key_range_meta.go
@@ -2,9 +2,7 @@ package meta
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/pg-sharding/spqr/coordinator/statistics"
@@ -20,37 +18,8 @@ const (
 	LockRetryStep = 500 * time.Millisecond
 )
 
-func rewriteMissingShardError(err error, shardID string) error {
-	var spErr *spqrerror.SpqrError
-	if errors.As(err, &spErr) && spErr.ErrorCode == spqrerror.SPQR_NO_DATASHARD {
-		return spqrerror.New(
-			spqrerror.SPQR_NO_DATASHARD,
-			fmt.Sprintf("Shard %q not found.", shardID),
-		).Hint("Run 'SHOW shards' to see all configured shards.")
-	}
-
-	cleanErr := strings.ToLower(spqrerror.CleanGrpcError(err).Error())
-	hasUnknownShard := strings.Contains(cleanErr, "unknown shard")
-	hasShardNotFound := strings.Contains(cleanErr, "shard") && strings.Contains(cleanErr, "not found")
-	if hasUnknownShard || hasShardNotFound {
-		return spqrerror.New(
-			spqrerror.SPQR_NO_DATASHARD,
-			fmt.Sprintf("Shard %q not found.", shardID),
-		).Hint("Run 'SHOW shards' to see all configured shards.")
-	}
-
-	return err
-}
-
-func validateTargetShardExists(ctx context.Context, mngr EntityMgrReader, shardID string) error {
-	if _, err := mngr.GetShard(ctx, shardID); err != nil {
-		return rewriteMissingShardError(err, shardID)
-	}
-	return nil
-}
-
 func ValidateKeyRangeForCreate(ctx context.Context, mngr EntityMgrReader, keyRange *kr.KeyRange) error {
-	if err := validateTargetShardExists(ctx, mngr, keyRange.ShardID); err != nil {
+	if _, err := mngr.GetShard(ctx, keyRange.ShardID); err != nil {
 		return err
 	}
 
@@ -106,7 +75,7 @@ func ValidateKeyRangeForModify(ctx context.Context, mngr EntityMgrReader, keyRan
 		return spqrerror.Newf(spqrerror.SPQR_KEYRANGE_ERROR, "key range %v not locked", keyRange.ID)
 	}
 
-	if err := validateTargetShardExists(ctx, mngr, keyRange.ShardID); err != nil {
+	if _, err := mngr.GetShard(ctx, keyRange.ShardID); err != nil {
 		return err
 	}
 

--- a/pkg/meta/key_range_meta_test.go
+++ b/pkg/meta/key_range_meta_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/coord"
 	"github.com/pg-sharding/spqr/pkg/meta"
 	"github.com/pg-sharding/spqr/pkg/models/kr"
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	"github.com/pg-sharding/spqr/pkg/models/topology"
 	"github.com/pg-sharding/spqr/qdb"
 	"github.com/stretchr/testify/assert"
@@ -64,13 +65,6 @@ var kr1NotLocked = &kr.KeyRange{
 	LowerBound:   []any{int64(0)},
 	ColumnTypes:  []string{qdb.ColumnTypeInteger},
 	IsLocked:     &boolFalse,
-}
-
-func expectedMissingShardError(shardID string, availableShards string) string {
-	return "Shard \"" + shardID + "\" not found.\n\n" +
-		"Available shards: " + availableShards + "\n" +
-		"Hint: Run 'SHOW SHARDS' to see all configured shards.\n" +
-		"      Run 'ADD SHARD " + shardID + " WITH HOSTS ...' to create it."
 }
 
 func prepareDbTestValidate(ctx context.Context) (*qdb.MemQDB, error) {
@@ -228,13 +222,13 @@ func TestValidateKeyRangeForModify_intersection(t *testing.T) {
 	is.Error(meta.ValidateKeyRangeForModify(ctx, mngr, kr1Double))
 }
 
-func TestValidateKeyRangeForCreate_unknownShardIncludesAvailableShardsAndHint(t *testing.T) {
+func TestValidateKeyRangeForCreate_unknownShardReturnsHint(t *testing.T) {
 	is := assert.New(t)
 	ctx := context.TODO()
 
 	memqdb, err := prepareDbTestValidate(ctx)
 	is.NoError(err)
-	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*config.Shard{}, false)
+	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*topology.DataShard{}, false, nil)
 
 	reqKr := &kr.KeyRange{
 		ID:           "kr_missing",
@@ -245,18 +239,23 @@ func TestValidateKeyRangeForCreate_unknownShardIncludesAvailableShardsAndHint(t 
 	}
 
 	err = meta.ValidateKeyRangeForCreate(ctx, mngr, reqKr)
-	is.EqualError(err, expectedMissingShardError("nonexistentshard", "sh1, sh2"))
+	is.Error(err)
+
+	spErr, ok := err.(*spqrerror.SpqrError)
+	is.True(ok)
+	is.Equal(spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
+	is.Equal("Shard \"nonexistentshard\" not found.", spErr.Error())
+	is.Equal("Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
 }
 
-func TestValidateKeyRangeForModify_unknownShardIncludesSingleAvailableShard(t *testing.T) {
+func TestValidateKeyRangeForModify_unknownShardReturnsHint(t *testing.T) {
 	is := assert.New(t)
 	ctx := context.TODO()
 
 	memqdb, err := prepareDbTestValidate(ctx)
 	is.NoError(err)
-	is.NoError(memqdb.DropShard(ctx, "sh2"))
 
-	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*config.Shard{}, false)
+	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*topology.DataShard{}, false, nil)
 	tranMngr := meta.NewTranEntityManager(mngr)
 
 	err = tranMngr.CreateKeyRange(ctx, kr1)
@@ -276,5 +275,11 @@ func TestValidateKeyRangeForModify_unknownShardIncludesSingleAvailableShard(t *t
 	}
 
 	err = meta.ValidateKeyRangeForModify(ctx, mngr, reqKr)
-	is.EqualError(err, expectedMissingShardError("nonexistentshard", "sh1"))
+	is.Error(err)
+
+	spErr, ok := err.(*spqrerror.SpqrError)
+	is.True(ok)
+	is.Equal(spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
+	is.Equal("Shard \"nonexistentshard\" not found.", spErr.Error())
+	is.Equal("Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
 }

--- a/pkg/meta/key_range_meta_test.go
+++ b/pkg/meta/key_range_meta_test.go
@@ -228,7 +228,7 @@ func TestValidateKeyRangeForCreate_unknownShardReturnsHint(t *testing.T) {
 
 	memqdb, err := prepareDbTestValidate(ctx)
 	is.NoError(err)
-	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*topology.DataShard{}, false, nil)
+	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, topology.TopMgrFromMap(map[string]*topology.DataShard{}), false, nil, qdb.DefaultMaxTxnSize)
 
 	reqKr := &kr.KeyRange{
 		ID:           "kr_missing",
@@ -255,7 +255,7 @@ func TestValidateKeyRangeForModify_unknownShardReturnsHint(t *testing.T) {
 	memqdb, err := prepareDbTestValidate(ctx)
 	is.NoError(err)
 
-	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*topology.DataShard{}, false, nil)
+	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, topology.TopMgrFromMap(map[string]*topology.DataShard{}), false, nil, qdb.DefaultMaxTxnSize)
 	tranMngr := meta.NewTranEntityManager(mngr)
 
 	err = tranMngr.CreateKeyRange(ctx, kr1, ds1ColTypes)

--- a/pkg/meta/key_range_meta_test.go
+++ b/pkg/meta/key_range_meta_test.go
@@ -66,6 +66,13 @@ var kr1NotLocked = &kr.KeyRange{
 	IsLocked:     &boolFalse,
 }
 
+func expectedMissingShardError(shardID string, availableShards string) string {
+	return "Shard \"" + shardID + "\" not found.\n\n" +
+		"Available shards: " + availableShards + "\n" +
+		"Hint: Run 'SHOW SHARDS' to see all configured shards.\n" +
+		"      Run 'ADD SHARD " + shardID + " WITH HOSTS ...' to create it."
+}
+
 func prepareDbTestValidate(ctx context.Context) (*qdb.MemQDB, error) {
 	memqdb, err := qdb.RestoreQDB(MemQDBPath)
 	if err != nil {
@@ -219,4 +226,55 @@ func TestValidateKeyRangeForModify_intersection(t *testing.T) {
 	is.NoError(err)
 
 	is.Error(meta.ValidateKeyRangeForModify(ctx, mngr, kr1Double))
+}
+
+func TestValidateKeyRangeForCreate_unknownShardIncludesAvailableShardsAndHint(t *testing.T) {
+	is := assert.New(t)
+	ctx := context.TODO()
+
+	memqdb, err := prepareDbTestValidate(ctx)
+	is.NoError(err)
+	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*config.Shard{}, false)
+
+	reqKr := &kr.KeyRange{
+		ID:           "kr_missing",
+		ShardID:      "nonexistentshard",
+		Distribution: "ds1",
+		LowerBound:   []any{int64(100)},
+		ColumnTypes:  []string{qdb.ColumnTypeInteger},
+	}
+
+	err = meta.ValidateKeyRangeForCreate(ctx, mngr, reqKr)
+	is.EqualError(err, expectedMissingShardError("nonexistentshard", "sh1, sh2"))
+}
+
+func TestValidateKeyRangeForModify_unknownShardIncludesSingleAvailableShard(t *testing.T) {
+	is := assert.New(t)
+	ctx := context.TODO()
+
+	memqdb, err := prepareDbTestValidate(ctx)
+	is.NoError(err)
+	is.NoError(memqdb.DropShard(ctx, "sh2"))
+
+	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*config.Shard{}, false)
+	tranMngr := meta.NewTranEntityManager(mngr)
+
+	err = tranMngr.CreateKeyRange(ctx, kr1)
+	is.NoError(err)
+	err = tranMngr.ExecNoTran(ctx)
+	is.NoError(err)
+
+	_, err = mngr.LockKeyRange(ctx, kr1.ID)
+	is.NoError(err)
+
+	reqKr := &kr.KeyRange{
+		ID:           kr1.ID,
+		ShardID:      "nonexistentshard",
+		Distribution: kr1.Distribution,
+		LowerBound:   kr1.LowerBound,
+		ColumnTypes:  kr1.ColumnTypes,
+	}
+
+	err = meta.ValidateKeyRangeForModify(ctx, mngr, reqKr)
+	is.EqualError(err, expectedMissingShardError("nonexistentshard", "sh1"))
 }

--- a/pkg/meta/key_range_meta_test.go
+++ b/pkg/meta/key_range_meta_test.go
@@ -258,7 +258,7 @@ func TestValidateKeyRangeForModify_unknownShardReturnsHint(t *testing.T) {
 	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*topology.DataShard{}, false, nil)
 	tranMngr := meta.NewTranEntityManager(mngr)
 
-	err = tranMngr.CreateKeyRange(ctx, kr1)
+	err = tranMngr.CreateKeyRange(ctx, kr1, ds1ColTypes)
 	is.NoError(err)
 	err = tranMngr.ExecNoTran(ctx)
 	is.NoError(err)

--- a/pkg/meta/key_range_meta_test.go
+++ b/pkg/meta/key_range_meta_test.go
@@ -241,11 +241,12 @@ func TestValidateKeyRangeForCreate_unknownShardReturnsHint(t *testing.T) {
 	err = meta.ValidateKeyRangeForCreate(ctx, mngr, reqKr)
 	is.Error(err)
 
-	spErr, ok := err.(*spqrerror.SpqrError)
-	is.True(ok)
-	is.Equal(spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
-	is.Equal("Shard \"nonexistentshard\" not found.", spErr.Error())
-	is.Equal("Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+	var spErr *spqrerror.SpqrError
+	if is.ErrorAs(err, &spErr) {
+		is.Equal(spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
+		is.Equal("Shard \"nonexistentshard\" not found.", spErr.Error())
+		is.Equal("Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+	}
 }
 
 func TestValidateKeyRangeForModify_unknownShardReturnsHint(t *testing.T) {
@@ -277,9 +278,10 @@ func TestValidateKeyRangeForModify_unknownShardReturnsHint(t *testing.T) {
 	err = meta.ValidateKeyRangeForModify(ctx, mngr, reqKr)
 	is.Error(err)
 
-	spErr, ok := err.(*spqrerror.SpqrError)
-	is.True(ok)
-	is.Equal(spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
-	is.Equal("Shard \"nonexistentshard\" not found.", spErr.Error())
-	is.Equal("Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+	var spErr *spqrerror.SpqrError
+	if is.ErrorAs(err, &spErr) {
+		is.Equal(spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
+		is.Equal("Shard \"nonexistentshard\" not found.", spErr.Error())
+		is.Equal("Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+	}
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -601,16 +601,10 @@ func ProcessCreate(ctx context.Context, astmt spqrparser.Statement, mngr EntityM
 			return nil, spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "shard with id %s already exists", stmt.Id)
 		}
 
+		err = spqrerror.CleanGrpcError(err)
 		var spErr *spqrerror.SpqrError
-		if errors.As(err, &spErr) {
-			if spErr.ErrorCode != spqrerror.SPQR_NO_DATASHARD {
-				return nil, err
-			}
-		} else {
-			cleanErr := spqrerror.CleanGrpcError(err)
-			if !strings.Contains(cleanErr.Error(), "unknown shard") {
-				return nil, cleanErr
-			}
+		if !errors.As(err, &spErr) || spErr.ErrorCode != spqrerror.SPQR_NO_DATASHARD {
+			return nil, err
 		}
 
 		options, err := topology.OptionsFromSQL(stmt.Options)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/models/distributions"
 	"github.com/pg-sharding/spqr/pkg/models/kr"
 	"github.com/pg-sharding/spqr/pkg/models/rrelation"
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	"github.com/pg-sharding/spqr/pkg/models/topology"
 	"github.com/pg-sharding/spqr/pkg/tupleslot"
 	"github.com/pg-sharding/spqr/qdb"
@@ -186,7 +187,7 @@ func TestCreateShardAllowsGrpcWrappedUnknownShardError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mngr := mockmgr.NewMockEntityMgr(ctrl)
-	mngr.EXPECT().GetShard(ctx, "sh-new").Return(nil, fmt.Errorf("rpc error: code = Unknown desc = unknown shard sh-new"))
+	mngr.EXPECT().GetShard(ctx, "sh-new").Return(nil, spqrerror.ToGrpcError(spqrerror.ShardNotFound("sh-new")))
 	mngr.EXPECT().AddDataShard(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, shard *topology.DataShard) error {
 		assert.Equal(t, "sh-new", shard.ID)
 		assert.Equal(t, []string{listener.Addr().String()}, shard.Hosts())

--- a/pkg/meta/tran_entity_manager.go
+++ b/pkg/meta/tran_entity_manager.go
@@ -62,6 +62,7 @@ type EntityMgrReader interface {
 	GetKeyRange(ctx context.Context, krId string) (*kr.KeyRange, error)
 	GetDistribution(ctx context.Context, id string) (*distributions.Distribution, error)
 	ListKeyRanges(ctx context.Context, distribution string) ([]*kr.KeyRange, error)
+	ListShards(ctx context.Context) ([]*topology.DataShard, error)
 }
 
 // Wrapper of EntityManager. Keeps track of changes made during a transaction that have not yet been committed.

--- a/pkg/meta/tran_entity_manager.go
+++ b/pkg/meta/tran_entity_manager.go
@@ -62,7 +62,6 @@ type EntityMgrReader interface {
 	GetKeyRange(ctx context.Context, krId string) (*kr.KeyRange, error)
 	GetDistribution(ctx context.Context, id string) (*distributions.Distribution, error)
 	ListKeyRanges(ctx context.Context, distribution string) ([]*kr.KeyRange, error)
-	ListShards(ctx context.Context) ([]*topology.DataShard, error)
 }
 
 // Wrapper of EntityManager. Keeps track of changes made during a transaction that have not yet been committed.

--- a/pkg/models/spqrerror/spqrerror.go
+++ b/pkg/models/spqrerror/spqrerror.go
@@ -1,9 +1,13 @@
 package spqrerror
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/jackc/pgx/v5/pgproto3"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -95,6 +99,17 @@ type SpqrError struct {
 	ErrContext    string
 }
 
+const (
+	grpcErrorDomain       = "spqr"
+	grpcErrorCodeKey      = "code"
+	grpcErrorHintKey      = "hint"
+	grpcErrorDetailKey    = "detail"
+	grpcErrorContextKey   = "context"
+	grpcErrorPositionKey  = "position"
+	grpcErrorQueryKey     = "internal_query"
+	shardNotFoundHintText = "Run 'SHOW shards' to see all configured shards."
+)
+
 func (e *SpqrError) Hint(h string) *SpqrError {
 	e.ErrHint = h
 	return e
@@ -177,6 +192,10 @@ func Newf(errorCode string, format string, a ...any) *SpqrError {
 	return err
 }
 
+func ShardNotFound(shardID string) *SpqrError {
+	return Newf(SPQR_NO_DATASHARD, "Shard %q not found.", shardID).Hint(shardNotFoundHintText)
+}
+
 // Error returns the error message associated with the SpqrError.
 // It formats the error message using the underlying error's Error method.
 //
@@ -184,6 +203,47 @@ func Newf(errorCode string, format string, a ...any) *SpqrError {
 //   - string: The formatted error message.
 func (e *SpqrError) Error() string {
 	return e.Err.Error()
+}
+
+func ToGrpcError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var spErr *SpqrError
+	if !errors.As(err, &spErr) {
+		return err
+	}
+
+	metadata := map[string]string{
+		grpcErrorCodeKey: spErr.ErrorCode,
+	}
+	if spErr.ErrHint != "" {
+		metadata[grpcErrorHintKey] = spErr.ErrHint
+	}
+	if spErr.ErrDetail != "" {
+		metadata[grpcErrorDetailKey] = spErr.ErrDetail
+	}
+	if spErr.ErrContext != "" {
+		metadata[grpcErrorContextKey] = spErr.ErrContext
+	}
+	if spErr.Position != 0 {
+		metadata[grpcErrorPositionKey] = strconv.FormatInt(int64(spErr.Position), 10)
+	}
+	if spErr.InternalQuery != "" {
+		metadata[grpcErrorQueryKey] = spErr.InternalQuery
+	}
+
+	st, detailErr := status.New(codes.Unknown, spErr.Error()).WithDetails(&errdetails.ErrorInfo{
+		Reason:   spErr.ErrorCode,
+		Domain:   grpcErrorDomain,
+		Metadata: metadata,
+	})
+	if detailErr != nil {
+		return err
+	}
+
+	return st.Err()
 }
 
 // Try convert grpc error to error without "rpc error: code..."
@@ -195,6 +255,32 @@ func CleanGrpcError(err error) error {
 		return nil
 	}
 	if st, ok := status.FromError(err); ok {
+		for _, detail := range st.Details() {
+			info, ok := detail.(*errdetails.ErrorInfo)
+			if !ok || info.Domain != grpcErrorDomain {
+				continue
+			}
+
+			code := info.Reason
+			if code == "" {
+				code = info.Metadata[grpcErrorCodeKey]
+			}
+			if code == "" {
+				break
+			}
+
+			spErr := New(code, st.Message()).
+				Hint(info.Metadata[grpcErrorHintKey]).
+				Detail(info.Metadata[grpcErrorDetailKey]).
+				Context(info.Metadata[grpcErrorContextKey]).
+				Query(info.Metadata[grpcErrorQueryKey])
+
+			if position, parseErr := strconv.ParseInt(info.Metadata[grpcErrorPositionKey], 10, 32); parseErr == nil {
+				spErr.Pos(int32(position))
+			}
+
+			return spErr
+		}
 		return fmt.Errorf("%s", st.Message())
 	}
 	return err // non grpc error

--- a/pkg/models/spqrerror/spqrerror.go
+++ b/pkg/models/spqrerror/spqrerror.go
@@ -276,7 +276,7 @@ func CleanGrpcError(err error) error {
 				Query(info.Metadata[grpcErrorQueryKey])
 
 			if position, parseErr := strconv.ParseInt(info.Metadata[grpcErrorPositionKey], 10, 32); parseErr == nil {
-				spErr.Pos(int32(position))
+				spErr.Position = int32(position)
 			}
 
 			return spErr

--- a/pkg/models/spqrerror/spqrerror_test.go
+++ b/pkg/models/spqrerror/spqrerror_test.go
@@ -24,13 +24,14 @@ func TestCleanGrpcErrorRestoresSpqrErrorMetadata(t *testing.T) {
 
 	cleanErr := spqrerror.CleanGrpcError(spqrerror.ToGrpcError(original))
 
-	spErr, ok := cleanErr.(*spqrerror.SpqrError)
-	assert.True(t, ok)
-	assert.Equal(t, original.ErrorCode, spErr.ErrorCode)
-	assert.Equal(t, original.Error(), spErr.Error())
-	assert.Equal(t, original.ErrHint, spErr.ErrHint)
-	assert.Equal(t, original.ErrDetail, spErr.ErrDetail)
-	assert.Equal(t, original.ErrContext, spErr.ErrContext)
-	assert.Equal(t, original.Position, spErr.Position)
-	assert.Equal(t, original.InternalQuery, spErr.InternalQuery)
+	var spErr *spqrerror.SpqrError
+	if assert.ErrorAs(t, cleanErr, &spErr) {
+		assert.Equal(t, original.ErrorCode, spErr.ErrorCode)
+		assert.Equal(t, original.Error(), spErr.Error())
+		assert.Equal(t, original.ErrHint, spErr.ErrHint)
+		assert.Equal(t, original.ErrDetail, spErr.ErrDetail)
+		assert.Equal(t, original.ErrContext, spErr.ErrContext)
+		assert.Equal(t, original.Position, spErr.Position)
+		assert.Equal(t, original.InternalQuery, spErr.InternalQuery)
+	}
 }

--- a/pkg/models/spqrerror/spqrerror_test.go
+++ b/pkg/models/spqrerror/spqrerror_test.go
@@ -1,0 +1,36 @@
+package spqrerror_test
+
+import (
+	"testing"
+
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShardNotFound(t *testing.T) {
+	err := spqrerror.ShardNotFound("shard2")
+
+	assert.Equal(t, spqrerror.SPQR_NO_DATASHARD, err.ErrorCode)
+	assert.Equal(t, "Shard \"shard2\" not found.", err.Error())
+	assert.Equal(t, "Run 'SHOW shards' to see all configured shards.", err.ErrHint)
+}
+
+func TestCleanGrpcErrorRestoresSpqrErrorMetadata(t *testing.T) {
+	original := spqrerror.ShardNotFound("shard2").
+		Detail("shard lookup failed").
+		Context("key range validation").
+		Pos(42).
+		Query("CREATE KEY RANGE krid2")
+
+	cleanErr := spqrerror.CleanGrpcError(spqrerror.ToGrpcError(original))
+
+	spErr, ok := cleanErr.(*spqrerror.SpqrError)
+	assert.True(t, ok)
+	assert.Equal(t, original.ErrorCode, spErr.ErrorCode)
+	assert.Equal(t, original.Error(), spErr.Error())
+	assert.Equal(t, original.ErrHint, spErr.ErrHint)
+	assert.Equal(t, original.ErrDetail, spErr.ErrDetail)
+	assert.Equal(t, original.ErrContext, spErr.ErrContext)
+	assert.Equal(t, original.Position, spErr.Position)
+	assert.Equal(t, original.InternalQuery, spErr.InternalQuery)
+}

--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -1101,7 +1101,7 @@ func (q *EtcdQDB) GetShard(ctx context.Context, id string) (*Shard, error) {
 	}
 
 	if len(resp.Kvs) == 0 {
-		return nil, spqrerror.Newf(spqrerror.SPQR_NO_DATASHARD, "unknown shard %s", id)
+		return nil, spqrerror.ShardNotFound(id)
 	}
 	if len(resp.Kvs) > 1 {
 		return nil, spqrerror.Newf(spqrerror.SPQR_METADATA_CORRUPTION,

--- a/qdb/memqdb.go
+++ b/qdb/memqdb.go
@@ -783,7 +783,7 @@ func (q *MemQDB) GetShard(_ context.Context, id string) (*Shard, error) {
 		return shard, nil
 	}
 
-	return nil, spqrerror.Newf(spqrerror.SPQR_NO_DATASHARD, "unknown shard %s", id)
+	return nil, spqrerror.ShardNotFound(id)
 }
 
 func (q *MemQDB) AlterShard(_ context.Context, newShard *Shard) error {

--- a/qdb/memqdb_test.go
+++ b/qdb/memqdb_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	"github.com/pg-sharding/spqr/qdb"
 	"github.com/pg-sharding/spqr/router/rfqn"
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,19 @@ var mockDataTransferTransaction = &qdb.DataTransferTransaction{
 	ToShardId:   mockShard.ID,
 	FromShardId: mockShard.ID,
 	Status:      "fake_st",
+}
+
+func TestMemQDBGetShardReturnsShardNotFound(t *testing.T) {
+	memqdb, err := qdb.RestoreQDB(MemQDBPath)
+	assert.NoError(t, err)
+
+	_, err = memqdb.GetShard(context.TODO(), "missing-shard")
+
+	spErr, ok := err.(*spqrerror.SpqrError)
+	assert.True(t, ok)
+	assert.Equal(t, spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
+	assert.Equal(t, "Shard \"missing-shard\" not found.", spErr.Error())
+	assert.Equal(t, "Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
 }
 
 // must run with -race

--- a/qdb/memqdb_test.go
+++ b/qdb/memqdb_test.go
@@ -46,11 +46,12 @@ func TestMemQDBGetShardReturnsShardNotFound(t *testing.T) {
 
 	_, err = memqdb.GetShard(context.TODO(), "missing-shard")
 
-	spErr, ok := err.(*spqrerror.SpqrError)
-	assert.True(t, ok)
-	assert.Equal(t, spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
-	assert.Equal(t, "Shard \"missing-shard\" not found.", spErr.Error())
-	assert.Equal(t, "Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+	var spErr *spqrerror.SpqrError
+	if assert.ErrorAs(t, err, &spErr) {
+		assert.Equal(t, spqrerror.SPQR_NO_DATASHARD, spErr.ErrorCode)
+		assert.Equal(t, "Shard \"missing-shard\" not found.", spErr.Error())
+		assert.Equal(t, "Run 'SHOW shards' to see all configured shards.", spErr.ErrHint)
+	}
 }
 
 // must run with -race

--- a/test/regress/tests/console/expected/add.out
+++ b/test/regress/tests/console/expected/add.out
@@ -38,7 +38,11 @@ SHOW key_ranges;
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 33 ROUTE TO nonexistentshard FOR DISTRIBUTION ds1;
-ERROR:  unknown shard nonexistentshard
+ERROR:  Shard "nonexistentshard" not found.
+
+Available shards: sh1, sh2, sh3, sh4
+Hint: Run 'SHOW SHARDS' to see all configured shards.
+      Run 'ADD SHARD nonexistentshard WITH HOSTS ...' to create it.
 DROP DISTRIBUTION ALL CASCADE;
  distribution_id 
 -----------------

--- a/test/regress/tests/console/expected/add.out
+++ b/test/regress/tests/console/expected/add.out
@@ -39,10 +39,7 @@ SHOW key_ranges;
 
 CREATE KEY RANGE krid2 FROM 33 ROUTE TO nonexistentshard FOR DISTRIBUTION ds1;
 ERROR:  Shard "nonexistentshard" not found.
-
-Available shards: sh1, sh2, sh3, sh4
-Hint: Run 'SHOW SHARDS' to see all configured shards.
-      Run 'ADD SHARD nonexistentshard WITH HOSTS ...' to create it.
+HINT:  Run 'SHOW shards' to see all configured shards.
 DROP DISTRIBUTION ALL CASCADE;
  distribution_id 
 -----------------

--- a/test/regress/tests/console/expected/add_1.out
+++ b/test/regress/tests/console/expected/add_1.out
@@ -38,7 +38,11 @@ SHOW key_ranges;
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 33 ROUTE TO nonexistentshard FOR DISTRIBUTION ds1;
-ERROR:  unknown shard nonexistentshard
+ERROR:  Shard "nonexistentshard" not found.
+
+Available shards: sh1, sh2, sh3, sh4
+Hint: Run 'SHOW SHARDS' to see all configured shards.
+      Run 'ADD SHARD nonexistentshard WITH HOSTS ...' to create it.
 DROP DISTRIBUTION ALL CASCADE;
  distribution_id 
 -----------------

--- a/test/regress/tests/console/expected/add_1.out
+++ b/test/regress/tests/console/expected/add_1.out
@@ -39,10 +39,7 @@ SHOW key_ranges;
 
 CREATE KEY RANGE krid2 FROM 33 ROUTE TO nonexistentshard FOR DISTRIBUTION ds1;
 ERROR:  Shard "nonexistentshard" not found.
-
-Available shards: sh1, sh2, sh3, sh4
-Hint: Run 'SHOW SHARDS' to see all configured shards.
-      Run 'ADD SHARD nonexistentshard WITH HOSTS ...' to create it.
+HINT:  Run 'SHOW shards' to see all configured shards.
 DROP DISTRIBUTION ALL CASCADE;
  distribution_id 
 -----------------

--- a/test/regress/tests/coordinator/expected/coordinator.out
+++ b/test/regress/tests/coordinator/expected/coordinator.out
@@ -45,10 +45,7 @@ SHOW key_ranges;
 
 CREATE KEY RANGE krid2 FROM 33 ROUTE TO nonexistentshard FOR DISTRIBUTION ds1;
 ERROR:  Shard "nonexistentshard" not found.
-
-Available shards: sh1, sh2, sh3, sh4
-Hint: Run 'SHOW SHARDS' to see all configured shards.
-      Run 'ADD SHARD nonexistentshard WITH HOSTS ...' to create it.
+HINT:  Run 'SHOW shards' to see all configured shards.
 DROP DISTRIBUTION ALL CASCADE;
  distribution_id 
 -----------------

--- a/test/regress/tests/coordinator/expected/coordinator.out
+++ b/test/regress/tests/coordinator/expected/coordinator.out
@@ -44,7 +44,11 @@ SHOW key_ranges;
 (1 row)
 
 CREATE KEY RANGE krid2 FROM 33 ROUTE TO nonexistentshard FOR DISTRIBUTION ds1;
-ERROR:  unknown shard nonexistentshard
+ERROR:  Shard "nonexistentshard" not found.
+
+Available shards: sh1, sh2, sh3, sh4
+Hint: Run 'SHOW SHARDS' to see all configured shards.
+      Run 'ADD SHARD nonexistentshard WITH HOSTS ...' to create it.
 DROP DISTRIBUTION ALL CASCADE;
  distribution_id 
 -----------------

--- a/test/regress/tests/coordinator/expected/shards.out
+++ b/test/regress/tests/coordinator/expected/shards.out
@@ -105,7 +105,8 @@ SHOW SHARDS;
 (4 rows)
 
 ALTER SHARD unknown OPTIONS (ADD SSLMODE 'require');
-ERROR:  SPQRD: unknown shard unknown
+ERROR:  SPQRD: Shard "unknown" not found.
+HINT:  Run 'SHOW shards' to see all configured shards.
 ALTER SHARD sh1 OPTIONS (DROP SSLMODE 'require', ADD SSLMODE 'verify-full');
 ERROR:  SPQRV: malformed options array
 HINT:  option "sslmode" with value "require" not found


### PR DESCRIPTION
Provide actionable shard-not-found messages for key-range validation with available shard list and hints, and clean gRPC wrappers before emitting console errors so users see the underlying problem directly.