### PR TITLE
fix tests flap: isolate auth fixtures from feature tests

### DIFF
--- a/test/feature/docker-compose-debug.yaml
+++ b/test/feature/docker-compose-debug.yaml
@@ -107,8 +107,6 @@ services:
         condition: service_healthy
       shard3-replica:
         condition: service_healthy
-      kdc:
-        condition: service_started
     healthcheck: &router-healthcheck
       test: psql -h regress_router -p 6432 -U regress -d regress
       interval: 10s
@@ -192,39 +190,40 @@ services:
     networks:
       - feature_test_network
   ldapserver:
-    image: "osixia/openldap:latest"
+    image: "osixia/openldap:1.5.0"
+    profiles:
+      - auth
+    privileged: true
     hostname: regress_ldap_server
     container_name: regress_ldap_server
-    environment:
-      - LDAP_ROOT=dc=example,dc=com
-      - LDAP_ADMIN_USERNAME=admin
-      - LDAP_ADMIN_PASSWORD=adminpassword
-      - LDAP_USERS=regress
-      - LDAP_PASSWORDS=12345678
-      - LDAP_PORT_NUMBER=389
-      - LDAP_LDAPS_PORT_NUMBER=636
+    environment: &ldap-env
+      LDAP_ADMIN_USERNAME: admin
+      LDAP_ADMIN_PASSWORD: adminpassword
+      LDAP_DOMAIN: example.com
+      LDAP_READONLY_USER: true
+      LDAP_READONLY_USER_USERNAME: regress
+      LDAP_READONLY_USER_PASSWORD: 12345678
+      LDAP_PORT_NUMBER: 389
+      LDAP_LDAPS_PORT_NUMBER: 636
     ports:
       - "1389:389"
       - "1636:636"
     healthcheck: &ldap-healthcheck
-      test: ldapwhoami -D "cn=regress,ou=users,dc=example,dc=com" -w 12345678
+      test: ldapwhoami -H ldap://127.0.0.1:389 -D "cn=regress,dc=example,dc=com" -w 12345678
       interval: 10s
       timeout: 3s
       retries: 50
     networks:
       - feature_test_network
   ldapserver2:
-    image: "osixia/openldap:latest"
+    image: "osixia/openldap:1.5.0"
+    profiles:
+      - auth
+    privileged: true
     hostname: regress_ldap_server_2
     container_name: regress_ldap_server_2
     environment:
-      - LDAP_ROOT=dc=example,dc=com
-      - LDAP_ADMIN_USERNAME=admin
-      - LDAP_ADMIN_PASSWORD=adminpassword
-      - LDAP_USERS=regress
-      - LDAP_PASSWORDS=12345678
-      - LDAP_PORT_NUMBER=389
-      - LDAP_LDAPS_PORT_NUMBER=636
+      <<: *ldap-env
     ports:
       - "2389:389"
       - "2636:636"
@@ -246,6 +245,8 @@ services:
     entrypoint: ["/usr/local/bin/etcd", "--advertise-client-urls", "http://regress_qdb_0_1:2379", "--listen-client-urls", "http://0.0.0.0:2379"]
 
   kdc:
+    profiles:
+      - auth
     build:
       context: ./conf/kdc
     volumes:
@@ -258,4 +259,3 @@ volumes:
 networks:
   feature_test_network:
     name: feature_test_network
-

--- a/test/feature/docker-compose.yaml
+++ b/test/feature/docker-compose.yaml
@@ -107,12 +107,6 @@ services:
         condition: service_healthy
       shard3-replica:
         condition: service_healthy
-      kdc:
-        condition: service_started
-      ldapserver:
-        condition: service_healthy
-      ldapserver2:
-        condition: service_healthy
       coordinator:
         condition: service_started
     healthcheck: &router-healthcheck
@@ -209,6 +203,8 @@ services:
     entrypoint: ["/usr/local/bin/etcd", "--advertise-client-urls", "http://regress_qdb_0_1:2379", "--listen-client-urls", "http://0.0.0.0:2379"]
   ldapserver:
     image: "osixia/openldap:1.5.0"
+    profiles:
+      - auth
     privileged: true
     hostname: regress_ldap_server
     container_name: regress_ldap_server
@@ -233,6 +229,8 @@ services:
       - feature_test_network
   ldapserver2:
     image: "osixia/openldap:1.5.0"
+    profiles:
+      - auth
     privileged: true
     hostname: regress_ldap_server_2
     container_name: regress_ldap_server_2
@@ -246,6 +244,8 @@ services:
     networks:
       - feature_test_network
   kdc:
+    profiles:
+      - auth
     build:
       context: ./conf/kdc
     volumes:

