### PR TITLE
fix: flacky scenario "planned transaction is rejected"

### DIFF
--- a/router/recovery/recovery.go
+++ b/router/recovery/recovery.go
@@ -61,7 +61,7 @@ func (d *TwoPCWatchDog) RecoverDistributedTx() (map[string]struct{}, error) {
 
 		serv, err := d.p.ConnectionWithTSA(0xFFFFFFFFFFFFFFFF, kr.ShardKey{
 			Name: sh.ID,
-		}, tsa.TSA(config.TargetSessionAttrsAny))
+		}, tsa.TSA(config.TargetSessionAttrsRW))
 		if err != nil {
 			spqrlog.Zero.Error().Err(err).Msg("")
 			return nil, err


### PR DESCRIPTION
fix flacky scenario: planned transaction is rejected in generatedFeatures/2pc_recovery.feature ( https://github.com/pg-sharding/spqr/actions/runs/27749705563/job/82100134916 )
I think there is no sence check prepared transactions on replica. Or may be need setup replica connection more sofisticated.
see log
```
{"level":"info","shard":"sh1","time":"2026-06-19T12:45:37Z","message":"fetching stale two phase commit data"}
{"level":"debug","client":18446744073709551615,"shard":"sh1","effective tsa":"any","time":"2026-06-19T12:45:37Z","message":"acquiring new instance connection for client to shard with target session attrs"}
{"level":"debug","pool":4907256692880,"tokens":50,"time":"2026-06-19T12:45:37Z","message":"initialized pool queue with tokens"}
{"level":"info","host":"spqr_shard_1_replica:6432","ssl":false,"time":"2026-06-19T12:45:37Z","message":"instance acquire new connection"}
{"level":"debug","shard":4907259875808,"msg":{"Type":"StartupMessage","ProtocolVersion":196608,"Parameters":{"application_name":"app","client_encoding":"UTF8","database":"regress","spqrguard.prevent_distributed_table_modify":"off","spqrguard.prevent_reference_table_modify":"off","user":"regress"}},"time":"2026-06-19T12:45:37Z","message":"shard connection startup message"}
...
```