### PR TITLE
fix flacky coordinator.feature and proxy_console.feature tests

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2346,7 +2346,10 @@ func processAlterShard(ctx context.Context,
 func optionsToTuple(opts []topology.GenericOption) string {
 	t := []string{}
 	sort.Slice(opts, func(i, j int) bool {
-		return opts[i].Name < opts[j].Name
+		if opts[i].Name != opts[j].Name {
+			return opts[i].Name < opts[j].Name
+		}
+		return opts[i].Arg < opts[j].Arg
 	})
 	for _, v := range opts {
 		t = append(t, fmt.Sprintf("%s=%v", v.Name, v.Arg))

--- a/test/feature/features/coordinator.feature
+++ b/test/feature/features/coordinator.feature
@@ -480,11 +480,11 @@ Feature: Coordinator test
     [
       {
         "shard":"sh1",
-        "options": "{host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,db=regress,user=regress,password=12345678}"
+        "options": "{db=regress,host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,password=12345678,user=regress}"
       },
       {
         "shard":"sh2",
-        "options": "{host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432,db=regress,user=regress,password=12345678}"
+        "options": "{db=regress,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432,password=12345678,user=regress}"
       },
       {
         "shard":"sh3",
@@ -576,7 +576,7 @@ Feature: Coordinator test
     [
       {
         "shard":"sh2",
-        "options": "{host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432,db=regress,user=regress,password=12345678}"
+        "options": "{db=regress,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432,password=12345678,user=regress}"
       },
       {
         "shard":"sh3",
@@ -595,7 +595,7 @@ Feature: Coordinator test
     [
       {
         "shard":"sh2",
-        "options": "{db=regress,user=regress,password=12345678,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432}"
+        "options": "{db=regress,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432,password=12345678,user=regress}"
       },
       {
         "shard":"sh3",

--- a/test/feature/features/proxy_console.feature
+++ b/test/feature/features/proxy_console.feature
@@ -328,11 +328,11 @@ Feature: Proxy console
         [
             {
                 "shard":"sh1",
-                "options": "{db=regress,user=regress,password=12345678,host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432}"
+                "options": "{db=regress,host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,password=12345678,user=regress}"
             },
             {
                 "shard":"sh2",
-                "options": "{db=regress,user=regress,password=12345678,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432}"
+                "options": "{db=regress,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432,password=12345678,user=regress}"
             },
             {
                 "shard":"sh5",
@@ -357,11 +357,11 @@ Feature: Proxy console
         [
             {
                 "shard":"sh1",
-                "options": "{db=regress,user=regress,password=12345678,host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432}"
+                "options": "{db=regress,host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,password=12345678,user=regress}"
             },
             {
                 "shard":"sh2",
-                "options": "{db=regress,user=regress,password=12345678,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432}"
+                "options": "{db=regress,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432,password=12345678,user=regress}"
             },
             {
                 "shard":"sh5",
@@ -386,11 +386,11 @@ Feature: Proxy console
         [
             {
                 "shard":"sh1",
-                "options": "{db=regress,user=regress,password=12345678,host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432}"
+                "options": "{db=regress,host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,password=12345678,user=regress}"
             },
             {
                 "shard":"sh2",
-                "options": "{db=regress,user=regress,password=12345678,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432}"
+                "options": "{db=regress,host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432,password=12345678,user=regress}"
             }
         ]
         """

--- a/test/regress/tests/coordinator/expected/shards.out
+++ b/test/regress/tests/coordinator/expected/shards.out
@@ -38,7 +38,7 @@ ALTER SHARD sh1 OPTIONS (SSLMODE 'require', ADD USER 'test_user', ADD USER 'anot
                           alter shard                           
 ----------------------------------------------------------------
  shard id -> sh1
- options  -> {sslmode=require,user=test_user,user=another_user}
+ options  -> {sslmode=require,user=another_user,user=test_user}
 (2 rows)
 
 SHOW SHARDS;

--- a/test/regress/tests/coordinator/expected/shards.out
+++ b/test/regress/tests/coordinator/expected/shards.out
@@ -44,7 +44,7 @@ ALTER SHARD sh1 OPTIONS (SSLMODE 'require', ADD USER 'test_user', ADD USER 'anot
 SHOW SHARDS;
  shard |                                                 options                                                  
 -------+----------------------------------------------------------------------------------------------------------
- sh1   | {host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,sslmode=require,user=test_user,user=another_user}
+ sh1   | {host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,sslmode=require,user=another_user,user=test_user}
  sh2   | {host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432}
  sh3   | {host=spqr_shard_3:6432,host=spqr_shard_3_replica:6432}
  sh4   | {host=spqr_shard_4:6432,host=spqr_shard_4_replica:6432}
@@ -63,7 +63,7 @@ ALTER SHARD sh1 OPTIONS (SET SSLMODE 'allow');
 SHOW SHARDS;
  shard |                                                options                                                 
 -------+--------------------------------------------------------------------------------------------------------
- sh1   | {host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,sslmode=allow,user=test_user,user=another_user}
+ sh1   | {host=spqr_shard_1:6432,host=spqr_shard_1_replica:6432,sslmode=allow,user=another_user,user=test_user}
  sh2   | {host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432}
  sh3   | {host=spqr_shard_3:6432,host=spqr_shard_3_replica:6432}
  sh4   | {host=spqr_shard_4:6432,host=spqr_shard_4_replica:6432}
@@ -82,7 +82,7 @@ ALTER SHARD sh1 OPTIONS (DROP HOST 'spqr_shard_1_replica:6432');
 SHOW SHARDS;
  shard |                                 options                                 
 -------+-------------------------------------------------------------------------
- sh1   | {host=spqr_shard_1:6432,sslmode=allow,user=test_user,user=another_user}
+ sh1   | {host=spqr_shard_1:6432,sslmode=allow,user=another_user,user=test_user}
  sh2   | {host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432}
  sh3   | {host=spqr_shard_3:6432,host=spqr_shard_3_replica:6432}
  sh4   | {host=spqr_shard_4:6432,host=spqr_shard_4_replica:6432}
@@ -98,7 +98,7 @@ ALTER SHARD sh1 OPTIONS (DROP SSLMODE 'allow');
 SHOW SHARDS;
  shard |                          options                          
 -------+-----------------------------------------------------------
- sh1   | {host=spqr_shard_1:6432,user=test_user,user=another_user}
+ sh1   | {host=spqr_shard_1:6432,user=another_user,user=test_user}
  sh2   | {host=spqr_shard_2:6432,host=spqr_shard_2_replica:6432}
  sh3   | {host=spqr_shard_3:6432,host=spqr_shard_3_replica:6432}
  sh4   | {host=spqr_shard_4:6432,host=spqr_shard_4_replica:6432}


### PR DESCRIPTION

0) fixed coordinator.feature and proxy_console.feature. Sorting for GenericOption is by Name. see
```
func optionsToTuple(opts []topology.GenericOption) string {
	t := []string{}
	sort.Slice(opts, func(i, j int) bool {
		return opts[i].Name < opts[j].Name
	})
	for _, v := range opts {
		t = append(t, fmt.Sprintf("%s=%v", v.Name, v.Arg))
	}
	return fmt.Sprintf("{%s}", strings.Join(t, ","))
}
```

<img width="1132" height="563" alt="image" src="https://github.com/user-attachments/assets/f3ea187c-1260-4f50-a631-3bf42ed98ad7" />

1) added sorting by arg into optionsToTuple in case name is equal. its help make tests less fragile


ps fix for https://github.com/pg-sharding/spqr/pull/2350/