### PR TITLE
proto_test.go: split deallocate test

### DIFF
--- a/test/xproto/proto_test.go
+++ b/test/xproto/proto_test.go
@@ -6925,7 +6925,20 @@ func TestDiscardAllRemovesPstmts(t *testing.T) {
 				},
 			},
 		},
+	}
+	XprotoTestRunner(t, frontend, tt)
+}
 
+func TestDiscardAllRemovesPstmtsByXproto(t *testing.T) {
+
+	frontend, conn, err := bootstrapConnection(t)
+	assert.NoError(t, err, "startup failed")
+
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	tt := []MessageGroup{
 		/* by Execute(DISCARD) */
 		{
 			Request: []pgproto3.FrontendMessage{
@@ -7104,6 +7117,20 @@ func TestDeallocateRemovesPstmts(t *testing.T) {
 				},
 			},
 		},
+	}
+	XprotoTestRunner(t, frontend, tt)
+}
+
+func TestDeallocateRemovesPstmtsByXproto(t *testing.T) {
+
+	frontend, conn, err := bootstrapConnection(t)
+	assert.NoError(t, err, "startup failed")
+
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	tt := []MessageGroup{
 		/* by Execute(DEALLOCATE ALL) */
 		{
 			Request: []pgproto3.FrontendMessage{
@@ -7342,6 +7369,20 @@ func TestDeallocatePrepareRemovesPstmts(t *testing.T) {
 				},
 			},
 		},
+	}
+	XprotoTestRunner(t, frontend, tt)
+}
+
+func TestDeallocatePrepareRemovesPstmtsByXproto(t *testing.T) {
+
+	frontend, conn, err := bootstrapConnection(t)
+	assert.NoError(t, err, "startup failed")
+
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	tt := []MessageGroup{
 		/* by Execute(DEALLOCATE ALL) */
 		{
 			Request: []pgproto3.FrontendMessage{


### PR DESCRIPTION
To run DEALLOCATE by simple query and by xproto