### PR TITLE
fix EtcdQDB.GetRelationSequence

### DIFF
--- a/qdb/etcdqdb.go
+++ b/qdb/etcdqdb.go
@@ -145,11 +145,11 @@ func sequenceNodePath(key string) string {
 
 func relationSequenceMappingNodePath(relation *rfqn.RelationFQN) string {
 	/* XXX: migrate here */
-	return path.Join(columnSequenceMappingNamespace, relation.RelationName)
+	return path.Join(columnSequenceMappingNamespace, relation.RelationName) + "/"
 }
 
 func columnSequenceMappingNodePath(relation *rfqn.RelationFQN, colName string) string {
-	return path.Join(relationSequenceMappingNodePath(relation), colName)
+	return path.Join(columnSequenceMappingNamespace, relation.RelationName, colName)
 }
 
 func taskGroupNodePath(id string) string {

--- a/test/regress/run_tests_coord.sh
+++ b/test/regress/run_tests_coord.sh
@@ -51,7 +51,7 @@ echo "go test!"
 insert_greeting "console"
 run_tests "console" "regress_router" "7432"
 #TODO: fix bugs, remove commented 'run_tests'
-#run_tests "router" "regress_router" "6432"
+run_tests "router" "regress_router" "6432"
 #run_tests "pooler" "regress_pooler" "6432"
 sleep 10
 echo "kill cluster"


### PR DESCRIPTION
issue #1725
0. next regress test step is enabled for clustered installation 
1. fixed EtcdQDB.GetRelationSequence:
```
regress_tests_coord   | not ok 29    - sequence                                  272 ms
...
regress_tests_coord   | --- /regress/tests/router/expected/sequence.out	2026-03-14 15:01:00.347311509 +0200
regress_tests_coord   | +++ /regress/tests/router/results/sequence.out	2026-03-14 15:15:49.449746385 +0200
regress_tests_coord   | @@ -122,9 +122,10 @@
regress_tests_coord   |  (1 row)
regress_tests_coord   |  
regress_tests_coord   |  SHOW sequences;
regress_tests_coord   | - name | value 
regress_tests_coord   | -------+-------
regress_tests_coord   | -(0 rows)
regress_tests_coord   | +  name   | value 
regress_tests_coord   | +---------+-------
regress_tests_coord   | + test_id | 3
regress_tests_coord   | +(1 row)
```