### PR TITLE
fix: deep-copy pgproto3 message byte slices to prevent cross-client data contamination

### DIFF
--- a/router/frontend/frontend.go
+++ b/router/frontend/frontend.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"context"
 	"io"
+	"slices"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgproto3"
@@ -16,6 +17,7 @@ import (
 	"github.com/pg-sharding/spqr/router/qrouter"
 	"github.com/pg-sharding/spqr/router/relay"
 	"github.com/pg-sharding/spqr/router/statistics"
+	"github.com/pg-sharding/spqr/router/xproto"
 )
 
 // ProcessMessage: process client iteration, until next transaction status idle
@@ -54,6 +56,7 @@ func ProcessMessage(qr qrouter.QueryRouter, rst relay.RelayStateMgr, msg pgproto
 		// copy interface
 		cpQ := *q
 		q = &cpQ
+		q.ParameterOIDs = slices.Clone(q.ParameterOIDs)
 
 		rst.AddExtendedProtocMessage(q)
 		return nil
@@ -68,6 +71,8 @@ func ProcessMessage(qr qrouter.QueryRouter, rst relay.RelayStateMgr, msg pgproto
 		// copy interface
 		cpQ := *q
 		q = &cpQ
+		q.Arguments = xproto.CopyByteSlices(q.Arguments)
+
 		spqrlog.Zero.Debug().
 			Uint("client", rst.Client().ID()).
 			Msg("client function call: simply fire parse stmt to connection")
@@ -85,6 +90,9 @@ func ProcessMessage(qr qrouter.QueryRouter, rst relay.RelayStateMgr, msg pgproto
 		// copy interface
 		cpQ := *q
 		q = &cpQ
+		q.Parameters = xproto.CopyByteSlices(q.Parameters)
+		q.ResultFormatCodes = slices.Clone(q.ResultFormatCodes)
+		q.ParameterFormatCodes = slices.Clone(q.ParameterFormatCodes)
 
 		rst.AddExtendedProtocMessage(q)
 		return nil

--- a/router/qrouter/proxy_routing.go
+++ b/router/qrouter/proxy_routing.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pg-sharding/spqr/router/rmeta"
 	"github.com/pg-sharding/spqr/router/server"
 	"github.com/pg-sharding/spqr/router/virtual"
+	"github.com/pg-sharding/spqr/router/xproto"
 
 	"github.com/pg-sharding/lyx/lyx"
 )
@@ -473,7 +474,7 @@ func (qr *ProxyQrouter) planQueryV1(
 						for _, is := range iis {
 							for _, col := range is.Columns {
 								colValues[col] = append(colValues[col],
-									v.Values[ind])
+									slices.Clone(v.Values[ind]))
 								ind++
 							}
 						}
@@ -1042,9 +1043,7 @@ func (qr *ProxyQrouter) addSortToPlan(
 							case *pgproto3.ErrorResponse:
 								errmsg = v
 							case *pgproto3.DataRow:
-								vals := make([][]byte, len(v.Values))
-								copy(vals, v.Values)
-								retSlice.TTS.Raw = append(retSlice.TTS.Raw, vals)
+								retSlice.TTS.Raw = append(retSlice.TTS.Raw, xproto.CopyByteSlices(v.Values))
 							default:
 								/* All ok? */
 							}
@@ -1149,9 +1148,7 @@ func (qr *ProxyQrouter) addLimitToPlan(
 					case *pgproto3.DataRow:
 
 						if len(retSlice.TTS.Raw) < limitVal {
-							vals := make([][]byte, len(v.Values))
-							copy(vals, v.Values)
-							retSlice.TTS.Raw = append(retSlice.TTS.Raw, vals)
+							retSlice.TTS.Raw = append(retSlice.TTS.Raw, xproto.CopyByteSlices(v.Values))
 						}
 
 					default:
@@ -1322,7 +1319,7 @@ func (qr *ProxyQrouter) planSPQR_CTID(
 					case *pgproto3.ErrorResponse:
 						errmsg = v
 					case *pgproto3.DataRow:
-						vals := v.Values
+						vals := xproto.CopyByteSlices(v.Values)
 
 						vals = append([][]byte{fmt.Appendf(nil, "shard %s", sh.Name())}, vals...)
 

--- a/router/relay/relay_utils.go
+++ b/router/relay/relay_utils.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/prepstatement"
 	"github.com/pg-sharding/spqr/pkg/shard"
 	"github.com/pg-sharding/spqr/router/server"
+	"github.com/pg-sharding/spqr/router/xproto"
 )
 
 func BindAndReadSliceResult(rst *RelayStateImpl, bind *pgproto3.Bind, portal string) error {
@@ -93,17 +94,8 @@ recvLoop:
 			cp := *q
 			rd.ParamDesc = &cp
 		case *pgproto3.RowDescription:
-			// copy
-			rd.RowDesc = &pgproto3.RowDescription{}
-
-			rd.RowDesc.Fields = make([]pgproto3.FieldDescription, len(q.Fields))
-
-			for i := range len(q.Fields) {
-				s := make([]byte, len(q.Fields[i].Name))
-				copy(s, q.Fields[i].Name)
-
-				rd.RowDesc.Fields[i] = q.Fields[i]
-				rd.RowDesc.Fields[i].Name = s
+			rd.RowDesc = &pgproto3.RowDescription{
+				Fields: xproto.CopyFieldDescriptions(q.Fields),
 			}
 		case *pgproto3.ReadyForQuery:
 			break recvLoop
@@ -183,17 +175,8 @@ recvLoop:
 			saveCloseComplete = q
 
 		case *pgproto3.RowDescription:
-			// copy
-			rd.rd = &pgproto3.RowDescription{}
-
-			rd.rd.Fields = make([]pgproto3.FieldDescription, len(q.Fields))
-
-			for i := range len(q.Fields) {
-				s := make([]byte, len(q.Fields[i].Name))
-				copy(s, q.Fields[i].Name)
-
-				rd.rd.Fields[i] = q.Fields[i]
-				rd.rd.Fields[i].Name = s
+			rd.rd = &pgproto3.RowDescription{
+				Fields: xproto.CopyFieldDescriptions(q.Fields),
 			}
 		default:
 			return nil, fmt.Errorf("received unexpected message type %T", msg)

--- a/router/xproto/copy.go
+++ b/router/xproto/copy.go
@@ -1,0 +1,46 @@
+package xproto
+
+import (
+	"slices"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+)
+
+// CopyFieldDescriptions returns a deep copy of a []pgproto3.FieldDescription.
+// It clones the Name byte slice for each field to prevent data contamination
+// from shared buffers.
+func CopyFieldDescriptions(src []pgproto3.FieldDescription) []pgproto3.FieldDescription {
+	if src == nil {
+		return nil
+	}
+	dst := make([]pgproto3.FieldDescription, len(src))
+	copy(dst, src)
+	for i := range dst {
+		if dst[i].Name != nil {
+			dst[i].Name = slices.Clone(dst[i].Name)
+		}
+	}
+	return dst
+}
+
+// CopyByteSlices returns a deep copy of a [][]byte.
+// Each non-nil element is copied into freshly allocated memory,
+// ensuring no references to the original backing arrays remain.
+//
+// This is necessary because pgproto3 decodes message fields like
+// Bind.Parameters and DataRow.Values as sub-slices of a shared
+// read buffer (chunkReader) backed by a global sync.Pool.
+// Retaining those sub-slices past the next Receive() call risks
+// cross-query data contamination.
+func CopyByteSlices(src [][]byte) [][]byte {
+	if src == nil {
+		return nil
+	}
+	dst := make([][]byte, len(src))
+	for i, s := range src {
+		if s != nil {
+			dst[i] = slices.Clone(s)
+		}
+	}
+	return dst
+}

--- a/router/xproto/copy_test.go
+++ b/router/xproto/copy_test.go
@@ -1,0 +1,55 @@
+package xproto
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopyFieldDescriptions_NilInput(t *testing.T) {
+	if got := CopyFieldDescriptions(nil); got != nil {
+		t.Errorf("CopyFieldDescriptions(nil) = %v, want nil", got)
+	}
+}
+
+func TestCopyFieldDescriptions_DeepCopy(t *testing.T) {
+	src := []pgproto3.FieldDescription{
+		{Name: []byte("original"), TableOID: 1, DataTypeOID: 25},
+		{Name: []byte("second"), TableOID: 2, DataTypeOID: 23},
+	}
+	exp := []pgproto3.FieldDescription{
+		{Name: []byte("original"), TableOID: 1, DataTypeOID: 25},
+		{Name: []byte("second"), TableOID: 2, DataTypeOID: 23},
+	}
+	dst := CopyFieldDescriptions(src)
+
+	assert.Equal(t, exp, dst)
+}
+
+func TestCopyFieldDescriptions_NilName(t *testing.T) {
+	src := []pgproto3.FieldDescription{
+		{Name: nil, DataTypeOID: 25},
+	}
+	exp := []pgproto3.FieldDescription{
+		{Name: nil, DataTypeOID: 25},
+	}
+	dst := CopyFieldDescriptions(src)
+
+	assert.Equal(t, exp, dst)
+}
+
+func TestCopyByteSlices_NilInput(t *testing.T) {
+	if got := CopyByteSlices(nil); got != nil {
+		t.Errorf("CopyByteSlices(nil) = %v, want nil", got)
+	}
+}
+
+func TestCopyByteSlices_DeepCopy(t *testing.T) {
+	src := [][]byte{[]byte("hello"), []byte("world"), nil}
+	exp := [][]byte{[]byte("hello"), []byte("world"), nil}
+
+	dst := CopyByteSlices(src)
+
+	assert.Equal(t, exp, dst)
+}


### PR DESCRIPTION
## Summary

`pgproto3.Backend.Receive()` returns flyweight message structs whose `[][]byte` fields (`Bind.Parameters`, `FunctionCall.Arguments`, `DataRow.Values`) are sub-slices of a shared `chunkReader` buffer backed by a global `sync.Pool` (`iobufpool`). The pgproto3 docs explicitly state:

> "The returned message is only valid until the next call to Receive."

SPQR's `frontend.ProcessMessage` performs a shallow struct copy (`cpQ := *q`) before storing these messages in `xBuf` for deferred processing at Sync time. This copies the struct but **not** the underlying byte data — the `[][]byte` elements still point into the shared read buffer. Between the Bind `Receive()` and the eventual `ProcessExtendedBuffer`, subsequent `Receive()` calls can trigger `chunkReader` buffer recycling (`iobufpool.Put` / `iobufpool.Get`), allowing a completely different client goroutine to overwrite the buffer contents.

## Bug chain

```
pgproto3.Bind.Decode(src):
    dst.Parameters[i] = src[rp : rp+msgSize]     // sub-slice, NOT a copy

chunkReader.Next():
    if r.rp == r.wp {
        iobufpool.Put(r.buf)                       // recycle to global sync.Pool
        r.buf = iobufpool.Get(r.minBufSize)        // may come from ANY goroutine
    }

frontend.ProcessMessage():
    cpQ := *q    // shallow copy — Parameters still references the recycled buffer
    rst.AddExtendedProtocMessage(q)                // stored until Sync arrives
```

## Observed symptoms in production

Under concurrent load (multiple application consumers hitting the same router instance), query parameters were cross-contaminated with data from unrelated clients:

- **Integer parameter received Cyrillic text**: a `SELECT ... WHERE nmId IN ($1, $2)` with integer params received `"подч"` (a fragment of a Russian word from another client's INSERT)
- **Integer parameter received URL fragment**: same query type received `"61119/76"` (a path segment from another client's query)
- **Raw bytes in text parameters**: `0xbe` appearing in what should have been UTF-8 text

Retries did not help because the corruption was in the router's buffer pool, not in the connection. Every new query through the same SPQR router instance hit the same poisoned buffer pool.

## Root cause diagram

```
Client A: Bind(nmId=12345)
  → cl.Receive() → Backend.Receive()
    → chunkReader.Next() returns sub-slice of buf
      → Bind.Decode: Parameters[i] = src[rp:rp+msgSize]
        → frontend.go: cpQ := *q (shallow copy)
          → xBuf stores Bind; Parameters still points into buf

Client A: next cl.Receive() for Execute/Sync
  → chunkReader: rp == wp → iobufpool.Put(buf) → returned to global sync.Pool

Client B goroutine (concurrent):
  → iobufpool.Get() → receives the SAME buf
    → Client B fills buf with its own data (e.g. Cyrillic INSERT values)

Client A: ProcessExtendedBuffer
  → reads Parameters → sees Client B's data → sends garbage to shard
```

## Scope of affected fields

Only `[][]byte` fields decoded via sub-slicing need deep-copy. Other fields are safe:

| Field | Type | Safe? | Why |
|-------|------|-------|-----|
| `Bind.DestinationPortal` | `string` | Yes | `string()` copies bytes |
| `Bind.PreparedStatement` | `string` | Yes | `string()` copies bytes |
| `Bind.ParameterFormatCodes` | `[]int16` | Yes | `make([]int16, ...)` with `Uint16` reads |
| `Bind.ResultFormatCodes` | `[]int16` | Yes | `make([]int16, ...)` with `Uint16` reads |
| **`Bind.Parameters`** | `[][]byte` | **No** | **sub-slices of src** |
| `Parse.Name`, `Parse.Query` | `string` | Yes | `string()` copies bytes |
| `Parse.ParameterOIDs` | `[]uint32` | Yes | read via `buf.Next(4)` copy |
| **`FunctionCall.Arguments`** | `[][]byte` | **No** | **sub-slices of src** |
| **`DataRow.Values`** | `[][]byte` | **No** | **sub-slices of src** |

## Fix

Deep-copy all retained `[][]byte` fields at the earliest retention point:

- **`Bind.Parameters`** in `frontend.ProcessMessage` — primary fix for the reported bug
- **`FunctionCall.Arguments`** in `frontend.ProcessMessage` — same sub-slicing pattern
- **`DataRow.Values`** in `proxy_routing.go` — two locations where values are stored across shard `Receive()` iterations (`colValues` in distributed INSERT, `tts.Raw` in scatter plan)

A shared `xproto.CopyByteSlices` helper is added, following the existing `append([]byte(nil), ...)` idiom already used in `relay/executor.go` for `cacheCC.CommandTag`.

## Files changed

- **New**: `router/xproto/copy.go` — `CopyByteSlices([][]byte) [][]byte` helper
- **Edit**: `router/frontend/frontend.go` — deep-copy `Bind.Parameters` and `FunctionCall.Arguments`
- **Edit**: `router/qrouter/proxy_routing.go` — deep-copy `DataRow.Values` in two locations

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./router/...` passes (all existing tests)
- [x] `go test ./pkg/...` passes (all existing tests)
- [x] Deployed to production — confirmed the cross-contamination no longer occurs under the same concurrent workload that previously triggered it
