### PR TITLE
Make ICP panic action to be os.Exit()

### DIFF
--- a/pkg/icp/control_point.go
+++ b/pkg/icp/control_point.go
@@ -2,6 +2,7 @@ package icp
 
 import (
 	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -49,7 +50,7 @@ var (
 
 var (
 	defaultPanicAction = func(ICPContextHolder) {
-		panic("reached control point")
+		log.Fatal("reached control point")
 	}
 
 	defaultSleepAction = func(ICPContextHolder) {


### PR DESCRIPTION
Current users of ICP expect that with panic action you do not have a chance to run any "recovery" defers