### PR TITLE
fix: preserve routing metadata for derived table joins

### DIFF
--- a/router/planner/analyze.go
+++ b/router/planner/analyze.go
@@ -31,6 +31,124 @@ func analyzeFromClauseList(
 	return nil
 }
 
+func mergeRelationMap(dst, src map[rfqn.RelationFQN]struct{}) {
+	for rel := range src {
+		dst[rel] = struct{}{}
+	}
+}
+
+func cloneCteNames(src map[string]*lyx.CommonTableExpr) map[string]*lyx.CommonTableExpr {
+	dst := map[string]*lyx.CommonTableExpr{}
+	for name, cte := range src {
+		dst[name] = cte
+	}
+	return dst
+}
+
+func mergeRelationsByDistributionCol(dst, src map[string][]*rfqn.RelationFQN) {
+	for col, srcRels := range src {
+		for _, srcRel := range srcRels {
+			if !slices.ContainsFunc(dst[col], func(dstRel *rfqn.RelationFQN) bool {
+				return dstRel.String() == srcRel.String()
+			}) {
+				dst[col] = append(dst[col], srcRel)
+			}
+		}
+	}
+}
+
+func derivedColumnBelongsToRelation(colRef *lyx.ColumnRef, rel rfqn.RelationFQN, tableAliases map[string]rfqn.RelationFQN) bool {
+	if colRef.TableAlias == "" || colRef.TableAlias == rel.RelationName {
+		return true
+	}
+
+	resolvedRelation, ok := tableAliases[colRef.TableAlias]
+	return ok && resolvedRelation.String() == rel.String()
+}
+
+func derivedTableAliasInfo(q *lyx.SubSelect, rel rfqn.RelationFQN, tableAliases map[string]rfqn.RelationFQN) (rmeta.DerivedTableAlias, bool) {
+	aliasInfo := rmeta.DerivedTableAlias{
+		Relation: rel,
+		Columns:  map[string]string{},
+	}
+
+	selectStmt, ok := q.Arg.(*lyx.Select)
+	if !ok {
+		return aliasInfo, false
+	}
+
+	for _, target := range selectStmt.TargetList {
+		switch t := target.(type) {
+		case *lyx.AExprEmpty:
+			aliasInfo.PassthroughAll = true
+		case *lyx.ColumnRef:
+			if derivedColumnBelongsToRelation(t, rel, tableAliases) {
+				aliasInfo.Columns[t.ColName] = t.ColName
+			}
+		case *lyx.ResTarget:
+			if colRef, ok := t.Value.(*lyx.ColumnRef); ok && derivedColumnBelongsToRelation(colRef, rel, tableAliases) {
+				targetName := t.Name
+				if targetName == "" {
+					targetName = colRef.ColName
+				}
+				aliasInfo.Columns[targetName] = colRef.ColName
+			}
+		}
+	}
+
+	return aliasInfo, aliasInfo.PassthroughAll || len(aliasInfo.Columns) > 0
+}
+
+func analyzeSubSelectFromNode(ctx context.Context, q *lyx.SubSelect, rm *rmeta.RoutingMetadataContext) error {
+	savedRels := rm.Rels
+	savedRoutableRels := rm.RoutableRels
+	savedCteNames := rm.CteNames
+	savedTableAliases := rm.TableAliases
+	savedCTEAliases := rm.CTEAliases
+	savedDerivedTableAliases := rm.DerivedTableAliases
+	savedRelationsByDistributionCol := rm.RelationsByDistributionCol
+
+	rm.Rels = map[rfqn.RelationFQN]struct{}{}
+	rm.RoutableRels = map[rfqn.RelationFQN]struct{}{}
+	rm.CteNames = cloneCteNames(savedCteNames)
+	rm.TableAliases = map[string]rfqn.RelationFQN{}
+	rm.CTEAliases = map[string]string{}
+	rm.DerivedTableAliases = map[string]rmeta.DerivedTableAlias{}
+	rm.RelationsByDistributionCol = map[string][]*rfqn.RelationFQN{}
+
+	err := analyzeSelectStmt(ctx, q.Arg, rm)
+	localRels := rm.Rels
+	localRoutableRels := rm.RoutableRels
+	localTableAliases := rm.TableAliases
+	localRelationsByDistributionCol := rm.RelationsByDistributionCol
+
+	rm.Rels = savedRels
+	rm.RoutableRels = savedRoutableRels
+	rm.CteNames = savedCteNames
+	rm.TableAliases = savedTableAliases
+	rm.CTEAliases = savedCTEAliases
+	rm.DerivedTableAliases = savedDerivedTableAliases
+	rm.RelationsByDistributionCol = savedRelationsByDistributionCol
+
+	if err != nil {
+		return err
+	}
+
+	mergeRelationMap(rm.Rels, localRels)
+	mergeRelationMap(rm.RoutableRels, localRoutableRels)
+	mergeRelationsByDistributionCol(rm.RelationsByDistributionCol, localRelationsByDistributionCol)
+
+	if q.Alias != "" && len(localRels) == 1 {
+		for rel := range localRels {
+			if aliasInfo, ok := derivedTableAliasInfo(q, rel, localTableAliases); ok {
+				rm.DerivedTableAliases[q.Alias] = aliasInfo
+			}
+		}
+	}
+
+	return nil
+}
+
 // TODO : unit tests
 func analyzeSelectStmt(ctx context.Context, selectStmt lyx.Node, meta *rmeta.RoutingMetadataContext) error {
 
@@ -102,7 +220,7 @@ func analyzeFromNode(ctx context.Context, node lyx.FromClauseNode, routable bool
 		}
 
 	case *lyx.SubSelect:
-		return analyzeSelectStmt(ctx, q.Arg, rm)
+		return analyzeSubSelectFromNode(ctx, q, rm)
 	default:
 		// other cases to consider
 		// lateral join, natural, etc

--- a/router/qrouter/proxy_routing_test.go
+++ b/router/qrouter/proxy_routing_test.go
@@ -2105,6 +2105,173 @@ func TestJoins(t *testing.T) {
 	}
 }
 
