### PR TITLE
ci: cancel stale test runs on new push

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_SHARD: spqr-shard-image
   SHARD_CACHE_KEY: sha256sum-of-docker-shard


### PR DESCRIPTION
## Summary

- Add `concurrency` group to `tests.yaml` so a new push cancels the in-progress run for the same branch
- Matches the pattern already used in `spelling.yaml`
- Frees up runners sooner for other PRs and master builds

closes #2198