### PR TITLE
Try to mitigate CI flaps by uncreasing `__spqr__console_execute` retr…

### DIFF
--- a/router/planner/planner.go
+++ b/router/planner/planner.go
@@ -512,7 +512,7 @@ func MetadataVirtualFunctionCall(ctx context.Context,
 				defer cf()
 			}
 
-			return retry.DoValue(ctx, retry.WithMaxRetries(2, retry.NewConstant(time.Second)), func(ctx context.Context) (*tupleslot.TupleTableSlot, error) {
+			return retry.DoValue(ctx, retry.WithMaxRetries(10, retry.NewConstant(time.Second)), func(ctx context.Context) (*tupleslot.TupleTableSlot, error) {
 				tts, err := meta.ProcMetadataCommand(ctx, tstmt, mgr, rm.CSM, rm.ClientRule, nil, false)
 				if err != nil {
 					if st, ok := status.FromError(err); ok && st.Code() == codes.Canceled && st.Message() == "grpc: the client connection is closing" {


### PR DESCRIPTION
…y count