### PR TITLE
Fix regress test teardown in `schema_qual.sql`

### DIFF
--- a/test/regress/tests/router/expected/schema_qual.out
+++ b/test/regress/tests/router/expected/schema_qual.out
@@ -122,6 +122,7 @@ NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 DROP SCHEMA sh2 CASCADE;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 SET __spqr__maintain_params TO false;
+SET search_path TO 'public';
 \c spqr-console
 DROP DISTRIBUTION ALL CASCADE;
  distribution_id 

--- a/test/regress/tests/router/sql/schema_qual.sql
+++ b/test/regress/tests/router/sql/schema_qual.sql
@@ -53,6 +53,7 @@ DROP SCHEMA sh1 CASCADE;
 DROP SCHEMA sh2 CASCADE;
 
 SET __spqr__maintain_params TO false;
+SET search_path TO 'public';
 
 \c spqr-console
 


### PR DESCRIPTION
schema_qual.sql leaves the router session with:

```sql
SET search_path TO 'sh2';
```

Then it drops that schema:

```
DROP SCHEMA sh2 CASCADE;
```

Because pg_regress reuses the same router session for later router tests, the next test can inherit s`earch_path = sh2`, where `sh2` no longer exists. Then unqualified DDL in the next test fails.