### PR TITLE
test: avoid lock contention

### DIFF
--- a/pkg/pool/shardpool_test.go
+++ b/pkg/pool/shardpool_test.go
@@ -223,13 +223,12 @@ func TestShardPoolConnectionAcquireLimit(t *testing.T) {
 				// imitate use
 				time.Sleep(time.Duration(1+rand.Uint32()%50) * time.Millisecond)
 
-				mu.Lock()
 				cntExec.Add(1)
-
-				used[conn.ID()] = false
 
 				_ = shp.Put(conn)
 
+				mu.Lock()
+				used[conn.ID()] = false
 				mu.Unlock()
 			}
 		}()


### PR DESCRIPTION
Move the `used` map update in `TestShardPoolConnectionAcquireLimit` so the shard pool `Put` call is no longer made while holding the test mutex.

This was split out from #2597 so the CI failure-handler fix can stay focused on workflow changes.