--- a/test/feature/features/krb_auth.feature
+++ b/test/feature/features/krb_auth.feature
@@ -3,6 +3,7 @@ Feature: GSS Kerberos 5 auth test
     Given cluster environment is
     """
     ROUTER_CONFIG=/spqr/test/feature/conf/router_with_gss_frontend.yaml
+    COMPOSE_PROFILES=auth
     """
     Given cluster is up and running
     When I run commands on host "router"
@@ -20,6 +21,7 @@ Feature: GSS Kerberos 5 auth test
    Given cluster environment is
    """
    ROUTER_CONFIG=/spqr/test/feature/conf/router_with_ldap_frontend.yaml
+   COMPOSE_PROFILES=auth
    """
    Given cluster is up and running
    When I run command on host "router"

--- a/test/feature/features/ldap_auth.feature
+++ b/test/feature/features/ldap_auth.feature
@@ -4,6 +4,7 @@ Feature: LDAP auth test
     Given cluster environment is
     """
     ROUTER_CONFIG=/spqr/test/feature/conf/router_with_ldap_frontend.yaml
+    COMPOSE_PROFILES=auth
     """
     Given cluster is up and running
     When I run command on host "router"
@@ -20,6 +21,7 @@ Feature: LDAP auth test
     Given cluster environment is
     """
     ROUTER_CONFIG=/spqr/test/feature/conf/router_with_ldap_frontend.yaml
+    COMPOSE_PROFILES=auth
     """
     Given cluster is up and running
     Given host "ldapserver" is stopped
@@ -37,6 +39,7 @@ Feature: LDAP auth test
    Given cluster environment is
    """
    ROUTER_CONFIG=/spqr/test/feature/conf/router_with_ldap_frontend.yaml
+   COMPOSE_PROFILES=auth
    """
    Given cluster is up and running
    When I run command on host "router"

