### PR TITLE
Fix panic & release goroutines on route obsoletion

### DIFF
--- a/pkg/client/clientpool.go
+++ b/pkg/client/clientpool.go
@@ -151,7 +151,9 @@ func (c *PoolImpl) Shutdown() error {
 		return true
 	})
 
-	c.healthCheckCancel()
+	if c.healthCheckCancel != nil {
+		c.healthCheckCancel()
+	}
 
 	return nil
 }
@@ -247,8 +249,7 @@ const (
 // - Pool: A pointer to the newly created PoolImpl instance.
 func NewClientPool(clientDeadCheckInterval time.Duration) Pool {
 	pl := &PoolImpl{
-		pool: sync.Map{},
-
+		pool:              sync.Map{},
 		deadCheckInterval: config.ValueOrDefaultDuration(config.RouterConfig().ClientPoolDeadCheckInterval, clientDeadCheckInterval),
 		counters:          map[string]*atomic.Uint64{},
 	}

--- a/router/route/route.go
+++ b/router/route/route.go
@@ -163,3 +163,8 @@ func (r *Route) ReleaseClient(clientID uint) (bool, error) {
 func (r *Route) ForEachPool(cb func(pool.Pool) error) error {
 	return r.mShardPool.ForEachPool(cb)
 }
+
+func (r *Route) Close() error {
+	r.MultiShardPool().StopCacheWatchdog()
+	return r.ClientPool().Shutdown()
+}

--- a/router/rulerouter/route_pool.go
+++ b/router/rulerouter/route_pool.go
@@ -23,7 +23,7 @@ type RoutePool interface {
 		frRule *config.FrontendRule,
 	) (*route.Route, error)
 
-	Obsolete(key route.Key) *route.Route
+	Obsolete(key route.Key)
 	Shutdown() error
 	NotifyRoutes(func(route *route.Route) (bool, error)) error
 }
@@ -75,17 +75,17 @@ func (r *RoutePoolImpl) NotifyRoutes(cb func(route *route.Route) (bool, error)) 
 }
 
 // TODO : unit tests
-func (r *RoutePoolImpl) Obsolete(key route.Key) *route.Route {
+func (r *RoutePoolImpl) Obsolete(key route.Key) {
 	ret, ok := r.pool.LoadAndDelete(key)
 	if ok {
 		rt, ok := ret.(*route.Route)
 		if !ok {
-			return nil
+			return
 		}
-		return rt
-	}
 
-	return nil
+		/* Stop watchdogs, if any */
+		_ = rt.Close()
+	}
 }
 
 // TODO : unit tests
@@ -140,8 +140,7 @@ func (r *RoutePoolImpl) MatchRoute(key route.Key,
 
 	if loaded {
 		// conflict, release goroutines
-		nroute.MultiShardPool().StopCacheWatchdog()
-		_ = nroute.ClientPool().Shutdown()
+		_ = nroute.Close()
 	}
 	rt, ok := act.(*route.Route)
 	if !ok {

--- a/router/rulerouter/rulerouter.go
+++ b/router/rulerouter/rulerouter.go
@@ -288,11 +288,7 @@ func (r *RuleRouterImpl) PreRoute(conn net.Conn, pt port.RouterPortType) (rclien
 	if err := cl.Auth(rt); err != nil {
 		_ = cl.ReplyErr(err)
 		if !config.RouterConfig().DisableObsoleteClient {
-			route := r.Obsolete(key)
-			/* Stop watchdogs, if any */
-			if route != nil {
-				route.MultiShardPool().StopCacheWatchdog()
-			}
+			r.Obsolete(key)
 		}
 		return cl, err
 	}


### PR DESCRIPTION
```
goroutine 83 [running]:
github.com/pg-sharding/spqr/pkg/client.(*PoolImpl).Shutdown(0x34447ba0a2a0)
	/home/reshke/spqr/pkg/client/clientpool.go:153 +0x3c
github.com/pg-sharding/spqr/router/route.(*Route).Close(0x34447ba0a3c0)
	/home/reshke/spqr/router/route/route.go:169 +0x5a
github.com/pg-sharding/spqr/router/rulerouter.(*RoutePoolImpl).Obsolete(0x34447bac4d00, {{0x34447bd8c2e8, 0x5}, {0x34447bd8c3a8, 0x3}})
	/home/reshke/spqr/router/rulerouter/route_pool.go:87 +0x145
github.com/pg-sharding/spqr/router/rulerouter.(*RuleRouterImpl).PreRoute(0x34447bd97380, {0x2191678, 0x34447ba82008}, 0x0)
	/home/reshke/spqr/router/rulerouter/rulerouter.go:291 +0x12cd
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).serv(0x34447badc480, {0x2191678, 0x34447ba82008}, 0x0)
	/home/reshke/spqr/router/instance/instance.go:199 +0x18b
github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run.func3()
	/home/reshke/spqr/router/instance/instance.go:284 +0x65
created by github.com/pg-sharding/spqr/router/instance.(*InstanceImpl).Run in goroutine 15
	/home/reshke/spqr/router/instance/instance.go:283 +0x6a5
```