### PR TITLE
fix: decode binary-format UUID bind params in routing

### DIFF
--- a/pkg/plan/util.go
+++ b/pkg/plan/util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/google/uuid"
 	"github.com/pg-sharding/spqr/qdb"
 	"github.com/pg-sharding/spqr/router/xproto"
 )
@@ -21,9 +22,15 @@ func ParseResolveParamValue(paramCode int16, ind int, tp string, bindParams [][]
 	case xproto.FormatCodeBinary:
 		switch tp {
 		case qdb.ColumnTypeUUID:
-			val := string(bindParams[ind])
-			return val, nil
+			fallthrough
 		case qdb.ColumnTypeUUIDHashed:
+			if len(bindParams[ind]) == 16 {
+				val, err := uuid.FromBytes(bindParams[ind])
+				if err != nil {
+					return nil, ErrResolvingValue
+				}
+				return val.String(), nil
+			}
 			return string(bindParams[ind]), nil
 		case qdb.ColumnTypeVarcharDeprecated:
 			fallthrough

--- a/pkg/plan/util_test.go
+++ b/pkg/plan/util_test.go
@@ -30,6 +30,63 @@ func TestParseResolveParamValueNegativeIndex(t *testing.T) {
 	assert.ErrorIs(t, err, plan.ErrResolvingValue)
 }
 
+func TestParseResolveParamValueBinaryUUIDRawBytes(t *testing.T) {
+	t.Parallel()
+
+	rawUUID := []byte{
+		0x00, 0x01, 0x02, 0x03,
+		0x04, 0x05,
+		0x06, 0x07,
+		0x08, 0x09,
+		0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+	}
+
+	tests := []struct {
+		name       string
+		columnType string
+	}{
+		{
+			name:       "UUID",
+			columnType: qdb.ColumnTypeUUID,
+		},
+		{
+			name:       "UUIDHashed",
+			columnType: qdb.ColumnTypeUUIDHashed,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			val, err := plan.ParseResolveParamValue(xproto.FormatCodeBinary, 0, tt.columnType, [][]byte{rawUUID})
+			assert.NoError(t, err)
+			assert.Equal(t, "00010203-0405-0607-0809-0a0b0c0d0e0f", val)
+		})
+	}
+}
+
+func TestParseResolveParamValueBinaryUUIDTextFallback(t *testing.T) {
+	t.Parallel()
+
+	uuidText := "550e8400-e29b-41d4-a716-446655440000"
+
+	val, err := plan.ParseResolveParamValue(xproto.FormatCodeBinary, 0, qdb.ColumnTypeUUID, [][]byte{[]byte(uuidText)})
+	assert.NoError(t, err)
+	assert.Equal(t, uuidText, val)
+}
+
+func TestParseResolveParamValueTextUUID(t *testing.T) {
+	t.Parallel()
+
+	uuidText := "550e8400-e29b-41d4-a716-446655440000"
+
+	val, err := plan.ParseResolveParamValue(xproto.FormatCodeText, 0, qdb.ColumnTypeUUID, [][]byte{[]byte(uuidText)})
+	assert.NoError(t, err)
+	assert.Equal(t, uuidText, val)
+}
+
 func TestParseResolveParamValueValidBind(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Routing now decodes UUID bind parameters sent in binary format. PostgreSQL drivers that bind UUIDs with format code 1 send the raw 16-byte representation; `pkg/plan/util.go` previously only handled the text form, so binary-format UUID params failed to resolve to a routing key. The 16-byte value is now converted to the canonical hyphenated string, with the existing text path unchanged as the fallback.

## Why this matters
Issue #2591 reports that prepared statements with binary UUID bind params are not routed correctly, which affects any driver that defaults to binary format for the uuid OID (JDBC, npgsql, and Go's pgx in binary mode). The conversion mirrors how the surrounding code handles the other fixed-width binary types in the same switch.

## Testing
New table-driven tests in `pkg/plan/util_test.go` cover the 16-byte binary form (canonical string out), the existing text form, and malformed lengths falling through to the previous behavior. `gofmt`, `go vet`, and `go test ./pkg/plan/` pass.

Fixes #2591
