### PR TITLE
Add counter for total auth & init (tls) errors

### DIFF
--- a/coordinator/pkg/clustered_coord.go
+++ b/coordinator/pkg/clustered_coord.go
@@ -93,6 +93,16 @@ func (ci grpcConnMgr) TotalTCPCount() int64 {
 	return 0
 }
 
+// FailedAuthCount implements RuleRouter.
+func (ci grpcConnMgr) FailedAuthCount() int64 {
+	return 0
+}
+
+// FailedInitCount implements RuleRouter.
+func (ci grpcConnMgr) FailedInitCount() int64 {
+	return 0
+}
+
 // TODO : unit tests
 func (ci grpcConnMgr) IterRouter(cb func(cc *grpc.ClientConn, addr string) error) error {
 	ctx := context.TODO()

--- a/pkg/connmgr/connmgr.go
+++ b/pkg/connmgr/connmgr.go
@@ -18,6 +18,8 @@ type ConnectionStatMgr interface {
 	TotalTCPCount() int64
 	ActiveTCPCount() int64
 	TotalCancelCount() int64
+	FailedInitCount() int64
+	FailedAuthCount() int64
 }
 
 type ConnectionMgr interface {

--- a/pkg/engine/virtual_relation.go
+++ b/pkg/engine/virtual_relation.go
@@ -350,6 +350,8 @@ func InstanceVirtualRelationScan(_ context.Context, ci connmgr.ConnectionMgr) *t
 			"total_tcp_connection_count",
 			"total_cancel_requests",
 			"active_tcp_connections",
+			"failed_auth",
+			"failed_init",
 			"total_requests",
 		)}
 
@@ -359,6 +361,8 @@ func InstanceVirtualRelationScan(_ context.Context, ci connmgr.ConnectionMgr) *t
 		fmt.Sprintf("%v", ci.TotalTCPCount()),
 		fmt.Sprintf("%v", ci.TotalCancelCount()),
 		fmt.Sprintf("%v", ci.ActiveTCPCount()),
+		fmt.Sprintf("%v", ci.FailedAuthCount()),
+		fmt.Sprintf("%v", ci.FailedInitCount()),
 		fmt.Sprintf("%d", stats),
 	)
 

--- a/router/mock/rulerouter/mock_rulerouter.go
+++ b/router/mock/rulerouter/mock_rulerouter.go
@@ -115,6 +115,34 @@ func (mr *MockRuleRouterMockRecorder) ErrorCounts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ErrorCounts", reflect.TypeOf((*MockRuleRouter)(nil).ErrorCounts))
 }
 
+// FailedAuthCount mocks base method.
+func (m *MockRuleRouter) FailedAuthCount() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailedAuthCount")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// FailedAuthCount indicates an expected call of FailedAuthCount.
+func (mr *MockRuleRouterMockRecorder) FailedAuthCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailedAuthCount", reflect.TypeOf((*MockRuleRouter)(nil).FailedAuthCount))
+}
+
+// FailedInitCount mocks base method.
+func (m *MockRuleRouter) FailedInitCount() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FailedInitCount")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// FailedInitCount indicates an expected call of FailedInitCount.
+func (mr *MockRuleRouterMockRecorder) FailedInitCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FailedInitCount", reflect.TypeOf((*MockRuleRouter)(nil).FailedInitCount))
+}
+
 // ForEach mocks base method.
 func (m *MockRuleRouter) ForEach(cb func(shard.ShardHostCtl) error) error {
 	m.ctrl.T.Helper()

--- a/router/rulerouter/rulerouter.go
+++ b/router/rulerouter/rulerouter.go
@@ -63,9 +63,11 @@ type RuleRouterImpl struct {
 
 	initSem semaphore.Weighted
 
-	totalTCPCount   atomic.Int64
-	activeTCPCount  atomic.Int64
-	cancelConnCount atomic.Int64
+	totalTCPCount       atomic.Int64
+	activeTCPCount      atomic.Int64
+	cancelConnCount     atomic.Int64
+	clientInitFailCount atomic.Int64
+	clientAuthFailCount atomic.Int64
 }
 
 // ErrorCounts implements [RuleRouter].
@@ -133,6 +135,16 @@ func (r *RuleRouterImpl) TotalCancelCount() int64 {
 // TotalTCPCount implements RuleRouter.
 func (r *RuleRouterImpl) TotalTCPCount() int64 {
 	return r.totalTCPCount.Load()
+}
+
+// FailedAuthCount implements RuleRouter.
+func (r *RuleRouterImpl) FailedAuthCount() int64 {
+	return r.clientAuthFailCount.Load()
+}
+
+// FailedInitCount implements RuleRouter.
+func (r *RuleRouterImpl) FailedInitCount() int64 {
+	return r.clientInitFailCount.Load()
 }
 
 // TODO : unit tests
@@ -217,6 +229,7 @@ func (r *RuleRouterImpl) PreRoute(conn net.Conn, pt port.RouterPortType) (rclien
 
 	if err := cl.Init(tlsConfig); err != nil {
 		r.initSem.Release(1)
+		r.clientInitFailCount.Add(1)
 		return cl, err
 	}
 
@@ -286,6 +299,7 @@ func (r *RuleRouterImpl) PreRoute(conn net.Conn, pt port.RouterPortType) (rclien
 	}
 
 	if err := cl.Auth(rt); err != nil {
+		r.clientAuthFailCount.Add(1)
 		_ = cl.ReplyErr(err)
 		if !config.RouterConfig().DisableObsoleteClient {
 			r.Obsolete(key)


### PR DESCRIPTION
```
spqr-console=> show instance;
 total_tcp_connection_count | total_cancel_requests | active_tcp_connections | failed_auth | failed_init | total_requests
----------------------------+-----------------------+------------------------+-------------+-------------+----------------
 8                          | 0                     | 1                      | 7           | 0           | 0
(1 row)
```