### PR TITLE
Fix govet inline warnings for generic slices calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	go.etcd.io/etcd/client/v3 v3.6.11
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.50.0
-	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6
 	golang.org/x/sync v0.20.0
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 	google.golang.org/grpc v1.81.0
@@ -50,6 +49,7 @@ require (
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
+	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
 )
 
 require (

--- a/router/relay/executor.go
+++ b/router/relay/executor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pg-sharding/spqr/router/server"
 	"github.com/pg-sharding/spqr/router/statistics"
 	"github.com/pg-sharding/spqr/router/twopc"
-	"golang.org/x/exp/slices"
 
 	"github.com/pg-sharding/lyx/lyx"
 )
@@ -1094,9 +1093,14 @@ func (s *QueryStateExecutorImpl) ExpandRoutes(routes []kr.ShardKey) error {
 	beforeTx := s.Client().Server().TxStatus()
 
 	for _, shkey := range routes {
-		if slices.ContainsFunc(s.ActiveShards(), func(c kr.ShardKey) bool {
-			return shkey == c
-		}) {
+		found := false
+		for _, c := range s.ActiveShards() {
+			if shkey == c {
+				found = true
+				break
+			}
+		}
+		if found {
 			continue
 		}
 

--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pg-sharding/spqr/pkg/prepstatement"
 	"github.com/pg-sharding/spqr/pkg/shard"
 	"github.com/pg-sharding/spqr/qdb"
-	"golang.org/x/exp/slices"
 
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/pg-sharding/spqr/pkg/config"
@@ -755,7 +754,7 @@ func (rst *RelayStateImpl) DescribePrepared(objType byte, name string, dMsg *pgp
 			// columns from output
 			for ind := range def.OverwriteRemoveParamIDs {
 				// NB: ind are zero - indexed
-				desc.ParameterOIDs = slices.Delete(desc.ParameterOIDs, ind-1, ind)
+				desc.ParameterOIDs = append(desc.ParameterOIDs[:ind-1], desc.ParameterOIDs[ind:]...)
 			}
 
 			if err := rst.Client().Send(desc); err != nil {


### PR DESCRIPTION
`govet` is a set of analyzers built into Go. One of them — `inline` — checks whether the Go compiler can inline a function call, meaning substitute the function body directly at the call site instead of making an actual function call. This is an optimization that eliminates the overhead of a function call.

The problem was that `slices.ContainsFunc` and `slices.Delete` are generic functions (with type parameters). The Go compiler doesn't yet know how to inline generic calls when types are inferred automatically (type inference). The `inline` analyzer in the newer version of golangci-lint detects this and reports an error.

Plain code without generics is inlined by the compiler without issues, so the analyzer no longer complains.