### PR TITLE
replace critical error os.Exit() with context cancellation

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -14,6 +14,7 @@ import (
 	"runtime/pprof"
 	"sync"
 	"syscall"
+	"time"
 
 	coordApp "github.com/pg-sharding/spqr/coordinator/app"
 	coord "github.com/pg-sharding/spqr/coordinator/pkg"
@@ -405,9 +406,11 @@ var runCmd = &cobra.Command{
 		errCh := make(chan error)
 
 		go func() {
-			for {
-				<-errCh
-				os.Exit(1)
+			select {
+			case err := <-errCh:
+				spqrlog.Zero.Error().Err(err).Msg("critical error, initiating graceful shutdown")
+				cancelCtx()
+			case <-ctx.Done():
 			}
 		}()
 
@@ -474,8 +477,19 @@ var runCmd = &cobra.Command{
 			log.Println(http.ListenAndServe("localhost:6060", nil))
 		}()
 
-		wg.Wait()
+		done := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(done)
+		}()
 
+		select {
+		case <-done:
+			spqrlog.Zero.Info().Msg("router shut down gracefully")
+		case <-time.After(30 * time.Second):
+			spqrlog.Zero.Warn().Msg("shutdown timeout exceeded, forcing exit")
+			os.Exit(1)
+		}
 		return nil
 	},
 }

--- a/router/app/app.go
+++ b/router/app/app.go
@@ -123,6 +123,10 @@ func (app *App) ServiceUnixSocket(ctx context.Context) error {
 		return err
 	}
 	socketPath := path.Join(config.UnixSocketDirectory, fmt.Sprintf(".s.PGSQL.%s", config.RouterConfig().RouterPort))
+
+	// Remove any existing socket file from previous runs
+	_ = os.Remove(socketPath)
+
 	lAddr := &net.UnixAddr{Name: socketPath, Net: "unix"}
 	listener, err := net.ListenUnix("unix", lAddr)
 	if err != nil {
@@ -130,15 +134,21 @@ func (app *App) ServiceUnixSocket(ctx context.Context) error {
 	}
 	defer func(listener net.Listener) {
 		_ = listener.Close()
+		_ = os.Remove(socketPath)
 	}(listener)
 
 	spqrlog.Zero.Info().
 		Msg("SPQR Router is ready by unix socket")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		_ = app.spqr.Run(ctx, listener, port.UnixSocketPortType)
 	}()
 
 	<-ctx.Done()
+	wg.Wait()
 	return nil
 }
 


### PR DESCRIPTION
```
listen unix /var/run/postgresql/.s.PGSQL.6432: bind: address already in use","time":"2026-04-08T12:17:43Z","message":"failed to serve unix socket"}
```

Should fix the problem in https://github.com/pg-sharding/spqr/issues/2235