### PR TITLE
Fix CI unhealthy container log collection

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,12 +93,12 @@ jobs:
              if [[ ${{ matrix.version }} == *"-mdb" ]]; then 
                 version=$(echo ${{ matrix.version }} | awk '{ print substr($1, 1, 2)  }'); 
                 if !(make POSTGRES_VERSION=$version codename=${{ matrix.os-version }} mdb-branch=MDB_$version shard-image=shard-image-mdb regress); then
-                  docker compose -f test/regress/docker-compose.yaml ps -a --format "table {{.ID}}\t{{.Status}}" | grep -i unhealthy | awk '{print $1}' | xargs -n 1 docker logs; 
+                  docker compose -f test/regress/docker-compose.yaml ps -a --format "table {{.ID}}\t{{.Status}}" | awk 'tolower($0) ~ /unhealthy/ {print $1}' | xargs -r -n 1 docker logs;
                   exit 1;
                 fi
              else 
                 if !(make POSTGRES_VERSION=${{ matrix.version }} codename=${{ matrix.os-version }} regress; ); then
-                  docker compose -f test/regress/docker-compose.yaml ps -a --format "table {{.ID}}\t{{.Status}}" | grep -i unhealthy | awk '{print $1}' | xargs -n 1 docker logs; 
+                  docker compose -f test/regress/docker-compose.yaml ps -a --format "table {{.ID}}\t{{.Status}}" | awk 'tolower($0) ~ /unhealthy/ {print $1}' | xargs -r -n 1 docker logs;
                   exit 1;
                 fi
              fi
@@ -120,7 +120,7 @@ jobs:
       - name: Run tests
         run: |
               if !(make POSTGRES_VERSION=${{ matrix.version }} codename=${{ matrix.os-version }} regress_coord; ); then
-                docker compose -f test/regress/docker-compose-coord.yaml ps -a --format "table {{.ID}}\t{{.Status}}" | grep -i unhealthy | awk '{print $1}' | xargs -n 1 docker logs; 
+                docker compose -f test/regress/docker-compose-coord.yaml ps -a --format "table {{.ID}}\t{{.Status}}" | awk 'tolower($0) ~ /unhealthy/ {print $1}' | xargs -r -n 1 docker logs;
                 exit 1;
               fi
 
@@ -137,7 +137,7 @@ jobs:
       - name: Run tests
         run: |
           if !(make isolation_regress); then
-            docker compose -f test/isolation/docker-compose.yaml ps -a --format "table {{.ID}}\t{{.Status}}" | grep -i unhealthy | awk '{print $1}' | xargs -n 1 docker logs; 
+            docker compose -f test/isolation/docker-compose.yaml ps -a --format "table {{.ID}}\t{{.Status}}" | awk 'tolower($0) ~ /unhealthy/ {print $1}' | xargs -r -n 1 docker logs;
             exit 1;
           fi
 

--- a/pkg/pool/shardpool_test.go
+++ b/pkg/pool/shardpool_test.go
@@ -223,13 +223,12 @@ func TestShardPoolConnectionAcquireLimit(t *testing.T) {
 				// imitate use
 				time.Sleep(time.Duration(1+rand.Uint32()%50) * time.Millisecond)
 
-				mu.Lock()
 				cntExec.Add(1)
-
-				used[conn.ID()] = false
 
 				_ = shp.Put(conn)
 
+				mu.Lock()
+				used[conn.ID()] = false
 				mu.Unlock()
 			}
 		}()

--- a/pkg/pool/shardpool_test.go
+++ b/pkg/pool/shardpool_test.go
@@ -223,12 +223,13 @@ func TestShardPoolConnectionAcquireLimit(t *testing.T) {
 				// imitate use
 				time.Sleep(time.Duration(1+rand.Uint32()%50) * time.Millisecond)
 
+				mu.Lock()
 				cntExec.Add(1)
+
+				used[conn.ID()] = false
 
 				_ = shp.Put(conn)
 
-				mu.Lock()
-				used[conn.ID()] = false
 				mu.Unlock()
 			}
 		}()


### PR DESCRIPTION
Fixes CI failure handlers that collect logs from unhealthy Docker containers.

The previous pipelines used `grep -i unhealthy`, which exits with status 1 when no containers match. Under GitHub Actions' `bash -eo pipefail`, that can abort the failure handler and mask the original test failure.

Filtering directly in `awk` keeps the pipeline successful when there are no unhealthy containers, while still passing matching container IDs to `docker logs`.