### PR TITLE
fix: init_sql log last statement loss

### DIFF
--- a/router/qlog/provider/local.go
+++ b/router/qlog/provider/local.go
@@ -81,6 +81,10 @@ func (dw *LocalQlog) Recover(_ context.Context, path string) ([]string, error) {
 		}
 	}
 
+	if strings.TrimSpace(qs) != "" {
+		queries = append(queries, qs)
+	}
+
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}

--- a/router/qlog/provider/local.go
+++ b/router/qlog/provider/local.go
@@ -39,7 +39,6 @@ func (dw *LocalQlog) DumpQuery(_ context.Context, fname string, q string) error 
 	return nil
 }
 
-// TODO : unit tests
 func (dw *LocalQlog) Recover(_ context.Context, path string) ([]string, error) {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return []string{}, err

--- a/router/qlog/provider/local_test.go
+++ b/router/qlog/provider/local_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDumpQueryFileExists(t *testing.T) {
@@ -69,4 +71,83 @@ func TestDumpQueryReadonlyFile(t *testing.T) {
 
 	assert.Error(err)
 	assert.ErrorIs(err, os.ErrPermission)
+}
+
+func TestRecoverFileNotFound(t *testing.T) {
+	assert := assert.New(t)
+	localQLog := NewLocalQlog()
+
+	queries, err := localQLog.Recover(context.Background(), "non_existed_file")
+
+	assert.Error(err)
+	assert.Empty(queries)
+}
+
+func TestRecover(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name:     "empty file",
+			content:  "",
+			expected: nil,
+		},
+		{
+			name:     "simple query",
+			content:  "SELECT 1;",
+			expected: []string{" SELECT 1;"},
+		},
+		{
+			name:     "query without semicolon",
+			content:  "SELECT 1",
+			expected: []string{" SELECT 1"},
+		},
+		{
+			name:     "multiple queries",
+			content:  "SELECT 1;\nSELECT 2;",
+			expected: []string{" SELECT 1;", " SELECT 2;"},
+		},
+		{
+			name:     "multiple queries without last semicolon",
+			content:  "SELECT 1;\nSELECT 2",
+			expected: []string{" SELECT 1;", " SELECT 2"},
+		},
+		{
+			name:     "query with comment",
+			content:  "-- comment\nSELECT 1;",
+			expected: []string{" SELECT 1;"},
+		},
+		{
+			name: "multiline query",
+			content: `CREATE KEY RANGE uid_range_1
+FROM 00000000-0000-0000-0000-000000000000
+ROUTE TO shard1
+FOR DISTRIBUTION uid_ds;`,
+			expected: []string{" CREATE KEY RANGE uid_range_1 FROM 00000000-0000-0000-0000-000000000000 ROUTE TO shard1 FOR DISTRIBUTION uid_ds;"},
+		},
+		{
+			name: "multiline query without semicolon",
+			content: `CREATE KEY RANGE uid_range_1
+FROM 00000000-0000-0000-0000-000000000000
+ROUTE TO shard1
+FOR DISTRIBUTION uid_ds`,
+			expected: []string{" CREATE KEY RANGE uid_range_1 FROM 00000000-0000-0000-0000-000000000000 ROUTE TO shard1 FOR DISTRIBUTION uid_ds"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localQLog := NewLocalQlog()
+			tmpFilePath := filepath.Join(t.TempDir(), "recover_test")
+			err := os.WriteFile(tmpFilePath, []byte(tt.content), 0644)
+			require.NoError(t, err)
+
+			queries, err := localQLog.Recover(context.Background(), tmpFilePath)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, queries)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #986

The issue was partially resolved in #1011, but there was still a bug where the last statement would be lost if it didn't end with `;`.

In this PR, I'm fixing the remaining bug. It looks like the issue in #986 will be fully resolved.