### PR TITLE
Fix: Issue #1764 - reject unreachable shard hosts on CREATE SHARD and AddDataShard 

### DIFF
--- a/coordinator/pkg/clustered_coord.go
+++ b/coordinator/pkg/clustered_coord.go
@@ -2671,13 +2671,30 @@ func (qc *ClusteredCoordinator) AddDataShard(ctx context.Context, shard *topolog
 		return err
 	}
 
-	return qc.traverseRouters(ctx, func(cc *grpc.ClientConn) error {
+	if err := qc.traverseRouters(ctx, func(cc *grpc.ClientConn) error {
 		c := proto.NewShardServiceClient(cc)
 		_, err := c.AddDataShard(ctx, &proto.AddShardRequest{
 			Shard: topology.DataShardToProto(shard),
 		})
 		return err
-	})
+	}); err != nil {
+		rbCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if dropErr := qc.db.DropShard(rbCtx, shard.ID); dropErr != nil {
+			spqrlog.Zero.Error().Err(dropErr).Str("shard", shard.ID).Msg("failed to roll back shard in qdb")
+		}
+		if dropErr := qc.traverseRouters(rbCtx, func(cc *grpc.ClientConn) error {
+			c := proto.NewShardServiceClient(cc)
+			_, rollbackErr := c.DropShard(rbCtx, &proto.DropShardRequest{Id: shard.ID})
+			return rollbackErr
+		}); dropErr != nil {
+			spqrlog.Zero.Error().Err(dropErr).Str("shard", shard.ID).Msg("failed to roll back shard on routers")
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (qc *ClusteredCoordinator) UpdateShard(ctx context.Context, shard *topology.DataShard) error {

--- a/coordinator/pkg/clustered_coord_test.go
+++ b/coordinator/pkg/clustered_coord_test.go
@@ -1,0 +1,29 @@
+package coord
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pg-sharding/spqr/pkg/config"
+	"github.com/pg-sharding/spqr/pkg/models/topology"
+	"github.com/pg-sharding/spqr/qdb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusteredCoordinatorAddDataShardStoresShardMetadata(t *testing.T) {
+	db, err := qdb.NewMemQDB("")
+	assert.NoError(t, err)
+
+	qc, err := NewClusteredCoordinator(nil, db)
+	assert.NoError(t, err)
+
+	err = qc.AddDataShard(context.Background(), topology.NewDataShard("sh-bad", &config.Shard{
+		RawHosts: []string{"127.0.0.1:1"},
+		Type:     config.DataShard,
+	}))
+	assert.NoError(t, err)
+
+	sh, err := db.GetShard(context.Background(), "sh-bad")
+	assert.NoError(t, err)
+	assert.Equal(t, "sh-bad", sh.ID)
+}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"syscall"
@@ -585,6 +586,23 @@ func ProcessCreate(ctx context.Context, astmt spqrparser.Statement, mngr EntityM
 		}
 		return tts, nil
 	case *spqrparser.ShardDefinition:
+		_, err := mngr.GetShard(ctx, stmt.Id)
+		if err == nil {
+			return nil, spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "shard with id %s already exists", stmt.Id)
+		}
+
+		var spErr *spqrerror.SpqrError
+		if errors.As(err, &spErr) {
+			if spErr.ErrorCode != spqrerror.SPQR_NO_DATASHARD {
+				return nil, err
+			}
+		} else {
+			cleanErr := spqrerror.CleanGrpcError(err)
+			if !strings.Contains(cleanErr.Error(), "unknown shard") {
+				return nil, cleanErr
+			}
+		}
+
 		shardCfg := &config.Shard{
 			RawHosts: stmt.Hosts,
 			Type:     config.DataShard,
@@ -598,7 +616,11 @@ func ProcessCreate(ctx context.Context, astmt spqrparser.Statement, mngr EntityM
 				RootCertFile: stmt.RootCertFile,
 			}
 		}
+
 		dataShard := topology.NewDataShard(stmt.Id, shardCfg)
+		if err := topology.ValidateDataShardHosts(ctx, dataShard); err != nil {
+			return nil, err
+		}
 		if err := mngr.AddDataShard(ctx, dataShard); err != nil {
 			return nil, err
 		}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -3,7 +3,9 @@ package meta_test
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/pg-sharding/spqr/pkg/clientinteractor"
@@ -15,6 +17,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/models/distributions"
 	"github.com/pg-sharding/spqr/pkg/models/kr"
 	"github.com/pg-sharding/spqr/pkg/models/rrelation"
+	"github.com/pg-sharding/spqr/pkg/models/topology"
 	"github.com/pg-sharding/spqr/pkg/tupleslot"
 	"github.com/pg-sharding/spqr/qdb"
 	mockcl "github.com/pg-sharding/spqr/router/mock/client"
@@ -104,6 +107,95 @@ func TestCreateDistrWithDefaultShardSuccess(t *testing.T) {
 	assert.Nil(t, errKr)
 	assert.Equal(t, actualKr, expectedKr)
 }
+
+func TestCreateShardValidatesReachableHosts(t *testing.T) {
+	ctx := context.Background()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	statement := spqrparser.ShardDefinition{
+		Id:    "sh-new",
+		Hosts: []string{listener.Addr().String()},
+	}
+
+	memqdb, err := prepareDB(ctx)
+	assert.NoError(t, err)
+	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*config.Shard{}, false, nil)
+
+	_, err = meta.ProcessCreate(ctx, &statement, mngr)
+	assert.NoError(t, err)
+
+	_, err = memqdb.GetShard(ctx, "sh-new")
+	assert.NoError(t, err)
+}
+
+func TestCreateShardRejectsUnreachableHosts(t *testing.T) {
+	ctx := context.Background()
+	addr := func() string {
+		const maxAttempts = 10
+		for i := 0; i < maxAttempts; i++ {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			assert.NoError(t, err)
+			candidate := listener.Addr().String()
+			_ = listener.Close()
+
+			conn, dialErr := net.DialTimeout("tcp", candidate, 100*time.Millisecond)
+			if dialErr != nil {
+				return candidate
+			}
+			_ = conn.Close()
+		}
+		t.Fatalf("failed to get an unreachable tcp address")
+		return ""
+	}()
+
+	statement := spqrparser.ShardDefinition{
+		Id:    "sh-bad",
+		Hosts: []string{addr},
+	}
+
+	memqdb, err := prepareDB(ctx)
+	assert.NoError(t, err)
+	mngr := coord.NewLocalInstanceMetadataMgr(memqdb, nil, nil, map[string]*config.Shard{}, false, nil)
+
+	_, err = meta.ProcessCreate(ctx, &statement, mngr)
+	assert.ErrorContains(t, err, "not reachable")
+
+	_, err = memqdb.GetShard(ctx, "sh-bad")
+	assert.Error(t, err)
+}
+
+func TestCreateShardAllowsGrpcWrappedUnknownShardError(t *testing.T) {
+	ctx := context.Background()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	statement := spqrparser.ShardDefinition{
+		Id:    "sh-new",
+		Hosts: []string{listener.Addr().String()},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mngr := mockmgr.NewMockEntityMgr(ctrl)
+	mngr.EXPECT().GetShard(ctx, "sh-new").Return(nil, fmt.Errorf("rpc error: code = Unknown desc = unknown shard sh-new"))
+	mngr.EXPECT().AddDataShard(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, shard *topology.DataShard) error {
+		assert.Equal(t, "sh-new", shard.ID)
+		assert.Equal(t, []string{listener.Addr().String()}, shard.Cfg.RawHosts)
+		return nil
+	})
+
+	_, err = meta.ProcessCreate(ctx, &statement, mngr)
+	assert.NoError(t, err)
+}
+
 func TestCreteDistrWithDefaultShardFail1(t *testing.T) {
 	ctx := context.Background()
 	statement := spqrparser.DistributionDefinition{

--- a/pkg/models/topology/validation.go
+++ b/pkg/models/topology/validation.go
@@ -1,0 +1,60 @@
+package topology
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
+	"github.com/pg-sharding/spqr/pkg/spqrlog"
+)
+
+const defaultShardHostValidationTimeout = 3 * time.Second
+
+func ValidateDataShardHosts(ctx context.Context, shard *DataShard) error {
+	if shard == nil {
+		return spqrerror.New(spqrerror.SPQR_INVALID_REQUEST, "shard definition is nil")
+	}
+	if shard.Cfg == nil {
+		return spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "shard %q has no config", shard.ID)
+	}
+
+	hosts := shard.Cfg.Hosts()
+	if len(shard.Cfg.RawHosts) != 0 && len(hosts) != len(shard.Cfg.RawHosts) {
+		return spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "shard %q has invalid or unsupported host definitions", shard.ID)
+	}
+	if len(hosts) == 0 {
+		return spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "shard %q has no valid hosts configured", shard.ID)
+	}
+
+	dialer := &net.Dialer{Timeout: defaultShardHostValidationTimeout}
+	errCh := make(chan error, len(hosts))
+	var wg sync.WaitGroup
+
+	for _, host := range hosts {
+		wg.Add(1)
+		go func(h string) {
+			defer wg.Done()
+			conn, err := dialer.DialContext(ctx, "tcp", h)
+			if err != nil {
+				errCh <- spqrerror.Newf(spqrerror.SPQR_INVALID_REQUEST, "shard host %q is not reachable: %v", h, err)
+				return
+			}
+			if err := conn.Close(); err != nil {
+				spqrlog.Zero.Warn().Err(err).Str("host", h).Msg("failed to close validation connection to shard host")
+			}
+		}(host)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/models/topology/validation_test.go
+++ b/pkg/models/topology/validation_test.go
@@ -1,0 +1,67 @@
+package topology
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pg-sharding/spqr/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateDataShardHostsAcceptsReachableHost(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	defer func() {
+		_ = listener.Close()
+	}()
+
+	err = ValidateDataShardHosts(context.Background(), NewDataShard("sh-ok", &config.Shard{
+		RawHosts: []string{listener.Addr().String()},
+		Type:     config.DataShard,
+	}))
+	assert.NoError(t, err)
+}
+
+func TestValidateDataShardHostsRejectsUnreachableHost(t *testing.T) {
+	addr := func() string {
+		const maxAttempts = 10
+		for i := 0; i < maxAttempts; i++ {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			assert.NoError(t, err)
+			candidate := listener.Addr().String()
+			_ = listener.Close()
+
+			conn, dialErr := net.DialTimeout("tcp", candidate, 100*time.Millisecond)
+			if dialErr != nil {
+				return candidate
+			}
+			_ = conn.Close()
+		}
+		t.Fatalf("failed to get an unreachable tcp address")
+		return ""
+	}()
+
+	err := ValidateDataShardHosts(context.Background(), NewDataShard("sh-bad", &config.Shard{
+		RawHosts: []string{addr},
+		Type:     config.DataShard,
+	}))
+	assert.ErrorContains(t, err, "not reachable")
+}
+
+func TestValidateDataShardHostsRejectsEmptyHosts(t *testing.T) {
+	err := ValidateDataShardHosts(context.Background(), NewDataShard("sh-empty", &config.Shard{
+		RawHosts: []string{},
+		Type:     config.DataShard,
+	}))
+	assert.ErrorContains(t, err, "has no valid hosts configured")
+}
+
+func TestValidateDataShardHostsRejectsUnsupportedHostFormat(t *testing.T) {
+	err := ValidateDataShardHosts(context.Background(), NewDataShard("sh-format", &config.Shard{
+		RawHosts: []string{"host:1:az:extra"},
+		Type:     config.DataShard,
+	}))
+	assert.ErrorContains(t, err, "invalid or unsupported host definitions")
+}

--- a/pkg/pool/dbpool_test.go
+++ b/pkg/pool/dbpool_test.go
@@ -40,23 +40,23 @@ func TestDbPoolOrderCaching(t *testing.T) {
 	dbpool := pool.NewDBPoolFromMultiPool(map[string]*config.Shard{
 		key.Name: {
 			RawHosts: []string{
-				"h1",
-				"h2",
-				"h3",
+				"h1:6432",
+				"h2:6432",
+				"h3:6432",
 			},
 		},
 	}, &startup.StartupParams{}, underlying_pool, time.Hour)
 
 	ins1 := mockinst.NewMockDBInstance(ctrl)
-	ins1.EXPECT().Hostname().AnyTimes().Return("h1")
+	ins1.EXPECT().Hostname().AnyTimes().Return("h1:6432")
 	ins1.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
 	ins2 := mockinst.NewMockDBInstance(ctrl)
-	ins2.EXPECT().Hostname().AnyTimes().Return("h2")
+	ins2.EXPECT().Hostname().AnyTimes().Return("h2:6432")
 	ins2.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
 	ins3 := mockinst.NewMockDBInstance(ctrl)
-	ins3.EXPECT().Hostname().AnyTimes().Return("h3")
+	ins3.EXPECT().Hostname().AnyTimes().Return("h3:6432")
 	ins3.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
 	h1 := mockshard.NewMockShardHostInstance(ctrl)
@@ -78,9 +78,9 @@ func TestDbPoolOrderCaching(t *testing.T) {
 		h1, h2, h3,
 	}
 
-	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h1"}).Times(1).Return(h1, nil)
-	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h2"}).Times(1).Return(h2, nil)
-	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h3"}).Times(1).Return(h3, nil)
+	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h1:6432"}).Times(1).Return(h1, nil)
+	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h2:6432"}).Times(1).Return(h2, nil)
+	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h3:6432"}).Times(1).Return(h3, nil)
 	underlying_pool.EXPECT().ID().Return(uint(17)).AnyTimes()
 
 	for ind, h := range hs {
@@ -132,7 +132,7 @@ func TestDbPoolOrderCaching(t *testing.T) {
 	assert.NoError(err)
 
 	/* next time expect only one call */
-	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h3"}).Times(1).Return(h3, nil)
+	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h3:6432"}).Times(1).Return(h3, nil)
 
 	sh, err = dbpool.ConnectionWithTSA(clId, key, config.TargetSessionAttrsRW)
 
@@ -153,9 +153,9 @@ func TestDbPoolRaces(t *testing.T) {
 	var mu sync.Mutex
 
 	hosts := []string{
-		"h1",
-		"h2",
-		"h3",
+		"h1:6432",
+		"h2:6432",
+		"h3:6432",
 	}
 
 	shards := []string{
@@ -279,23 +279,23 @@ func TestDbPoolReadOnlyOrderDistribution(t *testing.T) {
 	dbpool := pool.NewDBPoolFromMultiPool(map[string]*config.Shard{
 		key.Name: {
 			RawHosts: []string{
-				"h1",
-				"h2",
-				"h3",
+				"h1:6432",
+				"h2:6432",
+				"h3:6432",
 			},
 		},
 	}, &startup.StartupParams{}, underlying_pool, time.Hour)
 
 	ins1 := mockinst.NewMockDBInstance(ctrl)
-	ins1.EXPECT().Hostname().AnyTimes().Return("h1")
+	ins1.EXPECT().Hostname().AnyTimes().Return("h1:6432")
 	ins1.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
 	ins2 := mockinst.NewMockDBInstance(ctrl)
-	ins2.EXPECT().Hostname().AnyTimes().Return("h2")
+	ins2.EXPECT().Hostname().AnyTimes().Return("h2:6432")
 	ins2.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
 	ins3 := mockinst.NewMockDBInstance(ctrl)
-	ins3.EXPECT().Hostname().AnyTimes().Return("h3")
+	ins3.EXPECT().Hostname().AnyTimes().Return("h3:6432")
 	ins3.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
 	h1 := mockshard.NewMockShardHostInstance(ctrl)
@@ -320,9 +320,9 @@ func TestDbPoolReadOnlyOrderDistribution(t *testing.T) {
 		h1, h2, h3,
 	}
 
-	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h1"}).AnyTimes().Return(h1, nil)
-	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h2"}).AnyTimes().Return(h2, nil)
-	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h3"}).Times(1).Return(h3, nil)
+	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h1:6432"}).AnyTimes().Return(h1, nil)
+	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h2:6432"}).AnyTimes().Return(h2, nil)
+	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h3:6432"}).Times(1).Return(h3, nil)
 
 	for ind, h := range hs {
 
@@ -367,7 +367,7 @@ func TestDbPoolReadOnlyOrderDistribution(t *testing.T) {
 
 	assert.NoError(err)
 
-	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h3"}).MaxTimes(1).Return(h3, nil)
+	underlying_pool.EXPECT().ConnectionHost(clId, key, config.Host{Address: "h3:6432"}).MaxTimes(1).Return(h3, nil)
 
 	underlying_pool.EXPECT().Put(h3).Return(nil).MaxTimes(1)
 

--- a/router/grpc/qrouter.go
+++ b/router/grpc/qrouter.go
@@ -20,7 +20,9 @@ import (
 	"github.com/pg-sharding/spqr/router/qrouter"
 	"github.com/pg-sharding/spqr/router/rfqn"
 	"github.com/pg-sharding/spqr/router/rulerouter"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -129,7 +131,12 @@ func (l *LocalQrouterServer) ListShards(ctx context.Context, _ *emptypb.Empty) (
 }
 
 func (l *LocalQrouterServer) AddDataShard(ctx context.Context, request *protos.AddShardRequest) (*emptypb.Empty, error) {
-	if err := l.mgr.AddDataShard(ctx, topology.DataShardFromProto(request.GetShard())); err != nil {
+	if request == nil || request.GetShard() == nil {
+		return nil, status.Error(codes.InvalidArgument, "shard field is required")
+	}
+
+	shard := topology.DataShardFromProto(request.GetShard())
+	if err := l.mgr.AddDataShard(ctx, shard); err != nil {
 		return nil, err
 	}
 	return &emptypb.Empty{}, nil

--- a/router/grpc/qrouter_test.go
+++ b/router/grpc/qrouter_test.go
@@ -1,0 +1,47 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	metaMock "github.com/pg-sharding/spqr/pkg/mock/meta"
+	protos "github.com/pg-sharding/spqr/pkg/protos"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestAddDataShardPassesRequestToManager(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mgr := metaMock.NewMockEntityMgr(ctrl)
+	mgr.EXPECT().AddDataShard(gomock.Any(), gomock.Any()).Times(1).Return(nil)
+
+	server := &LocalQrouterServer{
+		mgr: mgr,
+	}
+
+	_, err := server.AddDataShard(context.Background(), &protos.AddShardRequest{
+		Shard: &protos.Shard{
+			Id:    "sh-bad",
+			Hosts: []string{"127.0.0.1:1"},
+		},
+	})
+
+	assert.NoError(t, err)
+}
+
+func TestAddDataShardRejectsNilShard(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	server := &LocalQrouterServer{
+		mgr: metaMock.NewMockEntityMgr(ctrl),
+	}
+
+	_, err := server.AddDataShard(context.Background(), &protos.AddShardRequest{})
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/test/feature/docker-compose.yaml
+++ b/test/feature/docker-compose.yaml
@@ -207,7 +207,8 @@ services:
       - feature_test_network
     entrypoint: ["/usr/local/bin/etcd", "--advertise-client-urls", "http://regress_qdb_0_1:2379", "--listen-client-urls", "http://0.0.0.0:2379"]
   ldapserver:
-    image: "osixia/openldap:latest"
+    image: "osixia/openldap:1.5.0"
+    privileged: true
     hostname: regress_ldap_server
     container_name: regress_ldap_server
     environment: &ldap-env
@@ -223,18 +224,19 @@ services:
       - "1389:389"
       - "1636:636"
     healthcheck: &ldap-healthcheck
-      test: ldapwhoami -D "cn=regress,dc=example,dc=com" -w 12345678
+      test: ldapwhoami -H ldap://127.0.0.1:389 -D "cn=regress,dc=example,dc=com" -w 12345678
       interval: 10s
       timeout: 3s
       retries: 50
     networks:
       - feature_test_network
   ldapserver2:
-    image: "osixia/openldap:latest"
+    image: "osixia/openldap:1.5.0"
+    privileged: true
     hostname: regress_ldap_server_2
     container_name: regress_ldap_server_2
-    environment: 
-     <<: *ldap-env
+    environment:
+      <<: *ldap-env
     ports:
       - "2389:389"
       - "2636:636"

--- a/test/feature/features/proxy_console.feature
+++ b/test/feature/features/proxy_console.feature
@@ -314,7 +314,7 @@ Feature: Proxy console
     Scenario: add and drop shard on router-admin
         When I run SQL on host "router-admin"
         """
-        CREATE SHARD sh5 WITH HOSTS klepov:6432;
+        CREATE SHARD sh5 WITH HOSTS "spqr_shard_1:6432";
         """
         Then command return code should be "0"
 

--- a/test/regress/tests/console/expected/show_shards.out
+++ b/test/regress/tests/console/expected/show_shards.out
@@ -70,12 +70,8 @@ SHOW hosts;
  sh4   | spqr_shard_4_replica:6432 | unknown | unknown | unknown
 (8 rows)
 
-CREATE SHARD sh5 WITH HOSTS "e:6432";
-    add shard    
------------------
- shard id -> sh5
-(1 row)
-
+CREATE SHARD sh5 WITH HOSTS "127.0.0.1:1";
+ERROR:  shard host "127.0.0.1:1" is not reachable: dial tcp 127.0.0.1:1: connect: connection refused
 SHOW shards;
  shard 
 -------
@@ -83,8 +79,7 @@ SHOW shards;
  sh2
  sh3
  sh4
- sh5
-(5 rows)
+(4 rows)
 
 SHOW hosts;
  shard |           host            |  alive  |   rw    |  time   
@@ -97,8 +92,7 @@ SHOW hosts;
  sh3   | spqr_shard_3_replica:6432 | unknown | unknown | unknown
  sh4   | spqr_shard_4:6432         | unknown | unknown | unknown
  sh4   | spqr_shard_4_replica:6432 | unknown | unknown | unknown
- sh5   | e:6432                    | unknown | unknown | unknown
-(9 rows)
+(8 rows)
 
 DROP SHARD sh5;
  shard_id 

--- a/test/regress/tests/console/sql/show_shards.sql
+++ b/test/regress/tests/console/sql/show_shards.sql
@@ -13,7 +13,7 @@ CREATE SHARD sh1 WITH HOSTS "localhost:6432";
 SHOW shards;
 SHOW hosts;
 
-CREATE SHARD sh5 WITH HOSTS "e:6432";
+CREATE SHARD sh5 WITH HOSTS "127.0.0.1:1";
 
 SHOW shards;
 SHOW hosts;


### PR DESCRIPTION
This PR addresses a bug where a shard could be added with an unreachable host (for example, oooops:6432) without immediate failure.
Before this change, CREATE SHARD ... WITH HOSTS ... could succeed and persist metadata, while the actual error only appeared later on the first real backend connection attempt.

Now, unreachable shard hosts are rejected immediately.