### PR TITLE
Fix panic: unexpected proto version message size

### DIFF
--- a/router/client/client.go
+++ b/router/client/client.go
@@ -499,12 +499,12 @@ func (cl *PsqlClient) Init(tlsconfig *tls.Config) error {
 		}
 
 		msgSize := int(binary.BigEndian.Uint32(headerRaw) - 4)
-		msg := make([]byte, msgSize)
 
 		if msgSize != 4 {
-			return fmt.Errorf("message is of unexpected size %d, want size 4", msgSize)
+			return fmt.Errorf("message has unexpected size %d, want size 4", msgSize)
 		}
 
+		msg := make([]byte, msgSize)
 		_, err = cl.conn.Read(msg)
 		if err != nil {
 			return err

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -498,11 +498,12 @@ func (cl *PsqlClient) Init(tlsconfig *tls.Config) error {
 			return err
 		}
 
-		msgSize := int(binary.BigEndian.Uint32(headerRaw) - 4)
+		msgSize := int(binary.BigEndian.Uint32(headerRaw))
 
-		if msgSize < 4 {
-			return fmt.Errorf("message has unexpected size %d, want size 4", msgSize)
+		if msgSize < 8 {
+			return fmt.Errorf("message has unexpected size %d", msgSize)
 		}
+		msgSize -= 4
 
 		msg := make([]byte, msgSize)
 		_, err = cl.conn.Read(msg)

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -500,7 +500,7 @@ func (cl *PsqlClient) Init(tlsconfig *tls.Config) error {
 
 		msgSize := int(binary.BigEndian.Uint32(headerRaw) - 4)
 
-		if msgSize != 4 {
+		if msgSize < 4 {
 			return fmt.Errorf("message has unexpected size %d, want size 4", msgSize)
 		}
 

--- a/router/client/client.go
+++ b/router/client/client.go
@@ -501,6 +501,10 @@ func (cl *PsqlClient) Init(tlsconfig *tls.Config) error {
 		msgSize := int(binary.BigEndian.Uint32(headerRaw) - 4)
 		msg := make([]byte, msgSize)
 
+		if msgSize != 4 {
+			return fmt.Errorf("message is of unexpected size %d, want size 4", msgSize)
+		}
+
 		_, err = cl.conn.Read(msg)
 		if err != nil {
 			return err


### PR DESCRIPTION
```
panic: runtime error: index out of range [3] with length 2

goroutine 31311 [running]:
encoding/binary.bigEndian.Uint32({}, {0x3fa8528149e0, 0x2, 0x2})
	/usr/local/go/src/encoding/binary/binary.go:177 +0x8a
github.com/pg-sharding/spqr/router/client.(*PsqlClient).Init(0x3fa85249c270, 0x3fa8525690e0)
	/root/build/spqr/router/client/client.go:457 +0x279
github.com/pg-sharding/spqr/router/rulerouter.(*RuleRouterImpl).PreRoute(0x3fa8526a6340, {0x1c44458, 0x3fa85228c8b8}, 0x0)
	/root/build/spqr/router/rulerouter/rulerouter.go:216 +0x262
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).serv(0x3fa8522ca280, {0x1c44458, 0x3fa85228c8b8}, 0x0)
	/root/build/spqr/router/instance/instance.go:194 +0x18b
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run.func3()
	/root/build/spqr/router/instance/instance.go:279 +0x65
created by github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run in goroutine 49
	/root/build/spqr/router/instance/instance.go:278 +0x6a5
```