### PR TITLE
Use graceful shutdown for failed-auth client pools

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -196,6 +196,7 @@ goooal
 gorm
 goyacc
 Greenplum
+Grac
 gss
 gssapi
 GSSREQ

--- a/coordinator/pkg/clustered_coord.go
+++ b/coordinator/pkg/clustered_coord.go
@@ -224,6 +224,12 @@ func (ci grpcConnMgr) Shutdown() error {
 	return spqrerror.New(spqrerror.SPQR_NOT_IMPLEMENTED, "grpcConnectionIterator shutdown not implemented")
 }
 
+// TODO : implement
+// TODO : unit tests
+func (ci grpcConnMgr) GracShutdown() {
+
+}
+
 // TODO : unit tests
 func (ci grpcConnMgr) ForEach(cb func(sh shard.ShardHostCtl) error) error {
 	return ci.IterRouter(func(cc *grpc.ClientConn, addr string) error {

--- a/pkg/client/clientpool.go
+++ b/pkg/client/clientpool.go
@@ -43,7 +43,7 @@ type Pool interface {
 	Put(client Client) error
 	Pop(id uint) (bool, error)
 
-	/* Same as Shutdown(), but does not immidiately kill user */
+	/* Same as Shutdown(), but does not immediately kill user */
 	GracShutdown()
 	Shutdown() error
 }

--- a/pkg/client/clientpool.go
+++ b/pkg/client/clientpool.go
@@ -43,6 +43,8 @@ type Pool interface {
 	Put(client Client) error
 	Pop(id uint) (bool, error)
 
+	/* Same as Shutdown(), but does not immidiately kill user */
+	GracShutdown()
 	Shutdown() error
 }
 
@@ -125,6 +127,12 @@ func (c *PoolImpl) Pop(id uint) (bool, error) {
 
 // TODO : unit tests
 
+func (c *PoolImpl) GracShutdown() {
+	if c.healthCheckCancel != nil {
+		c.healthCheckCancel()
+	}
+}
+
 // Shutdown shuts down the client pool by closing all clients and releasing associated resources.
 //
 // It iterates over all clients in the pool, closes each client, and then clears the pool.
@@ -135,6 +143,8 @@ func (c *PoolImpl) Pop(id uint) (bool, error) {
 // Returns:
 //   - error: An error if any occurred during the shutdown process.
 func (c *PoolImpl) Shutdown() error {
+
+	c.GracShutdown()
 
 	c.pool.Range(func(_, value any) bool {
 		cl, ok := value.(Client)
@@ -150,10 +160,6 @@ func (c *PoolImpl) Shutdown() error {
 
 		return true
 	})
-
-	if c.healthCheckCancel != nil {
-		c.healthCheckCancel()
-	}
 
 	return nil
 }

--- a/pkg/mock/client/mock_clientpool.go
+++ b/pkg/mock/client/mock_clientpool.go
@@ -1363,6 +1363,18 @@ func (mr *MockPoolMockRecorder) ErrorCounts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorCounts", reflect.TypeOf((*MockPool)(nil).ErrorCounts))
 }
 
+// GracShutdown mocks base method.
+func (m *MockPool) GracShutdown() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GracShutdown")
+}
+
+// GracShutdown indicates an expected call of GracShutdown.
+func (mr *MockPoolMockRecorder) GracShutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GracShutdown", reflect.TypeOf((*MockPool)(nil).GracShutdown))
+}
+
 // Pop mocks base method.
 func (m *MockPool) Pop(id uint) (bool, error) {
 	m.ctrl.T.Helper()

--- a/router/mock/rulerouter/mock_rulerouter.go
+++ b/router/mock/rulerouter/mock_rulerouter.go
@@ -143,6 +143,18 @@ func (mr *MockRuleRouterMockRecorder) ForEachPool(cb any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForEachPool", reflect.TypeOf((*MockRuleRouter)(nil).ForEachPool), cb)
 }
 
+// GracShutdown mocks base method.
+func (m *MockRuleRouter) GracShutdown() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GracShutdown")
+}
+
+// GracShutdown indicates an expected call of GracShutdown.
+func (mr *MockRuleRouterMockRecorder) GracShutdown() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GracShutdown", reflect.TypeOf((*MockRuleRouter)(nil).GracShutdown))
+}
+
 // InstanceHealthChecks mocks base method.
 func (m *MockRuleRouter) InstanceHealthChecks() map[string]tsa.CachedCheckResult {
 	m.ctrl.T.Helper()

--- a/router/rulerouter/route_pool.go
+++ b/router/rulerouter/route_pool.go
@@ -24,6 +24,7 @@ type RoutePool interface {
 	) (*route.Route, error)
 
 	Obsolete(key route.Key)
+	GracShutdown()
 	Shutdown() error
 	NotifyRoutes(func(route *route.Route) (bool, error)) error
 }
@@ -85,9 +86,14 @@ func (r *RoutePoolImpl) Obsolete(key route.Key) {
 
 		/* Stop watchdogs, if any */
 		rt.MultiShardPool().StopCacheWatchdog()
-		/* XXX: do not .Close() or Shutdown client pool here, we
+		/* XXX: do not .Close() or .Shutdown() client pool here, we
 		* do not want to reset still active client connections */
+		rt.ClientPool().GracShutdown()
 	}
+}
+
+func (r *RoutePoolImpl) GracShutdown() {
+	/* nop */
 }
 
 // TODO : unit tests


### PR DESCRIPTION
Is has been revealed that client connection reset counter-measure done in aa4a319fb has regression in case of constantly failing user auth: server does not perform client pool cleanup.  