### PR TITLE
Fix router startup panic

### DIFF
--- a/router/client/client.go
+++ b/router/client/client.go
@@ -979,6 +979,11 @@ func (f FakeClient) Send(_ pgproto3.BackendMessage) error {
 	return nil
 }
 
+func (f FakeClient) ReplyErrMsgPure(e error) error {
+	spqrlog.Zero.Error().Err(e).Msg("sql init error")
+	return nil
+}
+
 var _ RouterClient = &FakeClient{}
 
 func NewNoopClient(clientInfo *routerproto.ClientInfo, rAddr string) NoopClient {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x19dcd92]

goroutine 1 [running]:
github.com/pg-sharding/spqr/router/client.(*FakeClient).ReplyErrMsgPure(0x2fe208d02cd0, {0x20cc500, 0x2fe208d02d10})
	<autogenerated>:1 +0x32
github.com/pg-sharding/spqr/pkg/clientinteractor.(*PSQLInteractor).ReportError(0x2fe208d02d00, {0x20cc500, 0x2fe208d02d10})
	/home/klea/repo/golang/spqr-klepov/pkg/clientinteractor/interactor.go:240 +0x74
github.com/pg-sharding/spqr/router/console.(*LocalInstanceConsole).ExecuteMetadataQuery(0x2fe208c16c30, {0x20e3af8, 0x2fe208c16910}, {0x20cbbe0, 0x2fe208d02cf0}, {0x21160f0, 0x2fe208d02cd0}, {0x20cbbc0, 0x2e237a0})
	/home/klea/repo/golang/spqr-klepov/router/console/console.go:144 +0x16b4
github.com/pg-sharding/spqr/router/console.(*LocalInstanceConsole).ProcessQuery(0x2fe208c16c30, {0x20e3af8, 0x2fe208c16910}, {0x2fe2089609c0, 0x2e}, {0x21160f0, 0x2fe208d02cd0}, {0x20cbbc0, 0x2e237a0})
	/home/klea/repo/golang/spqr-klepov/router/console/console.go:162 +0x3ec
github.com/pg-sharding/spqr/router/instance.(*InitSQLMetadataBootstrapper).InitializeMetadata(0x2fe208ca3c98, {0x20e3af8, 0x2fe208c16910}, {0x20e7720, 0x2fe208c6c880})
	/home/klea/repo/golang/spqr-klepov/router/instance/sqlfile.go:34 +0x4a2
```