### PR TITLE
Fix flacky tls_shard.feature test

### DIFF
--- a/pkg/models/transaction/transaction.go
+++ b/pkg/models/transaction/transaction.go
@@ -114,7 +114,7 @@ func checkCommandPart(part googleProto.Message, current int, target int) int {
 		return current
 	}
 	v := reflect.ValueOf(part)
-	if v.Kind() == reflect.Ptr && !v.IsNil() {
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
 		if current != GRUnknown {
 			return GRError
 		} else {

--- a/test/feature/features/tls_shard.feature
+++ b/test/feature/features/tls_shard.feature
@@ -256,6 +256,8 @@ Feature: TLS connections to shards via coordinator
     """
     Then command return code should be "0"
 
+    When we wait for "2" seconds
+
     When I run SQL on host "router"
     """
     CREATE TABLE test_sync (id INT PRIMARY KEY, data TEXT);


### PR DESCRIPTION
1) Changes metadata in coordinator and its propagating to routers are not instantly. This concerns SyncRouterMetadata too.
<img width="782" height="197" alt="image" src="https://github.com/user-attachments/assets/148fab1e-0398-4a14-887a-e0db91b1d75b" />


2) fixed linter issue. I don't know why the linter was activated on this PR. The linter has been acting strangely lately.
```
  pkg/models/transaction/transaction.go:117:17: inline: Constant reflect.Ptr should be inlined (govet)
  	if v.Kind() == reflect.Ptr && !v.IsNil() {
```