### PR TITLE
fix feature test flakes by isolating auth fixtures

### DIFF
--- a/test/feature/docker-compose-debug.yaml
+++ b/test/feature/docker-compose-debug.yaml
@@ -107,8 +107,6 @@ services:
         condition: service_healthy
       shard3-replica:
         condition: service_healthy
-      kdc:
-        condition: service_started
     healthcheck: &router-healthcheck
       test: psql -h regress_router -p 6432 -U regress -d regress
       interval: 10s
@@ -192,39 +190,40 @@ services:
     networks:
       - feature_test_network
   ldapserver:
-    image: "osixia/openldap:latest"
+    image: "osixia/openldap:1.5.0"
+    profiles:
+      - auth
+    privileged: true
     hostname: regress_ldap_server
     container_name: regress_ldap_server
-    environment:
-      - LDAP_ROOT=dc=example,dc=com
-      - LDAP_ADMIN_USERNAME=admin
-      - LDAP_ADMIN_PASSWORD=adminpassword
-      - LDAP_USERS=regress
-      - LDAP_PASSWORDS=12345678
-      - LDAP_PORT_NUMBER=389
-      - LDAP_LDAPS_PORT_NUMBER=636
+    environment: &ldap-env
+      LDAP_ADMIN_USERNAME: admin
+      LDAP_ADMIN_PASSWORD: adminpassword
+      LDAP_DOMAIN: example.com
+      LDAP_READONLY_USER: true
+      LDAP_READONLY_USER_USERNAME: regress
+      LDAP_READONLY_USER_PASSWORD: 12345678
+      LDAP_PORT_NUMBER: 389
+      LDAP_LDAPS_PORT_NUMBER: 636
     ports:
       - "1389:389"
       - "1636:636"
     healthcheck: &ldap-healthcheck
-      test: ldapwhoami -D "cn=regress,ou=users,dc=example,dc=com" -w 12345678
+      test: ldapwhoami -H ldap://127.0.0.1:389 -D "cn=regress,dc=example,dc=com" -w 12345678
       interval: 10s
       timeout: 3s
       retries: 50
     networks:
       - feature_test_network
   ldapserver2:
-    image: "osixia/openldap:latest"
+    image: "osixia/openldap:1.5.0"
+    profiles:
+      - auth
+    privileged: true
     hostname: regress_ldap_server_2
     container_name: regress_ldap_server_2
     environment:
-      - LDAP_ROOT=dc=example,dc=com
-      - LDAP_ADMIN_USERNAME=admin
-      - LDAP_ADMIN_PASSWORD=adminpassword
-      - LDAP_USERS=regress
-      - LDAP_PASSWORDS=12345678
-      - LDAP_PORT_NUMBER=389
-      - LDAP_LDAPS_PORT_NUMBER=636
+      <<: *ldap-env
     ports:
       - "2389:389"
       - "2636:636"
@@ -246,6 +245,8 @@ services:
     entrypoint: ["/usr/local/bin/etcd", "--advertise-client-urls", "http://regress_qdb_0_1:2379", "--listen-client-urls", "http://0.0.0.0:2379"]
 
   kdc:
+    profiles:
+      - auth
     build:
       context: ./conf/kdc
     volumes:

--- a/test/feature/docker-compose.yaml
+++ b/test/feature/docker-compose.yaml
@@ -107,12 +107,6 @@ services:
         condition: service_healthy
       shard3-replica:
         condition: service_healthy
-      kdc:
-        condition: service_started
-      ldapserver:
-        condition: service_healthy
-      ldapserver2:
-        condition: service_healthy
       coordinator:
         condition: service_started
     healthcheck: &router-healthcheck
@@ -209,6 +203,8 @@ services:
     entrypoint: ["/usr/local/bin/etcd", "--advertise-client-urls", "http://regress_qdb_0_1:2379", "--listen-client-urls", "http://0.0.0.0:2379"]
   ldapserver:
     image: "osixia/openldap:1.5.0"
+    profiles:
+      - auth
     privileged: true
     hostname: regress_ldap_server
     container_name: regress_ldap_server
@@ -233,6 +229,8 @@ services:
       - feature_test_network
   ldapserver2:
     image: "osixia/openldap:1.5.0"
+    profiles:
+      - auth
     privileged: true
     hostname: regress_ldap_server_2
     container_name: regress_ldap_server_2
@@ -246,6 +244,8 @@ services:
     networks:
       - feature_test_network
   kdc:
+    profiles:
+      - auth
     build:
       context: ./conf/kdc
     volumes:

--- a/test/feature/features/krb_auth.feature
+++ b/test/feature/features/krb_auth.feature
@@ -3,6 +3,7 @@ Feature: GSS Kerberos 5 auth test
     Given cluster environment is
     """
     ROUTER_CONFIG=/spqr/test/feature/conf/router_with_gss_frontend.yaml
+    COMPOSE_PROFILES=auth
     """
     Given cluster is up and running
     When I run commands on host "router"
@@ -20,6 +21,7 @@ Feature: GSS Kerberos 5 auth test
    Given cluster environment is
    """
    ROUTER_CONFIG=/spqr/test/feature/conf/router_with_ldap_frontend.yaml
+   COMPOSE_PROFILES=auth
    """
    Given cluster is up and running
    When I run command on host "router"

--- a/test/feature/features/ldap_auth.feature
+++ b/test/feature/features/ldap_auth.feature
@@ -4,6 +4,7 @@ Feature: LDAP auth test
     Given cluster environment is
     """
     ROUTER_CONFIG=/spqr/test/feature/conf/router_with_ldap_frontend.yaml
+    COMPOSE_PROFILES=auth
     """
     Given cluster is up and running
     When I run command on host "router"
@@ -20,6 +21,7 @@ Feature: LDAP auth test
     Given cluster environment is
     """
     ROUTER_CONFIG=/spqr/test/feature/conf/router_with_ldap_frontend.yaml
+    COMPOSE_PROFILES=auth
     """
     Given cluster is up and running
     Given host "ldapserver" is stopped
@@ -37,6 +39,7 @@ Feature: LDAP auth test
    Given cluster environment is
    """
    ROUTER_CONFIG=/spqr/test/feature/conf/router_with_ldap_frontend.yaml
+   COMPOSE_PROFILES=auth
    """
    Given cluster is up and running
    When I run command on host "router"


### PR DESCRIPTION
Move LDAP and KDC feature-test fixtures behind an auth Docker Compose profile so non-auth scenarios no longer fail while starting unused auth services.

This PR fixes https://github.com/pg-sharding/spqr/actions/runs/26088605906/job/76711202784?pr=2548