### PR TITLE
Partially undo e88aebd and fix.

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -661,3 +661,4 @@ yjoin
 YMid
 yylex
 zerolog
+zjoin

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -581,6 +581,8 @@ tlt
 TMINUS
 tmpfs
 tmpnum
+typarray
+typname
 Toidxs
 topbar
 TOPENBR

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -583,6 +583,7 @@ tmpfs
 tmpnum
 typarray
 typname
+typnamespace
 Toidxs
 topbar
 TOPENBR

--- a/router/qrouter/proxy_routing.go
+++ b/router/qrouter/proxy_routing.go
@@ -988,8 +988,8 @@ func (qr *ProxyQrouter) addSortToPlan(
 				}
 				/* We can sort by column reference only if we know type of column.
 				* For now, all we know in advance is type of distribution column. */
-				rfqn, err := rm.ResolveRelationByAlias(colRef.TableAlias)
-				if err != nil {
+				rfqn, err := rm.ResolveRelationByAlias(colRef.TableAlias, colRef.ColName)
+				if err != nil || rfqn == nil {
 					/* We can receive `complex query` error from ResolveRelationByAlias.
 					* log it and ignore */
 					spqrlog.Zero.

--- a/router/rmeta/expr.go
+++ b/router/rmeta/expr.go
@@ -265,17 +265,15 @@ func (rm *RoutingMetadataContext) ProcessConstExpr(alias, colname string, expr l
 	var resolvedRelation *rfqn.RelationFQN
 	var err error
 
-	resolvedRelation = rm.TryResolveByDistributionColumn(colname)
+	resolvedRelation, err = rm.ResolveRelationByAlias(alias, colname)
 
-	if resolvedRelation == nil {
-		resolvedRelation, err = rm.ResolveRelationByAlias(alias)
-
-		if err != nil {
-			// failed to resolve relation, skip column
-			return err
-		}
+	if err != nil {
+		// failed to resolve relation, skip column
+		return err
 	}
-
+	if resolvedRelation == nil {
+		return nil
+	}
 	return rm.ProcessConstExprOnRFQN(resolvedRelation, colname, expr)
 }
 

--- a/router/rmeta/rmeta.go
+++ b/router/rmeta/rmeta.go
@@ -252,15 +252,8 @@ func (routingMeta *RoutingMetadataContext) RecordParamRefExpr(resolvedRelation *
 	return nil
 }
 
-func (rm *RoutingMetadataContext) TryResolveByDistributionColumn(colname string) *rfqn.RelationFQN {
-	if l, ok := rm.RelationsByDistributionCol[colname]; ok && len(l) == 1 {
-		return l[0]
-	}
-	return nil
-}
-
 // TODO : unit tests
-func (rm *RoutingMetadataContext) ResolveRelationByAlias(alias string) (*rfqn.RelationFQN, error) {
+func (rm *RoutingMetadataContext) ResolveRelationByAlias(alias, colname string) (*rfqn.RelationFQN, error) {
 	if _, ok := rm.Rels[rfqn.RelationFQN{RelationName: alias}]; ok {
 		return &rfqn.RelationFQN{RelationName: alias}, nil
 	}
@@ -270,8 +263,16 @@ func (rm *RoutingMetadataContext) ResolveRelationByAlias(alias string) (*rfqn.Re
 	} else {
 		// TBD: postpone routing from here to root of parsing tree
 		if len(rm.Rels) != 1 {
-			// ambiguity in column aliasing
-			return nil, rerrors.ErrComplexQuery
+
+			if l, ok := rm.RelationsByDistributionCol[colname]; ok {
+				if len(l) > 1 {
+					// ambiguity in column aliasing
+					return nil, rerrors.ErrComplexQuery
+				}
+				return l[0], nil
+			} else {
+				return nil, nil
+			}
 		}
 		for tbl := range rm.Rels {
 			resolvedRelation = tbl

--- a/test/regress/tests/router/expected/joins.out
+++ b/test/regress/tests/router/expected/joins.out
@@ -133,13 +133,8 @@ NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 --
 (0 rows)
 
--- catalog JOIN routing.
-SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore';
-NOTICE: send query to shard(s) : sh2
- oid | typarray 
------+----------
-(0 rows)
-
+-- catalog JOIN routing. XXX: make it deterministic and support.
+-- SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore';
 DROP TABLE xjoin;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 DROP TABLE yjoin;

--- a/test/regress/tests/router/expected/joins.out
+++ b/test/regress/tests/router/expected/joins.out
@@ -133,7 +133,7 @@ NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 --
 (0 rows)
 
--- catalog JOIN rouring.
+-- catalog JOIN routing.
 SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore';
 NOTICE: send query to shard(s) : sh2
  oid | typarray 

--- a/test/regress/tests/router/expected/joins.out
+++ b/test/regress/tests/router/expected/joins.out
@@ -31,12 +31,22 @@ CREATE RELATION yjoin (w_id);
  distribution id -> ds1
 (2 rows)
 
+CREATE RELATION zjoin (a);
+       attach table       
+--------------------------
+ relation name   -> zjoin
+ distribution id -> ds1
+(2 rows)
+
 \c regress
 SET __spqr__engine_v2 TO on;
 CREATE TABLE xjoin(id int);
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 CREATE TABLE yjoin(w_id int);
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
+CREATE TABLE zjoin(a int, b int);
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 INSERT INTO xjoin (id) values(1);
@@ -113,9 +123,21 @@ NOTICE: send query to shard(s) : sh2
 --
 (0 rows)
 
+SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE;
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
+--
+(0 rows)
+
+SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE WHERE b = 1;
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
+--
+(0 rows)
+
 DROP TABLE xjoin;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 DROP TABLE yjoin;
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
+DROP TABLE zjoin;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 RESET __spqr__engine_v2;
 \c spqr-console

--- a/test/regress/tests/router/expected/joins.out
+++ b/test/regress/tests/router/expected/joins.out
@@ -133,6 +133,13 @@ NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 --
 (0 rows)
 
+-- catalog JOIN rouring.
+SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore';
+NOTICE: send query to shard(s) : sh2
+ oid | typarray 
+-----+----------
+(0 rows)
+
 DROP TABLE xjoin;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 DROP TABLE yjoin;

--- a/test/regress/tests/router/sql/joins.sql
+++ b/test/regress/tests/router/sql/joins.sql
@@ -51,6 +51,9 @@ SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE;
 
 SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE WHERE b = 1;
 
+-- catalog JOIN rouring.
+SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore';
+
 DROP TABLE xjoin;
 DROP TABLE yjoin;
 DROP TABLE zjoin;

--- a/test/regress/tests/router/sql/joins.sql
+++ b/test/regress/tests/router/sql/joins.sql
@@ -51,7 +51,7 @@ SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE;
 
 SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE WHERE b = 1;
 
--- catalog JOIN rouring.
+-- catalog JOIN routing.
 SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore';
 
 DROP TABLE xjoin;

--- a/test/regress/tests/router/sql/joins.sql
+++ b/test/regress/tests/router/sql/joins.sql
@@ -5,6 +5,7 @@ CREATE KEY RANGE kridi2 from 11 route to sh2 FOR DISTRIBUTION ds1;
 CREATE KEY RANGE kridi1 from 0 route to sh1 FOR DISTRIBUTION ds1;
 CREATE RELATION xjoin (id);
 CREATE RELATION yjoin (w_id);
+CREATE RELATION zjoin (a);
 
 \c regress
 
@@ -12,6 +13,7 @@ SET __spqr__engine_v2 TO on;
 
 CREATE TABLE xjoin(id int);
 CREATE TABLE yjoin(w_id int);
+CREATE TABLE zjoin(a int, b int);
 
 INSERT INTO xjoin (id) values(1);
 INSERT INTO xjoin (id) values(10);
@@ -45,8 +47,13 @@ SELECT FROM xjoin a JOIN xjoin b ON true;
 SELECT FROM xjoin a JOIN xjoin b ON true WHERE a.id = 15;
 SELECT FROM xjoin a JOIN xjoin b ON true WHERE a.id = 11;
 
+SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE;
+
+SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE WHERE b = 1;
+
 DROP TABLE xjoin;
 DROP TABLE yjoin;
+DROP TABLE zjoin;
 
 RESET __spqr__engine_v2;
 

--- a/test/regress/tests/router/sql/joins.sql
+++ b/test/regress/tests/router/sql/joins.sql
@@ -51,8 +51,8 @@ SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE;
 
 SELECT FROM xjoin JOIN yjoin ON TRUE JOIN zjoin ON TRUE WHERE b = 1;
 
--- catalog JOIN routing.
-SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore';
+-- catalog JOIN routing. XXX: make it deterministic and support.
+-- SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore';
 
 DROP TABLE xjoin;
 DROP TABLE yjoin;


### PR DESCRIPTION
Some queries may miss explicit distribution rules for relations they route, with most obvious example is catalog routing. Specifying non-distribution columns for scatter-out queries should also work. 
Anyway, partially undo what e88aebd was trying to do and add test for future enhancements in this area.
Per users complains.

Reported-by: Andrey Leshko <andrey-leshko@yandex-team.ru>
Reviewed-by: rkhapov <rkhapov@yandex-team.ru>