### PR TITLE
Enable recently-fixed steps in clustered regress suite

### DIFF
--- a/test/regress/run_tests_coord.sh
+++ b/test/regress/run_tests_coord.sh
@@ -79,7 +79,7 @@ run_tests "kill_cluster" "regress_coordinator" "7002"
 sleep 10
 run_tests "coordinator" "regress_coordinator" "7002"
 
-# Сompare the results of the local and qdb coordinators
+# Compare the results of the local and qdb coordinators
 run_tests "common" "regress_coordinator" "7002"
 
 save_diffs /regress/tests/common/


### PR DESCRIPTION
Successful steps for clustered regress test suite are added. There's only one test left that doesn't pass.