### PR TITLE
Add `Peek` method to Client.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -62,6 +62,8 @@ type Client interface {
 
 	Send(msg pgproto3.BackendMessage) error
 	Receive() (pgproto3.FrontendMessage, error)
+	/* Await and parse next message, but do not "Receive" it */
+	Peek() (pgproto3.FrontendMessage, error)
 
 	Flush() error
 

--- a/pkg/mock/client/mock_clientpool.go
+++ b/pkg/mock/client/mock_clientpool.go
@@ -511,6 +511,21 @@ func (mr *MockClientInfoMockRecorder) PasswordMD5(salt any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PasswordMD5", reflect.TypeOf((*MockClientInfo)(nil).PasswordMD5), salt)
 }
 
+// Peek mocks base method.
+func (m *MockClientInfo) Peek() (pgproto3.FrontendMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Peek")
+	ret0, _ := ret[0].(pgproto3.FrontendMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Peek indicates an expected call of Peek.
+func (mr *MockClientInfoMockRecorder) Peek() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peek", reflect.TypeOf((*MockClientInfo)(nil).Peek))
+}
+
 // PreferredEngine mocks base method.
 func (m *MockClientInfo) PreferredEngine() string {
 	m.ctrl.T.Helper()

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -71,6 +71,8 @@ type PsqlClient struct {
 	/* cancel */
 	csm *pgproto3.CancelRequest
 
+	peekMsg pgproto3.FrontendMessage
+
 	cancelPid uint32
 	cancelKey []byte
 
@@ -749,11 +751,32 @@ func (cl *PsqlClient) PasswordMD5(salt [4]byte) (string, error) {
 }
 
 func (cl *PsqlClient) Receive() (pgproto3.FrontendMessage, error) {
+	if cl.peekMsg != nil {
+		msg := cl.peekMsg
+		cl.peekMsg = nil
+		return msg, nil
+	}
 	msg, err := cl.be.Receive()
 	spqrlog.Zero.Debug().
 		Uint("client", cl.ID()).
 		Interface("message", msg).
 		Msg("received message from client")
+	return msg, err
+}
+
+func (cl *PsqlClient) Peek() (pgproto3.FrontendMessage, error) {
+	if cl.peekMsg != nil {
+		return cl.peekMsg, nil
+	}
+	msg, err := cl.be.Receive()
+	spqrlog.Zero.Debug().
+		Uint("client", cl.ID()).
+		Interface("message", msg).
+		Err(err).
+		Msg("received message from client")
+	if err == nil {
+		cl.peekMsg = msg
+	}
 	return msg, err
 }
 
@@ -972,6 +995,10 @@ func (f FakeClient) ID() uint {
 }
 
 func (f FakeClient) Receive() (pgproto3.FrontendMessage, error) {
+	return &pgproto3.Query{}, nil
+}
+
+func (f FakeClient) Peek() (pgproto3.FrontendMessage, error) {
 	return &pgproto3.Query{}, nil
 }
 

--- a/router/client/client_test.go
+++ b/router/client/client_test.go
@@ -52,6 +52,84 @@ func TestCancel(t *testing.T) {
 	assert.NoError(err)
 }
 
+func TestPeek(t *testing.T) {
+	assert := assert.New(t)
+	ctrl := gomock.NewController(t)
+
+	rconn := mock_conn.NewMockRawConn(ctrl)
+
+	req := pgproto3.StartupMessage{
+		ProtocolVersion: pgproto3.ProtocolVersion30,
+		Parameters: map[string]string{
+			"user":     "u",
+			"database": "d",
+		},
+	}
+
+	bts, _ := req.Encode(nil)
+
+	rconn.EXPECT().Read(gomock.Any()).DoAndReturn(
+		func(b []byte) (int, error) {
+			copy(b, bts[:4])
+			return 4, nil
+		}).Times(1)
+
+	rconn.EXPECT().Read(gomock.Any()).DoAndReturn(
+		func(b []byte) (int, error) {
+			copy(b, bts[4:])
+			return len(bts) - 4, nil
+		}).Times(1)
+
+	q1 := &pgproto3.Query{
+		String: "s1",
+	}
+
+	btsQ1, _ := q1.Encode(nil)
+
+	rconn.EXPECT().Read(gomock.Any()).DoAndReturn(
+		func(b []byte) (int, error) {
+			copy(b, btsQ1)
+			return len(btsQ1), nil
+		}).Times(1)
+
+	q2 := &pgproto3.Query{
+		String: "s2",
+	}
+
+	btsQ2, _ := q2.Encode(nil)
+
+	rconn.EXPECT().Read(gomock.Any()).DoAndReturn(
+		func(b []byte) (int, error) {
+			copy(b, btsQ2)
+			return len(btsQ2), nil
+		}).Times(1)
+
+	client := client.NewPsqlClient(rconn, port.DefaultRouterPortType, "BLOCK", false, "")
+
+	err := client.Init(nil)
+	assert.NoError(err)
+
+	m1, err := client.Peek()
+	assert.NoError(err)
+	assert.Equal(q1, m1)
+	m2, err := client.Peek()
+	assert.NoError(err)
+	assert.Equal(q1, m2)
+	m3, err := client.Receive()
+	assert.NoError(err)
+	assert.Equal(q1, m3)
+
+	m4, err := client.Peek()
+	assert.NoError(err)
+	assert.Equal(q2, m4)
+	m5, err := client.Peek()
+	assert.NoError(err)
+	assert.Equal(q2, m5)
+	m6, err := client.Receive()
+	assert.NoError(err)
+	assert.Equal(q2, m6)
+}
+
 func TestNoGSSAPI(t *testing.T) {
 	assert := assert.New(t)
 	ctrl := gomock.NewController(t)

--- a/router/client/client_test.go
+++ b/router/client/client_test.go
@@ -84,24 +84,24 @@ func TestPeek(t *testing.T) {
 		String: "s1",
 	}
 
-	btsQ1, _ := q1.Encode(nil)
+	bytesQ1, _ := q1.Encode(nil)
 
 	rconn.EXPECT().Read(gomock.Any()).DoAndReturn(
 		func(b []byte) (int, error) {
-			copy(b, btsQ1)
-			return len(btsQ1), nil
+			copy(b, bytesQ1)
+			return len(bytesQ1), nil
 		}).Times(1)
 
 	q2 := &pgproto3.Query{
 		String: "s2",
 	}
 
-	btsQ2, _ := q2.Encode(nil)
+	bytesQ2, _ := q2.Encode(nil)
 
 	rconn.EXPECT().Read(gomock.Any()).DoAndReturn(
 		func(b []byte) (int, error) {
-			copy(b, btsQ2)
-			return len(btsQ2), nil
+			copy(b, bytesQ2)
+			return len(bytesQ2), nil
 		}).Times(1)
 
 	client := client.NewPsqlClient(rconn, port.DefaultRouterPortType, "BLOCK", false, "")

--- a/router/frontend/frontend.go
+++ b/router/frontend/frontend.go
@@ -146,7 +146,6 @@ func ProcessMessage(_ qrouter.QueryRouter, rst relay.RelayStateMgr, msg pgproto3
 
 		return ReplyErrUtil(rst, rst.ProcessOneMsgCarefully(context.Background(), q))
 	case *pgproto3.Describe:
-
 		return ReplyErrUtil(rst, rst.ProcessOneMsgCarefully(context.Background(), q))
 	case *pgproto3.FunctionCall:
 		// copy interface
@@ -156,9 +155,7 @@ func ProcessMessage(_ qrouter.QueryRouter, rst relay.RelayStateMgr, msg pgproto3
 
 		return ReplyErrUtil(rst, rst.ProcessOneMsgCarefully(context.Background(), q))
 	case *pgproto3.Execute:
-
 		return ReplyErrUtil(rst, rst.ProcessOneMsgCarefully(context.Background(), q))
-
 	case *pgproto3.Bind:
 		// copy interface
 		cpQ := *q

--- a/router/mock/client/mock_client.go
+++ b/router/mock/client/mock_client.go
@@ -624,6 +624,21 @@ func (mr *MockRouterClientMockRecorder) PasswordMD5(salt any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PasswordMD5", reflect.TypeOf((*MockRouterClient)(nil).PasswordMD5), salt)
 }
 
+// Peek mocks base method.
+func (m *MockRouterClient) Peek() (pgproto3.FrontendMessage, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Peek")
+	ret0, _ := ret[0].(pgproto3.FrontendMessage)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Peek indicates an expected call of Peek.
+func (mr *MockRouterClientMockRecorder) Peek() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Peek", reflect.TypeOf((*MockRouterClient)(nil).Peek))
+}
+
 // PreferredEngine mocks base method.
 func (m *MockRouterClient) PreferredEngine() string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Allows inspect about-to-be-recieved message in relay handling and other places