### PR TITLE
Fix panic on concurrent access to qdb.Distribution maps

### DIFF
--- a/qdb/memqdb.go
+++ b/qdb/memqdb.go
@@ -1125,7 +1125,7 @@ func (q *MemQDB) GetDistribution(_ context.Context, id string) (*Distribution, e
 		// DEPRECATE this
 		return nil, spqrerror.Newf(spqrerror.SPQR_OBJECT_NOT_EXIST, "distribution \"%s\" not found", id)
 	} else {
-		return ds, nil
+		return ds.Copy(), nil
 	}
 }
 
@@ -1145,7 +1145,7 @@ func (q *MemQDB) relationDistributionInternal(relation *rfqn.RelationFQN) (*Dist
 	} else {
 		// if there is no distr by key ds
 		// then we have corruption
-		return q.Distributions[ds], nil
+		return q.Distributions[ds].Copy(), nil
 	}
 }
 

--- a/qdb/models.go
+++ b/qdb/models.go
@@ -2,6 +2,7 @@ package qdb
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"time"
 
@@ -304,4 +305,18 @@ func (d *Distribution) GetRelation(fqn *rfqn.RelationFQN) (*DistributedRelation,
 
 	r, ok = d.FQNRelations[fqn.String()]
 	return r, ok
+}
+
+func (d *Distribution) Copy() *Distribution {
+	retDs := &Distribution{
+		ID:            d.ID,
+		ColTypes:      d.ColTypes,
+		Relations:     map[string]*DistributedRelation{},
+		FQNRelations:  map[string]*DistributedRelation{},
+		UniqueIndexes: map[string]*UniqueIndex{},
+	}
+	maps.Copy(retDs.Relations, d.Relations)
+	maps.Copy(retDs.FQNRelations, d.FQNRelations)
+	maps.Copy(retDs.UniqueIndexes, d.UniqueIndexes)
+	return retDs
 }


### PR DESCRIPTION
```
fatal error: concurrent map iteration and map write

goroutine 90290 [running]:
internal/runtime/maps.fatal({0x1be5aae?, 0x0?})
	/usr/local/go/src/runtime/panic.go:1181 +0x18
internal/runtime/maps.(*Iter).Next(0xf8977560?)
	/usr/local/go/src/internal/runtime/maps/table.go:819 +0x9b
github.com/pg-sharding/spqr/pkg/models/distributions.DistributionFromDB(0x8e4bcc49c00)
	/root/build/spqr/pkg/models/distributions/distribution.go:458 +0x556
github.com/pg-sharding/spqr/pkg/coord.(*Coordinator).GetRelationDistribution(0x8e4bc9ec040, {0x1c5a2d8, 0x26eb060}, 0x8e4bf7ff840)
	/root/build/spqr/pkg/coord/coord.go:576 +0x145
github.com/pg-sharding/spqr/router/rmeta.(*RoutingMetadataContext).GetRelationDistribution(0x8e4c05eaf00, {0x1c5a2d8, 0x26eb060}, 0x8e4bf7ff840)
	/root/build/spqr/router/rmeta/rmeta.go:203 +0x174
github.com/pg-sharding/spqr/router/planner.ProcessRangeNode({0x1c5a2d8, 0x26eb060}, 0x8e4c05eaf00, 0x8e4bf881260)
	/root/build/spqr/router/planner/plan_utils.go:363 +0x168
github.com/pg-sharding/spqr/router/planner.analyzeFromNode({0x1c5a2d8, 0x26eb060}, {0x1c4a160, 0x8e4bf881260}, 0x8e4c05eaf00)
	/root/build/spqr/router/planner/analyze.go:86 +0x174
github.com/pg-sharding/spqr/router/planner.analyzeFromClauseList({0x1c5a2d8, 0x26eb060}, {0x8e4bd8fd670, 0x1, 0x1}, 0x8e4c05eaf00)
	/root/build/spqr/router/planner/analyze.go:24 +0xd8
github.com/pg-sharding/spqr/router/planner.AnalyzeQueryV1({0x1c5a2d8, 0x26eb060}, 0x8e4c05eaf00, {0x1c4a060, 0x8e4c02e3980})
	/root/build/spqr/router/planner/analyze.go:431 +0x1385
github.com/pg-sharding/spqr/router/qrouter.(*ProxyQrouter).AnalyzeQuery(0x8e4bcbe6000, {0x1c5a2d8, 0x26eb060}, {0x7fd54803e168, 0x8e4be824a90}, 0x8e4bcc80b90, {0x8e4c04470e0, 0x8b}, {0x1c4a060, 0x8e4c02e3980})
	/root/build/spqr/router/qrouter/proxy.go:62 +0x207
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).ProcessSimpleQuery(0x8e4be55d6c0, 0x8e4bd8fd640, 0x1)
	/root/build/spqr/router/relay/relay.go:1250 +0x191
github.com/pg-sharding/spqr/router/frontend.ProcessMessage.func1()
	/root/build/spqr/router/frontend/frontend.go:59 +0x4e
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).queryProc(0x8e4be55d6c0, {0x8e4c044714e, 0x1b}, 0x8e4bf7ff7e0)
	/root/build/spqr/router/relay/qstate.go:223 +0x1559
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).ProcQueryAdvanced(0x8e4be55d6c0, {0x8e4c04470e0, 0x8b}, {0x1a39e00, 0x26edbc0}, {0x8e4c044714e, 0x1b}, 0x8e4bf7ff7e0, 0x0)
	/root/build/spqr/router/relay/qstate.go:551 +0x15cf
github.com/pg-sharding/spqr/router/relay.(*RelayStateImpl).ProcQueryAdvancedTx(0x8e4be55d6c0, {0x8e4c04470e0, 0x8b}, 0x8e4bf7ff7e0, 0x0, 0x1)
	/root/build/spqr/router/relay/qstate.go:96 +0x5f3
github.com/pg-sharding/spqr/router/frontend.ProcessMessage({0x1c64ff0, 0x8e4bcbe6000}, {0x1c726a0, 0x8e4be55d6c0}, {0x1c54ce0, 0x8e4be55f640})
	/root/build/spqr/router/frontend/frontend.go:57 +0x4fe
github.com/pg-sharding/spqr/router/frontend.Frontend({0x1c64ff0, 0x8e4bcbe6000}, {0x1c7f638, 0x8e4be824a90}, {0x1c56690, 0x26eb060}, {0x1c604f8, 0x8e4bcbd6150})
	/root/build/spqr/router/frontend/frontend.go:161 +0x8c5
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).serv(0x8e4bcbe2080, {0x1c63418, 0x8e4bce90500}, 0x0)
	/root/build/spqr/router/instance/instance.go:231 +0xabb
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run.func3()
	/root/build/spqr/router/instance/instance.go:279 +0x65
created by github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run in goroutine 167
	/root/build/spqr/router/instance/instance.go:278 +0x6a5
```