### PR TITLE
Replace `golang.org/x/exp/slices` with stdlib `slices`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	go.etcd.io/etcd/client/v3 v3.6.11
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.50.0
-	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6
 	golang.org/x/sync v0.20.0
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 	google.golang.org/grpc v1.81.0
@@ -50,6 +49,7 @@ require (
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.3 // indirect
 	github.com/jackc/pgtype v1.14.0 // indirect
+	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect
 )
 
 require (

--- a/router/relay/executor.go
+++ b/router/relay/executor.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pg-sharding/spqr/router/server"
 	"github.com/pg-sharding/spqr/router/statistics"
 	"github.com/pg-sharding/spqr/router/twopc"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/pg-sharding/lyx/lyx"
 )

--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/prepstatement"
 	"github.com/pg-sharding/spqr/pkg/shard"
 	"github.com/pg-sharding/spqr/qdb"
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/jackc/pgx/v5/pgproto3"
 	"github.com/pg-sharding/spqr/pkg/config"


### PR DESCRIPTION
`golangci-lint 2.12.1` introduced stricter `govet` inline analysis. The `golang.org/x/exp/slices` functions are marked with `//go:fix inline` directives to migrate callers to the stdlib `slices` package. The analyzer detects these directives but cannot inline the calls because generic type parameter inference is not yet supported.