+func TestDerivedTableLeftJoinRouting(t *testing.T) {
+	assert := assert.New(t)
+
+	type tcase struct {
+		query string
+		exp   plan.Plan
+	}
+
+	db, _ := qdb.NewMemQDB(MemQDBPath)
+	distribution := "dd_derived_left_join"
+	ctx := context.TODO()
+
+	chunk, err := db.CreateDistribution(ctx, &qdb.Distribution{
+		ID:       distribution,
+		ColTypes: []string{qdb.ColumnTypeInteger},
+		Relations: map[string]*qdb.DistributedRelation{
+			"opaque_lhs": {
+				Name: "opaque_lhs",
+				DistributionKey: []qdb.DistributionKeyEntry{
+					{
+						Column: "k",
+					},
+				},
+			},
+			"opaque_rhs": {
+				Name: "opaque_rhs",
+				DistributionKey: []qdb.DistributionKeyEntry{
+					{
+						Column: "k",
+					},
+				},
+			},
+		},
+	})
+	assert.NoError(err)
+	assert.NoError(db.ExecNoTransaction(ctx, chunk))
+
+	statements, err := db.CreateKeyRange(ctx, (&kr.KeyRange{
+		ShardID:      "sh1",
+		Distribution: distribution,
+		ID:           "id_derived_left_join_1",
+		LowerBound:   []any{int64(0)},
+		ColumnTypes:  []string{qdb.ColumnTypeInteger},
+	}).ToDB())
+	assert.NoError(err)
+	assert.NoError(db.ExecNoTransaction(ctx, statements))
+
+	statements, err = db.CreateKeyRange(ctx, (&kr.KeyRange{
+		ShardID:      "sh2",
+		Distribution: distribution,
+		ID:           "id_derived_left_join_2",
+		LowerBound:   []any{int64(10)},
+		ColumnTypes:  []string{qdb.ColumnTypeInteger},
+	}).ToDB())
+	assert.NoError(err)
+	assert.NoError(db.ExecNoTransaction(ctx, statements))
+
+	shardMapping := map[string]*topology.DataShard{
+		"sh1": {ID: "sh1"},
+		"sh2": {ID: "sh2"},
+	}
+	lc := coord.NewLocalInstanceMetadataMgr(db, nil, nil, topology.TopMgrFromMap(shardMapping), false, nil, qdb.DefaultMaxTxnSize)
+
+	pr, err := qrouter.NewProxyRouter(topology.TopMgrFromMap(shardMapping), lc, nil, &config.QRouter{
+		DefaultRouteBehaviour: "BLOCK",
+	}, nil, getIdentityMngr(lc), metricRegistry)
+	assert.NoError(err)
+
+	expected := &plan.ShardDispatchPlan{
+		ExecTarget: kr.ShardKey{
+			Name: "sh2",
+		},
+		TargetSessionAttrs: config.TargetSessionAttrsRW,
+	}
+
+	for _, tt := range []tcase{
+		{
+			query: `
+				SELECT *
+				FROM (
+					SELECT j, k
+					FROM opaque_lhs
+					WHERE k = 12 AND f = true
+				) left_src
+				LEFT JOIN (
+					SELECT j, k, SUM(v) AS total_v
+					FROM opaque_rhs
+					WHERE k = 12
+					GROUP BY j, k
+				) right_src
+					ON left_src.k = right_src.k;
+			`,
+			exp: expected,
+		},
+		{
+			query: `
+				WITH left_src AS (
+					SELECT j, k
+					FROM opaque_lhs
+					WHERE k = 12 AND f = true
+				)
+				SELECT *
+				FROM left_src l
+				LEFT JOIN (
+					SELECT j, k, SUM(v) AS total_v
+					FROM opaque_rhs
+					WHERE k = 12
+					GROUP BY j, k
+				) right_src
+					ON l.k = right_src.k;
+			`,
+			exp: expected,
+		},
+		{
+			query: `
+				SELECT *
+				FROM (
+					SELECT *
+					FROM opaque_lhs
+					WHERE k = 12 AND f = true
+				) left_src
+				LEFT JOIN (
+					SELECT j, k, SUM(v) AS total_v
+					FROM opaque_rhs
+					WHERE k = 12
+					GROUP BY j, k
+				) right_src
+					ON left_src.k = right_src.k;
+			`,
+			exp: expected,
+		},
+		{
+			query: `
+				SELECT *
+				FROM (
+					SELECT k AS kk
+					FROM opaque_lhs
+					WHERE k = 12 AND f = true
+				) left_src
+				LEFT JOIN (
+					SELECT k
+					FROM opaque_rhs
+					WHERE k = 12
+				) right_src
+					ON left_src.kk = right_src.k;
+			`,
+			exp: expected,
+		},
+	} {
+		parserRes, _, err := lyx.Parse(tt.query)
+		assert.NoError(err, "query %s", tt.query)
+
+		dh := session.NewSimpleHandler(config.TargetSessionAttrsRW, false, "", "")
+		dh.SetDistribution(session.VirtualParamLevelTxBlock, distribution)
+
+		stmt := parserRes[0]
+		rm := rmeta.NewRoutingMetadataContext(dh, &config.FrontendRule{}, tt.query, stmt, pr.CSM(), pr.Mgr(), &rmeta.MetadataCache{
+			Distributions: map[rfqn.RelationFQN]*distributions.Distribution{},
+		})
+
+		assert.NoError(planner.AnalyzeQueryV1(context.TODO(), rm, stmt), tt.query)
+		tmp, err := pr.PlanQueryExtended(context.TODO(), rm)
+		assert.NoError(err, "query %s", tt.query)
+		assert.Equal(tt.exp, tmp, tt.query)
+	}
+}
+
 func TestUnnest(t *testing.T) {
 	assert := assert.New(t)
 

--- a/router/rmeta/expr.go
+++ b/router/rmeta/expr.go
@@ -276,9 +276,10 @@ func (rm *RoutingMetadataContext) ProcessConstExpr(
 	alias, colname string,
 	expr lyx.Node) (bool, error) {
 	var resolvedRelation *rfqn.RelationFQN
+	var resolvedColname string
 	var err error
 
-	resolvedRelation, err = rm.ResolveRelationByAlias(alias, colname)
+	resolvedRelation, resolvedColname, err = rm.ResolveColumnRef(alias, colname)
 
 	if err != nil {
 		// failed to resolve relation, skip column
@@ -287,7 +288,7 @@ func (rm *RoutingMetadataContext) ProcessConstExpr(
 	if resolvedRelation == nil {
 		return false, nil
 	}
-	return rm.ProcessConstExprOnRFQN(resolvedRelation, colname, expr)
+	return rm.ProcessConstExprOnRFQN(resolvedRelation, resolvedColname, expr)
 }
 
 func (rm *RoutingMetadataContext) ComputeRoutingExpr(

--- a/router/rmeta/rmeta.go
+++ b/router/rmeta/rmeta.go
@@ -29,6 +29,12 @@ type AuxValuesKey struct {
 	ColRefName string
 }
 
+type DerivedTableAlias struct {
+	Relation       rfqn.RelationFQN
+	Columns        map[string]string
+	PassthroughAll bool
+}
+
 /* Detach trigger for shared invalidation? */
 type MetadataCache struct {
 	Distributions map[rfqn.RelationFQN]*distributions.Distribution
@@ -57,6 +63,9 @@ type RoutingMetadataContext struct {
 	// rarg:{range_var:{relname:"t2" inh:true relpersistence:"p" alias:{aliasname:"b"}
 	TableAliases map[string]rfqn.RelationFQN
 	CTEAliases   map[string]string
+	// DerivedTableAliases maps FROM-subquery aliases back to a single underlying
+	// relation when the subquery is simple enough to preserve routing metadata.
+	DerivedTableAliases map[string]DerivedTableAlias
 
 	SPH        session.SessionParamsHolder
 	ClientRule *config.FrontendRule
@@ -118,24 +127,25 @@ func NewRoutingMetadataContext(sph session.SessionParamsHolder,
 	mgr meta.EntityMgr,
 	mCache *MetadataCache) *RoutingMetadataContext {
 	return &RoutingMetadataContext{
-		Rels:            map[rfqn.RelationFQN]struct{}{},
-		RoutableRels:    map[rfqn.RelationFQN]struct{}{},
-		CteNames:        map[string]*lyx.CommonTableExpr{},
-		TableAliases:    map[string]rfqn.RelationFQN{},
-		CTEAliases:      map[string]string{},
-		Exprs:           map[rfqn.RelationFQN]map[string][]any{},
-		ParamRefs:       map[rfqn.RelationFQN]map[string][]int{},
-		MetaCache:       mCache,
-		AuxValues:       map[AuxValuesKey][]lyx.Node{},
-		AuxValuesParent: map[AuxValuesKey]AuxValuesKey{},
-		UsedAuxCTE:      map[AuxValuesKey][]*rfqn.RelationFQN{},
-		SPH:             sph,
-		CSM:             csm,
-		Mgr:             mgr,
-		Query:           query,
-		Stmt:            stmt,
-		ro:              false,
-		ClientRule:      clientRule,
+		Rels:                map[rfqn.RelationFQN]struct{}{},
+		RoutableRels:        map[rfqn.RelationFQN]struct{}{},
+		CteNames:            map[string]*lyx.CommonTableExpr{},
+		TableAliases:        map[string]rfqn.RelationFQN{},
+		CTEAliases:          map[string]string{},
+		DerivedTableAliases: map[string]DerivedTableAlias{},
+		Exprs:               map[rfqn.RelationFQN]map[string][]any{},
+		ParamRefs:           map[rfqn.RelationFQN]map[string][]int{},
+		MetaCache:           mCache,
+		AuxValues:           map[AuxValuesKey][]lyx.Node{},
+		AuxValuesParent:     map[AuxValuesKey]AuxValuesKey{},
+		UsedAuxCTE:          map[AuxValuesKey][]*rfqn.RelationFQN{},
+		SPH:                 sph,
+		CSM:                 csm,
+		Mgr:                 mgr,
+		Query:               query,
+		Stmt:                stmt,
+		ro:                  false,
+		ClientRule:          clientRule,
 
 		RelationsByDistributionCol: map[string][]*rfqn.RelationFQN{},
 	}
@@ -300,16 +310,26 @@ func (rm *RoutingMetadataContext) RecordParamRefExpr(resolvedRelation *rfqn.Rela
 }
 
 // TODO : unit tests
-func (rm *RoutingMetadataContext) ResolveRelationByAlias(alias, colname string) (*rfqn.RelationFQN, error) {
+func (rm *RoutingMetadataContext) ResolveColumnRef(alias, colname string) (*rfqn.RelationFQN, string, error) {
 	if _, ok := rm.Rels[rfqn.RelationFQN{RelationName: alias}]; ok {
-		return &rfqn.RelationFQN{RelationName: alias}, nil
+		return &rfqn.RelationFQN{RelationName: alias}, colname, nil
 	}
 	if _, ok := rm.CTEAliases[alias]; ok {
-		return nil, nil
+		return nil, "", nil
+	}
+	if derivedAlias, ok := rm.DerivedTableAliases[alias]; ok {
+		if derivedAlias.PassthroughAll {
+			return &derivedAlias.Relation, colname, nil
+		}
+		resolvedColname, ok := derivedAlias.Columns[colname]
+		if !ok {
+			return nil, "", nil
+		}
+		return &derivedAlias.Relation, resolvedColname, nil
 	}
 	if resolvedRelation, ok := rm.TableAliases[alias]; ok {
 		// TBD: postpone routing from here to root of parsing tree
-		return &resolvedRelation, nil
+		return &resolvedRelation, colname, nil
 	} else {
 		// TBD: postpone routing from here to root of parsing tree
 		if len(rm.Rels) != 1 {
@@ -317,18 +337,24 @@ func (rm *RoutingMetadataContext) ResolveRelationByAlias(alias, colname string) 
 			if l, ok := rm.RelationsByDistributionCol[colname]; ok {
 				if len(l) > 1 {
 					// ambiguity in column aliasing
-					return nil, rerrors.ErrComplexQuery.Hint(fmt.Sprintf("relation reference ambiguity by alias/colref: %v/%v", alias, colname))
+					return nil, "", rerrors.ErrComplexQuery.Hint(fmt.Sprintf("relation reference ambiguity by alias/colref: %v/%v", alias, colname))
 				}
-				return l[0], nil
+				return l[0], colname, nil
 			} else {
-				return nil, nil
+				return nil, "", nil
 			}
 		}
 		for tbl := range rm.Rels {
 			resolvedRelation = tbl
 		}
-		return &resolvedRelation, nil
+		return &resolvedRelation, colname, nil
 	}
+}
+
+// TODO : unit tests
+func (rm *RoutingMetadataContext) ResolveRelationByAlias(alias, colname string) (*rfqn.RelationFQN, error) {
+	resolvedRelation, _, err := rm.ResolveColumnRef(alias, colname)
+	return resolvedRelation, err
 }
 
 // TODO : unit tests


### PR DESCRIPTION
## Summary

- Preserve routing metadata for simple `FROM (SELECT ...) alias` derived tables by resolving alias columns back to passthrough columns from the underlying relation.
- Keep derived-table analysis scoped so inner table aliases and CTEs do not leak into the outer query, while still merging routing facts needed by the parent join.
- Add regression coverage for derived-table `LEFT JOIN` routing parity with the equivalent CTE shape, including passthrough `SELECT *` and renamed shard-key projection cases

## Motivation

An inline derived table on the preserved side of a `LEFT JOIN` could route differently from an equivalent CTE query. **In practice, this can silently dispatch to the wrong shard and return zero rows**, even when the left-side subquery has matching data

This change brings routing parity to simple derived-table aliases without broadening the router's scope to support arbitrary, complex derived-table semantics