### PR TITLE
move retries "keyrange locks" BL to meta layer (step 2)

### DIFF
--- a/coordinator/pkg/clustered_coord.go
+++ b/coordinator/pkg/clustered_coord.go
@@ -741,7 +741,7 @@ func (qc *ClusteredCoordinator) CreateKeyRange(ctx context.Context, keyRange *kr
 
 // TODO : unit tests
 func (qc *ClusteredCoordinator) LockKeyRange(ctx context.Context, keyRangeID string) (*kr.KeyRange, error) {
-	keyRange, err := meta.LockKeyRange(ctx, &qc.Coordinator, keyRangeID)
+	keyRange, err := qc.Coordinator.LockKeyRange(ctx, keyRangeID)
 	if err != nil {
 		return nil, err
 	}

--- a/coordinator/provider/keyranges.go
+++ b/coordinator/provider/keyranges.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pg-sharding/spqr/pkg/meta"
 	"github.com/pg-sharding/spqr/pkg/models/tasks"
 
 	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
@@ -44,7 +43,7 @@ func (c *CoordinatorService) CreateKeyRange(ctx context.Context, request *protos
 // TODO : unit tests
 func (c *CoordinatorService) LockKeyRange(ctx context.Context, request *protos.LockKeyRangeRequest) (*protos.ModifyReply, error) {
 	for _, id := range request.Id {
-		_, err := meta.LockKeyRange(ctx, c.impl, id)
+		_, err := c.impl.LockKeyRange(ctx, id)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/meta/key_range_meta.go
+++ b/pkg/meta/key_range_meta.go
@@ -195,6 +195,15 @@ func dropKeyRange(ctx context.Context, mngr *TranEntityManager, id string) error
 	return nil
 }
 
+// locks key range with retries
+//
+// Parameters:
+// - ctx (context.Context): The context of the operation.
+// - mngr (TranEntityManager): The entity manager used to manage the entities.
+// - keyRangeID (string): key range to lock
+// Returns:
+// - *kr.KeyRange: locked key range.
+// - error: An error if the locking any issues.
 func LockKeyRange(ctx context.Context, mngr EntityMgr, keyRangeID string) (*kr.KeyRange, error) {
 	t := time.Now()
 	if kr, err := retry.DoValue(ctx, retry.WithMaxRetries(MaxLockRetry,

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1029,7 +1029,7 @@ func ProcMetadataCommand(ctx context.Context,
 
 		return tts, nil
 	case *spqrparser.Lock:
-		if _, err := mgr.LockKeyRange(ctx, stmt.KeyRangeID); err != nil {
+		if _, err := LockKeyRange(ctx, mgr, stmt.KeyRangeID); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
issue #1737 
0) I think i twice runs retries fo lock key range in step 1 (https://github.com/pg-sharding/spqr/pull/2164): for service and for clustered coordinator. 
```
Coordinator -> main.go

var rootCmd = &cobra.Command{
...
		coordinator, err := coord.NewClusteredCoordinator(frTLS, db)
...
		app := app.NewApp(coordinator)
```
removed for servise
1) retries in lock key range are moved from clustered coordinator to meta layer