--- a/test/feature/spqr_test.go
+++ b/test/feature/spqr_test.go
@@ -617,17 +617,10 @@ func (tctx *testContext) stepClusterEnvironmentIs(body *godog.DocString) error {
 	byLine := func(r rune) bool {
 		return r == '\n' || r == '\r'
 	}
-	enableAuthProfile := false
 	for _, e := range strings.FieldsFunc(body.Content, byLine) {
 		if e = strings.TrimSpace(e); e != "" {
 			tctx.composerEnv = append(tctx.composerEnv, e)
-			if strings.Contains(e, "router_with_ldap_frontend.yaml") || strings.Contains(e, "router_with_gss_frontend.yaml") {
-				enableAuthProfile = true
-			}
 		}
-	}
-	if enableAuthProfile {
-		tctx.composerEnv = append(tctx.composerEnv, "COMPOSE_PROFILES=auth")
 	}
 
 	return nil

--- a/test/feature/spqr_test.go
+++ b/test/feature/spqr_test.go
@@ -617,10 +617,17 @@ func (tctx *testContext) stepClusterEnvironmentIs(body *godog.DocString) error {
 	byLine := func(r rune) bool {
 		return r == '\n' || r == '\r'
 	}
+	enableAuthProfile := false
 	for _, e := range strings.FieldsFunc(body.Content, byLine) {
 		if e = strings.TrimSpace(e); e != "" {
 			tctx.composerEnv = append(tctx.composerEnv, e)
+			if strings.Contains(e, "router_with_ldap_frontend.yaml") || strings.Contains(e, "router_with_gss_frontend.yaml") {
+				enableAuthProfile = true
+			}
 		}
+	}
+	if enableAuthProfile {
+		tctx.composerEnv = append(tctx.composerEnv, "COMPOSE_PROFILES=auth")
 	}
 
 	return nil

--- a/test/feature/testutil/docker_composer.go
+++ b/test/feature/testutil/docker_composer.go
@@ -125,8 +125,7 @@ func (dc *DockerComposer) fillContainers() error {
 		return err
 	}
 	dc.containers = make(map[string]container.Summary)
-	errorFlag := false
-	var name, state string
+	var failed []string
 	for _, c := range containers {
 		prj := c.Labels["com.docker.compose.project"]
 		srv := c.Labels["com.docker.compose.service"]
@@ -136,13 +135,11 @@ func (dc *DockerComposer) fillContainers() error {
 		dc.containers[srv] = c
 
 		if c.State != "running" && !dc.stopped[srv] {
-			errorFlag = true
-			name = srv
-			state = c.State
+			failed = append(failed, fmt.Sprintf("%s(%s)", srv, c.State))
 		}
 	}
-	if errorFlag {
-		return fmt.Errorf("container %s is %s, not running", name, state)
+	if len(failed) > 0 {
+		return fmt.Errorf("containers not running: %s", strings.Join(failed, ", "))
 	}
 	return nil
 }
@@ -176,6 +173,7 @@ func (dc *DockerComposer) waitHealthyContainers(timeout time.Duration) error {
 			return fmt.Errorf("timed out waiting for healthy containers: %s", strings.Join(waiting, ", "))
 		}
 		time.Sleep(time.Second)
+		// Refresh dc.containers so the next loop iteration sees updated container states.
 		if err := dc.fillContainers(); err != nil {
 			return err
 		}

--- a/test/feature/testutil/docker_composer.go
+++ b/test/feature/testutil/docker_composer.go
@@ -74,6 +74,7 @@ type Composer interface {
 type DockerComposer struct {
 	projectName string
 	config      string
+	env         []string
 	api         *client.Client
 	containers  map[string]container.Summary
 	stopped     map[string]bool
@@ -123,6 +124,7 @@ func (dc *DockerComposer) fillContainers() error {
 	if err != nil {
 		return err
 	}
+	dc.containers = make(map[string]container.Summary)
 	errorFlag := false
 	var name, state string
 	for _, c := range containers {
@@ -145,8 +147,45 @@ func (dc *DockerComposer) fillContainers() error {
 	return nil
 }
 
+func (dc *DockerComposer) waitHealthyContainers(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		var waiting []string
+		for service, c := range dc.containers {
+			if dc.stopped[service] {
+				continue
+			}
+			inspect, err := dc.api.ContainerInspect(context.Background(), c.ID)
+			if err != nil {
+				return fmt.Errorf("failed to inspect container %s: %s", service, err)
+			}
+			if inspect.State == nil {
+				return fmt.Errorf("container %s has no state", service)
+			}
+			if inspect.State.Status != "running" {
+				return fmt.Errorf("container %s is %s, not running", service, inspect.State.Status)
+			}
+			if inspect.State.Health != nil && inspect.State.Health.Status != "healthy" {
+				waiting = append(waiting, fmt.Sprintf("%s:%s", service, inspect.State.Health.Status))
+			}
+		}
+		if len(waiting) == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for healthy containers: %s", strings.Join(waiting, ", "))
+		}
+		time.Sleep(time.Second)
+		if err := dc.fillContainers(); err != nil {
+			return err
+		}
+	}
+}
+
 // Up brings all containers up according to config
 func (dc *DockerComposer) Up(env []string) error {
+	dc.env = env
+	dc.stopped = make(map[string]bool)
 	err := dc.runCompose([]string{"up", "-d", "--force-recreate", "-t", strconv.Itoa(int(defaultDockerComposeTimeout / time.Second))}, env)
 	if err != nil {
 		// to save container logs
@@ -162,7 +201,7 @@ func (dc *DockerComposer) Up(env []string) error {
 				continue
 			}
 			dc.containers[srv] = c
-			if (c.State != "running" || c.Status[len(c.Status)-len("(unhealthy)"):] == "(unhealthy)") && !dc.stopped[srv] {
+			if (c.State != "running" || strings.HasSuffix(c.Status, "(unhealthy)")) && !dc.stopped[srv] {
 				r, err := dc.api.ContainerLogs(context.TODO(), c.ID, container.LogsOptions{ShowStdout: true, ShowStderr: true})
 				if err != nil {
 					fmt.Printf("failed to get logs from \"%s\": %s\n", c.Names[0], err)
@@ -175,12 +214,17 @@ func (dc *DockerComposer) Up(env []string) error {
 		return err
 	}
 	err = dc.fillContainers()
-	return err
+	if err != nil {
+		return err
+	}
+	return dc.waitHealthyContainers(defaultDockerComposeTimeout)
 }
 
 // Down tears all containers/VMs down
 func (dc *DockerComposer) Down() error {
-	return dc.runCompose([]string{"down", "-v" /* "-t", strconv.Itoa(int(defaultDockerComposeTimeout / time.Second))*/}, nil)
+	err := dc.runCompose([]string{"down", "-v" /* "-t", strconv.Itoa(int(defaultDockerComposeTimeout / time.Second))*/}, dc.env)
+	dc.env = nil
+	return err
 }
 
 // Services returns names/ids of running containers


### PR DESCRIPTION
Move LDAP/KDC feature-test services behind an auth Compose profile so non-auth scenarios no longer fail on auth fixture startup. Auth router configs enable the profile automatically, and the test composer now waits for healthy containers before running steps.

This PR fixes https://github.com/pg-sharding/spqr/actions/runs/26088605906/job/76711202784?pr=2548