### PR TITLE
Fix 2PC recovery shard error handling

### DIFF
--- a/router/recovery/recovery.go
+++ b/router/recovery/recovery.go
@@ -160,6 +160,7 @@ func (d *TwoPCWatchDog) CheckTXShards(serv shard.ShardHostInstance, gid string) 
 	}
 
 	res := false
+	var errResponse *pgproto3.ErrorResponse
 
 	for {
 		msg, err := serv.Receive()
@@ -171,7 +172,12 @@ func (d *TwoPCWatchDog) CheckTXShards(serv shard.ShardHostInstance, gid string) 
 			if v.Values[0][0] == 't' {
 				res = true
 			}
+		case *pgproto3.ErrorResponse:
+			errResponse = v
 		case *pgproto3.ReadyForQuery:
+			if errResponse != nil {
+				return false, fmt.Errorf("failed to check prepared transaction %q on shard: %s", gid, errResponse.Message)
+			}
 			return res, nil
 		}
 	}
@@ -186,16 +192,31 @@ func (d *TwoPCWatchDog) executeCommitShards(shs []string, gid string) error {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
 		}
-		if res, err := d.CheckTXShards(serv, gid); err != nil {
-			return err
-		} else if !res {
-			/* tx already committed */
-			continue
-		}
 
-		/* Commit */
-		if err := d.DeployQueryOnShard(serv, fmt.Sprintf("COMMIT PREPARED '%s'", gid)); err != nil {
+		keepConnection := false
+		if err := func() error {
+			if res, err := d.CheckTXShards(serv, gid); err != nil {
+				return err
+			} else if !res {
+				/* tx already committed */
+				keepConnection = true
+				return nil
+			}
+
+			/* Commit */
+			if err := d.DeployQueryOnShard(serv, fmt.Sprintf("COMMIT PREPARED '%s'", gid)); err != nil {
+				return err
+			}
+			keepConnection = true
+			return nil
+		}(); err != nil {
+			_ = d.p.Discard(serv)
 			return err
+		}
+		if keepConnection {
+			if err := d.p.Put(serv); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -209,13 +230,19 @@ func (d *TwoPCWatchDog) DeployQueryOnShard(serv shard.ShardHostInstance, s strin
 		return err
 	}
 
+	var errResponse *pgproto3.ErrorResponse
 	for {
 		msg, err := serv.Receive()
 		if err != nil {
 			return err
 		}
-		switch msg.(type) {
+		switch v := msg.(type) {
+		case *pgproto3.ErrorResponse:
+			errResponse = v
 		case *pgproto3.ReadyForQuery:
+			if errResponse != nil {
+				return fmt.Errorf("failed to execute recovery query %q on shard: %s", s, errResponse.Message)
+			}
 			return nil
 		}
 	}
@@ -230,17 +257,32 @@ func (d *TwoPCWatchDog) executeRollbackShards(shs []string, gid string) error {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return err
 		}
-		if res, err := d.CheckTXShards(serv, gid); err != nil {
-			return err
-		} else if !res {
-			/* tx already committed */
-			spqrlog.Zero.Debug().Str("gid", gid).Msg("tx already committed/rejected")
-			continue
-		}
 
-		/* Commit */
-		if err := d.DeployQueryOnShard(serv, fmt.Sprintf("ROLLBACK PREPARED '%s'", gid)); err != nil {
+		keepConnection := false
+		if err := func() error {
+			if res, err := d.CheckTXShards(serv, gid); err != nil {
+				return err
+			} else if !res {
+				/* tx already committed */
+				spqrlog.Zero.Debug().Str("gid", gid).Msg("tx already committed/rejected")
+				keepConnection = true
+				return nil
+			}
+
+			/* Rollback */
+			if err := d.DeployQueryOnShard(serv, fmt.Sprintf("ROLLBACK PREPARED '%s'", gid)); err != nil {
+				return err
+			}
+			keepConnection = true
+			return nil
+		}(); err != nil {
+			_ = d.p.Discard(serv)
 			return err
+		}
+		if keepConnection {
+			if err := d.p.Put(serv); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

`2pc_recovery.feature` flakes because manual 2PC recovery can report success while a prepared transaction is still present on a shard.

https://github.com/pg-sharding/spqr/actions/runs/26267558485/job/77320420914

That means recovery returned successfully, but the shard-side `ROLLBACK PREPARED` / `COMMIT PREPARED` path did not actually clean up the prepared transaction.

## Root Cause

The recovery code did not treat shard `ErrorResponse` messages as failures. It waited for `ReadyForQuery` and returned `nil`, so a failed recovery query could be hidden from the caller.

The recovery path also acquired shard connections without returning them to the pool on successful paths or discarding them on failed paths. In repeated feature scenarios, that can leave stale/bad connections around and make the failure nondeterministic.

## Fix

This PR makes 2PC recovery authoritative:

- `CheckTXShards` now returns an error if the shard responds with `ErrorResponse`
- recovery query execution now returns an error if `COMMIT PREPARED` / `ROLLBACK PREPARED` fails
- shard connections are returned to the pool after successful recovery work
- shard connections are discarded after recovery errors

## Why This Fixes The Flap

The flaky assertion is caused by a mismatch between reported recovery success and actual shard state.

After this change, recovery can no longer silently succeed if shard cleanup fails. Either:

- the prepared transaction is actually committed/rolled back and `pg_prepared_xacts` becomes `0`, or
- recovery returns the real shard error and the test fails at the recovery command instead of later with a misleading leftover prepared transaction

This removes the hidden failure mode that produced `count = 1` after a successful `__spqr__run_2pc_recover()` call.
