### PR TITLE
Switch errComplexQuery to use `spqrerror` infrastructure 

### DIFF
--- a/router/rerrors/errors.go
+++ b/router/rerrors/errors.go
@@ -1,7 +1,11 @@
 package rerrors
 
-import "fmt"
+import (
+	"fmt"
 
-var ErrComplexQuery = fmt.Errorf("too complex query to route")
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
+)
+
+var ErrComplexQuery = spqrerror.Newf(spqrerror.SPQR_NOT_IMPLEMENTED, "too complex query to route")
 var ErrExecutorSyncLost = fmt.Errorf("sync lost in execution phase")
 var ErrInformationSchemaCombinedQuery = fmt.Errorf("combined information schema and regular relation is not supported")

--- a/router/rmeta/rmeta.go
+++ b/router/rmeta/rmeta.go
@@ -272,7 +272,7 @@ func (rm *RoutingMetadataContext) ResolveRelationByAlias(alias, colname string) 
 			if l, ok := rm.RelationsByDistributionCol[colname]; ok {
 				if len(l) > 1 {
 					// ambiguity in column aliasing
-					return nil, rerrors.ErrComplexQuery
+					return nil, rerrors.ErrComplexQuery.Hint(fmt.Sprintf("relation reference ambiguite by alias/colref: %v/%v", alias, colname))
 				}
 				return l[0], nil
 			} else {

--- a/router/rmeta/rmeta.go
+++ b/router/rmeta/rmeta.go
@@ -272,7 +272,7 @@ func (rm *RoutingMetadataContext) ResolveRelationByAlias(alias, colname string) 
 			if l, ok := rm.RelationsByDistributionCol[colname]; ok {
 				if len(l) > 1 {
 					// ambiguity in column aliasing
-					return nil, rerrors.ErrComplexQuery.Hint(fmt.Sprintf("relation reference ambiguite by alias/colref: %v/%v", alias, colname))
+					return nil, rerrors.ErrComplexQuery.Hint(fmt.Sprintf("relation reference ambiguity by alias/colref: %v/%v", alias, colname))
 				}
 				return l[0], nil
 			} else {


### PR DESCRIPTION
```
ERROR:  too complex query to route
HINT:  relation reference ambiguity by alias/colref: lc/shard_key
```