### PR TITLE
Revert "Properly implement timeouts in TSA checker function. (#2666)"

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -318,7 +318,6 @@ mintlify
 mmgr
 mngr
 mockcl
-mockconn
 mockcmgr
 mockgen
 mockinst

--- a/pkg/pool/dbpool.go
+++ b/pkg/pool/dbpool.go
@@ -45,8 +45,7 @@ type DBPool struct {
 
 	AcquireRetryCount int
 
-	recheckTCP   bool
-	CheckTimeout time.Duration
+	recheckTCP bool
 
 	// Background health checking
 	healthCheckCtx    context.Context
@@ -163,7 +162,7 @@ func (s *DBPool) recheckSingleHost(tsaKey TsaKey, oldEntry CachedEntry) {
 	}()
 
 	// Perform TSA check using existing checker
-	tcr, err := s.checker.CheckTSA(shardInstance, tsa.DefaultTSATimeout)
+	tcr, err := s.checker.CheckTSA(shardInstance)
 	if err != nil {
 		spqrlog.Zero.Warn().
 			Str("host", tsaKey.Host).
@@ -364,25 +363,25 @@ func (s *DBPool) selectReadWriteShardHost(clid uint, key kr.ShardKey, hosts []co
 //     during the selection process.
 //
 // // TODO : unit tests
-func (s *DBPool) selectShardHost(clid uint, key kr.ShardKey, hosts []config.Host, tsaAttrs tsa.TSA, primary bool) (shard.ShardHostInstance, error) {
+func (s *DBPool) selectShardHost(clid uint, key kr.ShardKey, hosts []config.Host, tsa tsa.TSA, primary bool) (shard.ShardHostInstance, error) {
 	hostToReason := map[string]string{}
 	sh := s.traverseHostsMatchCB(clid, key, hosts, func(shard shard.ShardHostInstance) bool {
-		tcr, err := s.checker.CheckTSA(shard, s.CheckTimeout)
+		tcr, err := s.checker.CheckTSA(shard)
 		good := tcr.CR.RW == primary
 
 		if err != nil {
 			hostToReason[shard.Instance().Hostname()] = err.Error()
 			_ = s.pool.Discard(shard)
 
-			s.cache.MarkUnmatched(tsaAttrs, shard.Instance().Hostname(), shard.Instance().AvailabilityZone(), tcr.CR.Alive, err.Error())
+			s.cache.MarkUnmatched(tsa, shard.Instance().Hostname(), shard.Instance().AvailabilityZone(), tcr.CR.Alive, err.Error())
 
 			return false
 		}
 
 		if good {
-			s.cache.MarkMatched(tsaAttrs, shard.Instance().Hostname(), shard.Instance().AvailabilityZone(), tcr.CR.Alive, tcr.CR.Reason)
+			s.cache.MarkMatched(tsa, shard.Instance().Hostname(), shard.Instance().AvailabilityZone(), tcr.CR.Alive, tcr.CR.Reason)
 		} else {
-			s.cache.MarkUnmatched(tsaAttrs, shard.Instance().Hostname(), shard.Instance().AvailabilityZone(), tcr.CR.Alive, tcr.CR.Reason)
+			s.cache.MarkUnmatched(tsa, shard.Instance().Hostname(), shard.Instance().AvailabilityZone(), tcr.CR.Alive, tcr.CR.Reason)
 		}
 
 		if tcr.CR.Alive && good {
@@ -394,7 +393,7 @@ func (s *DBPool) selectShardHost(clid uint, key kr.ShardKey, hosts []config.Host
 		_ = s.Put(shard)
 		return false
 
-	}, tsaAttrs)
+	}, tsa)
 	if sh != nil {
 		return sh, nil
 	}
@@ -702,7 +701,6 @@ func NewDBPool(tmgr topology.TopologyMgr, startupParams *startup.StartupParams, 
 		PreferAZ:          preferAZ,
 		AcquireRetryCount: config.ValueOrDefaultInt(config.RouterConfig().DbpoolAcquireRetryCount, DefaultAcquireRetryCount),
 		recheckTCP:/* default is false */ config.RouterConfig().DefaultRecheckTCPAliveness,
-		CheckTimeout: tsa.DefaultTSATimeout,
 
 		checker:           tsa.NewCachedTSAChecker(),
 		deadCheckInterval: config.ValueOrDefaultDuration(config.RouterConfig().DbpoolDeadCheckInterval, DefaultDeadCheckInterval),

--- a/pkg/pool/dbpool_test.go
+++ b/pkg/pool/dbpool_test.go
@@ -52,28 +52,14 @@ func TestDbPoolOrderCaching(t *testing.T) {
 			}), &startup.StartupParams{}, underlyingPool, time.Hour)
 
 	ins1 := mockinst.NewMockDBInstance(ctrl)
-	rawConn1 := mockinst.NewMockRawConn(ctrl)
-	rawConn1.EXPECT().SetReadDeadline(gomock.Any()).AnyTimes().Return(nil)
-	ins1.EXPECT().Conn().AnyTimes().Return(rawConn1)
-
 	ins1.EXPECT().Hostname().AnyTimes().Return("h1:6432")
 	ins1.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
 	ins2 := mockinst.NewMockDBInstance(ctrl)
-
-	rawConn2 := mockinst.NewMockRawConn(ctrl)
-	rawConn2.EXPECT().SetReadDeadline(gomock.Any()).AnyTimes().Return(nil)
-	ins2.EXPECT().Conn().AnyTimes().Return(rawConn2)
-
 	ins2.EXPECT().Hostname().AnyTimes().Return("h2:6432")
 	ins2.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
 	ins3 := mockinst.NewMockDBInstance(ctrl)
-
-	rawConn3 := mockinst.NewMockRawConn(ctrl)
-	rawConn3.EXPECT().SetReadDeadline(gomock.Any()).AnyTimes().Return(nil)
-	ins3.EXPECT().Conn().AnyTimes().Return(rawConn3)
-
 	ins3.EXPECT().Hostname().AnyTimes().Return("h3:6432")
 	ins3.EXPECT().AvailabilityZone().AnyTimes().Return("")
 
@@ -190,13 +176,9 @@ func TestDbPoolRaces(t *testing.T) {
 			for j := range sz {
 				sh := mockshard.NewMockShardHostInstance(ctrl)
 
-				instance := mockinst.NewMockDBInstance(ctrl)
-
-				c := mockinst.NewMockRawConn(ctrl)
-				instance.EXPECT().Conn().Return(c).AnyTimes()
-
-				instance.EXPECT().Hostname().Return(hst).AnyTimes()
-				instance.EXPECT().AvailabilityZone().Return("").AnyTimes()
+				ins1 := mockinst.NewMockDBInstance(ctrl)
+				ins1.EXPECT().Hostname().Return(hst).AnyTimes()
+				ins1.EXPECT().AvailabilityZone().Return("").AnyTimes()
 
 				sh.EXPECT().IsStale().AnyTimes().Return(false)
 
@@ -233,7 +215,7 @@ func TestDbPoolRaces(t *testing.T) {
 				sh.EXPECT().InstanceHostname().Return(hst).AnyTimes()
 
 				sh.EXPECT().ID().Return(uint((3*i+hi)*sz + j)).AnyTimes()
-				sh.EXPECT().Instance().Return(instance).AnyTimes()
+				sh.EXPECT().Instance().Return(ins1).AnyTimes()
 				mp[shname][hst] = append(mp[shname][hst], sh)
 			}
 		}
@@ -266,25 +248,22 @@ func TestDbPoolRaces(t *testing.T) {
 		ConnectionLimit: sz,
 	})
 
-	/* XXX: we dont want to test network speed */
-	dbpool.CheckTimeout = 0
-
 	sem := semaphore.NewWeighted(25)
 
 	for i := range 10 {
 		for range 200 {
 			assert.NoError(sem.Acquire(context.TODO(), 1))
 
-			go func(i int) {
+			go func() {
 				defer sem.Release(1)
 
 				sh, err := dbpool.ConnectionWithTSA(uint(i), kr.ShardKey{Name: shards[i%3]}, config.TargetSessionAttrsPS)
 				assert.NoError(err)
-
 				err = dbpool.Put(sh)
 				assert.NoError(err)
-			}(i)
+			}()
 		}
+
 	}
 }
 

--- a/pkg/tsa/cachedchecker.go
+++ b/pkg/tsa/cachedchecker.go
@@ -57,7 +57,7 @@ func NewCachedTSACheckerWithDuration(tsaRecheckDuration time.Duration) *CachedTS
 // Returns:
 //   - CheckResult: A struct containing the result of the TSA check.
 //   - error: An error if any occurred during the process.
-func (ctsa *CachedTSAChecker) CheckTSA(sh shard.ShardHostInstance, timeout time.Duration) (CachedCheckResult, error) {
+func (ctsa *CachedTSAChecker) CheckTSA(sh shard.ShardHostInstance) (CachedCheckResult, error) {
 
 	n := time.Now()
 	if v, ok := ctsa.cache.Load(sh.Instance().Hostname()); ok {
@@ -74,7 +74,7 @@ func (ctsa *CachedTSAChecker) CheckTSA(sh shard.ShardHostInstance, timeout time.
 	* will end up running innerChecker.
 	* However, a concurrent protocol to avoid this is too
 	* much for troubles here, so we are fine. */
-	cr, err := ctsa.innerChecker.CheckTSA(sh, timeout)
+	cr, err := ctsa.innerChecker.CheckTSA(sh)
 	if err != nil {
 		return CachedCheckResult{}, err
 	}

--- a/pkg/tsa/cachedchecker_test.go
+++ b/pkg/tsa/cachedchecker_test.go
@@ -56,7 +56,7 @@ func TestTSA_RW(t *testing.T) {
 	instance.EXPECT().Hostname().AnyTimes().Return("host1")
 	sh.EXPECT().Name().Return("sh1").AnyTimes()
 
-	cr, err := checker.CheckTSA(sh, 0)
+	cr, err := checker.CheckTSA(sh)
 	assert.NoError(err)
 	assert.True(cr.CR.Alive)
 	assert.True(cr.CR.RW)
@@ -83,7 +83,7 @@ func TestTSA_HostNotAlive(t *testing.T) {
 	instance.EXPECT().Hostname().AnyTimes().Return("host2")
 	sh.EXPECT().Name().Return("sh2").AnyTimes()
 
-	cr, err := checker.CheckTSA(sh, 0)
+	cr, err := checker.CheckTSA(sh)
 	assert.Error(err)
 	assert.False(cr.CR.Alive)
 }
@@ -120,7 +120,7 @@ func TestTSA_CacheExpiry(t *testing.T) {
 	sh.EXPECT().Name().Return("sh3").AnyTimes()
 
 	// First check
-	cr1, err1 := checker.CheckTSA(sh, 0)
+	cr1, err1 := checker.CheckTSA(sh)
 	assert.NoError(err1)
 	assert.True(cr1.CR.Alive)
 	assert.True(cr1.CR.RW)
@@ -129,7 +129,7 @@ func TestTSA_CacheExpiry(t *testing.T) {
 	time.Sleep(time.Second + time.Millisecond)
 
 	// Second check should trigger a new TSA check ()
-	cr2, err2 := checker.CheckTSA(sh, 0)
+	cr2, err2 := checker.CheckTSA(sh)
 	assert.EqualError(err2, "network timeout")
 	assert.False(cr2.CR.Alive)
 	assert.False(cr2.CR.RW)
@@ -164,13 +164,13 @@ func TestTSA_CacheHit(t *testing.T) {
 	sh.EXPECT().Name().Return("sh4").AnyTimes()
 
 	// First check
-	cr1, err1 := checker.CheckTSA(sh, 0)
+	cr1, err1 := checker.CheckTSA(sh)
 	assert.NoError(err1)
 	assert.True(cr1.CR.Alive)
 	assert.False(cr1.CR.RW)
 
 	// Second check should hit cache
-	cr2, err2 := checker.CheckTSA(sh, 0)
+	cr2, err2 := checker.CheckTSA(sh)
 	assert.NoError(err2)
 	assert.True(cr2.CR.Alive)
 	assert.False(cr2.CR.RW)

--- a/pkg/tsa/netchecker.go
+++ b/pkg/tsa/netchecker.go
@@ -1,6 +1,7 @@
 package tsa
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -25,7 +26,9 @@ type NetChecker struct {
 // Returns:
 //   - CheckResult: A struct containing the result of the TSA check.
 //   - error: An error if any occurred during the process.
-func (NetChecker) CheckTSA(sh shard.ShardHostInstance, timeout time.Duration) (CheckResult, error) {
+func (NetChecker) CheckTSA(sh shard.ShardHostInstance) (CheckResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultTSATimeout)
+	defer cancel()
 
 	if err := sh.Send(&pgproto3.Query{
 		String: "SHOW transaction_read_only",
@@ -45,15 +48,31 @@ func (NetChecker) CheckTSA(sh shard.ShardHostInstance, timeout time.Duration) (C
 	reason := "empty"
 
 	for {
-		if timeout != 0 {
-			if err := sh.Instance().Conn().SetReadDeadline(time.Now().Add(DefaultTSATimeout)); err != nil {
-				return CheckResult{}, err
+		// Use a goroutine with select to handle both timeout and receive
+		messageChan := make(chan pgproto3.BackendMessage, 1)
+		errorChan := make(chan error, 1)
+
+		go func() {
+			msg, err := sh.Receive()
+			if err != nil {
+				errorChan <- err
+				return
 			}
-		}
+			messageChan <- msg
+		}()
 
-		msg, err := sh.Receive()
-
-		if err != nil {
+		select {
+		case <-ctx.Done():
+			spqrlog.Zero.Debug().
+				Uint("shard", sh.ID()).
+				Dur("timeout", DefaultTSATimeout).
+				Msg("netchecker: TSA check timed out")
+			return CheckResult{
+				Alive:  false,
+				RW:     false,
+				Reason: fmt.Sprintf("TSA check timed out after %v", DefaultTSATimeout),
+			}, fmt.Errorf("TSA check timed out after %v", DefaultTSATimeout)
+		case err := <-errorChan:
 			spqrlog.Zero.Debug().
 				Uint("shard", sh.ID()).
 				Err(err).
@@ -63,55 +82,54 @@ func (NetChecker) CheckTSA(sh shard.ShardHostInstance, timeout time.Duration) (C
 				RW:     false,
 				Reason: "received an error while receiving the next message",
 			}, err
-		}
-
-		spqrlog.Zero.Debug().
-			Uint("shard", sh.ID()).
-			Str("type", fmt.Sprintf("%T", msg)).
-			Interface("message", msg).
-			Msg("netchecker: shard has received the next message")
-
-		switch qt := msg.(type) {
-		case *pgproto3.DataRow:
-			if len(qt.Values) == 1 && len(qt.Values[0]) == 3 && qt.Values[0][0] == 'o' && qt.Values[0][1] == 'f' && qt.Values[0][2] == 'f' {
-				readWrite = true
-				reason = "primary"
-			} else if len(qt.Values) == 1 && len(qt.Values[0]) == 2 && qt.Values[0][0] == 'o' && qt.Values[0][1] == 'n' {
-				readWrite = false
-				reason = "replica"
-			} else {
-				spqrlog.Zero.Debug().
-					Uint("shard", sh.ID()).
-					Msg("netchecker: unexpected datarow while calculating")
-				return CheckResult{
-					Alive:  false,
-					RW:     false,
-					Reason: fmt.Sprintf("unexpected datarow received: %v", qt.Values),
-				}, fmt.Errorf("unexpected datarow received: %v", qt.Values)
-			}
-
-		case *pgproto3.ReadyForQuery:
-			if txstatus.TXStatus(qt.TxStatus) != txstatus.TXIDLE {
-				spqrlog.Zero.Debug().
-					Uint("shard", sh.ID()).
-					Msg("netchecker: got unsync connection while calculating")
-				return CheckResult{
-					Alive:  false,
-					RW:     readWrite,
-					Reason: "the connection was unsynced while acquiring it",
-				}, fmt.Errorf("the connection was unsynced while acquiring it")
-			}
-
+		case msg := <-messageChan:
 			spqrlog.Zero.Debug().
 				Uint("shard", sh.ID()).
-				Bool("read-write", readWrite).
-				Bool("alive", true).
-				Msg("netchecker: finished")
-			return CheckResult{
-				Alive:  true,
-				RW:     readWrite,
-				Reason: reason,
-			}, nil
+				Str("type", fmt.Sprintf("%T", msg)).
+				Interface("message", msg).
+				Msg("netchecker: shard has received the next message")
+			switch qt := msg.(type) {
+			case *pgproto3.DataRow:
+				if len(qt.Values) == 1 && len(qt.Values[0]) == 3 && qt.Values[0][0] == 'o' && qt.Values[0][1] == 'f' && qt.Values[0][2] == 'f' {
+					readWrite = true
+					reason = "primary"
+				} else if len(qt.Values) == 1 && len(qt.Values[0]) == 2 && qt.Values[0][0] == 'o' && qt.Values[0][1] == 'n' {
+					readWrite = false
+					reason = "replica"
+				} else {
+					spqrlog.Zero.Debug().
+						Uint("shard", sh.ID()).
+						Msg("netchecker: got unexpected datarow while calculating")
+					return CheckResult{
+						Alive:  false,
+						RW:     false,
+						Reason: fmt.Sprintf("unexpected datarow received: %v", qt.Values),
+					}, fmt.Errorf("unexpected datarow received: %v", qt.Values)
+				}
+
+			case *pgproto3.ReadyForQuery:
+				if txstatus.TXStatus(qt.TxStatus) != txstatus.TXIDLE {
+					spqrlog.Zero.Debug().
+						Uint("shard", sh.ID()).
+						Msg("netchecker: got unsync connection while calculating")
+					return CheckResult{
+						Alive:  false,
+						RW:     readWrite,
+						Reason: "the connection was unsynced while acquiring it",
+					}, fmt.Errorf("the connection was unsynced while acquiring it")
+				}
+
+				spqrlog.Zero.Debug().
+					Uint("shard", sh.ID()).
+					Bool("read-write", readWrite).
+					Bool("alive", true).
+					Msg("netchecker: finished")
+				return CheckResult{
+					Alive:  true,
+					RW:     readWrite,
+					Reason: reason,
+				}, nil
+			}
 		}
 	}
 }

--- a/pkg/tsa/netchecker_test.go
+++ b/pkg/tsa/netchecker_test.go
@@ -3,6 +3,7 @@ package tsa_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgproto3"
 	mockshard "github.com/pg-sharding/spqr/pkg/mock/shard"
@@ -25,12 +26,9 @@ func TestChecker_CheckTSA(t *testing.T) {
 		mockShard.EXPECT().Receive().Return(&pgproto3.DataRow{
 			Values: [][]byte{[]byte("off")},
 		}, nil)
-		mockShard.EXPECT().Receive().Return(&pgproto3.CommandComplete{
-			CommandTag: []byte("SHOW"),
-		}, nil)
 		mockShard.EXPECT().Receive().Return(&pgproto3.ReadyForQuery{TxStatus: byte(txstatus.TXIDLE)}, nil)
 
-		result, err := checker.CheckTSA(mockShard, 0)
+		result, err := checker.CheckTSA(mockShard)
 		assert.NoError(t, err)
 		assert.True(t, result.Alive)
 		assert.True(t, result.RW)
@@ -42,12 +40,9 @@ func TestChecker_CheckTSA(t *testing.T) {
 		mockShard.EXPECT().Receive().Return(&pgproto3.DataRow{
 			Values: [][]byte{[]byte("on")},
 		}, nil)
-		mockShard.EXPECT().Receive().Return(&pgproto3.CommandComplete{
-			CommandTag: []byte("SHOW"),
-		}, nil)
 		mockShard.EXPECT().Receive().Return(&pgproto3.ReadyForQuery{TxStatus: byte(txstatus.TXIDLE)}, nil)
 
-		result, err := checker.CheckTSA(mockShard, 0)
+		result, err := checker.CheckTSA(mockShard)
 		assert.NoError(t, err)
 		assert.True(t, result.Alive)
 		assert.False(t, result.RW)
@@ -57,7 +52,7 @@ func TestChecker_CheckTSA(t *testing.T) {
 	t.Run("Error_sending_query_test", func(t *testing.T) {
 		mockShard.EXPECT().Send(&pgproto3.Query{String: "SHOW transaction_read_only"}).Return(errors.New("send error"))
 
-		result, err := checker.CheckTSA(mockShard, 0)
+		result, err := checker.CheckTSA(mockShard)
 		assert.Error(t, err)
 		assert.False(t, result.Alive)
 		assert.False(t, result.RW)
@@ -68,7 +63,7 @@ func TestChecker_CheckTSA(t *testing.T) {
 		mockShard.EXPECT().Send(&pgproto3.Query{String: "SHOW transaction_read_only"}).Return(nil)
 		mockShard.EXPECT().Receive().Return(nil, errors.New("receive an error"))
 
-		result, err := checker.CheckTSA(mockShard, 0)
+		result, err := checker.CheckTSA(mockShard)
 		assert.Error(t, err)
 		assert.False(t, result.Alive)
 		assert.False(t, result.RW)
@@ -79,7 +74,7 @@ func TestChecker_CheckTSA(t *testing.T) {
 		mockShard.EXPECT().Send(&pgproto3.Query{String: "SHOW transaction_read_only"}).Return(nil)
 		mockShard.EXPECT().Receive().Return(&pgproto3.ReadyForQuery{TxStatus: byte(txstatus.TXACT)}, nil)
 
-		result, err := checker.CheckTSA(mockShard, 0)
+		result, err := checker.CheckTSA(mockShard)
 		assert.Error(t, err)
 		assert.False(t, result.Alive)
 		assert.False(t, result.RW)
@@ -91,7 +86,7 @@ func TestChecker_CheckTSA(t *testing.T) {
 			Values: [][]byte{[]byte("maybe")},
 		}, nil)
 
-		result, err := checker.CheckTSA(mockShard, 0)
+		result, err := checker.CheckTSA(mockShard)
 		assert.Error(t, err)
 		assert.False(t, result.Alive)
 		assert.False(t, result.RW)
@@ -104,10 +99,30 @@ func TestChecker_CheckTSA(t *testing.T) {
 			Values: [][]byte{},
 		}, nil)
 
-		result, err := checker.CheckTSA(mockShard, 0)
+		result, err := checker.CheckTSA(mockShard)
 		assert.Error(t, err)
 		assert.False(t, result.Alive)
 		assert.False(t, result.RW)
 		assert.Contains(t, result.Reason, "unexpected datarow received")
+	})
+
+	t.Run("Timeout_test", func(t *testing.T) {
+		mockShard.EXPECT().Send(&pgproto3.Query{String: "SHOW transaction_read_only"}).Return(nil)
+
+		// Simulate a slow response
+		mockShard.EXPECT().Receive().DoAndReturn(func() (pgproto3.BackendMessage, error) {
+			time.Sleep(5 * time.Second)
+			return &pgproto3.DataRow{
+				Values: [][]byte{[]byte("off")},
+			}, nil
+		})
+
+		result, err := checker.CheckTSA(mockShard)
+
+		assert.Error(t, err)
+		assert.False(t, result.Alive)
+		assert.False(t, result.RW)
+		assert.Contains(t, result.Reason, "TSA check timed out after")
+		assert.Contains(t, err.Error(), "TSA check timed out after")
 	})
 }


### PR DESCRIPTION
This reverts commit 7fbf044ecef8fcf6469cc2ca1f7c7e838aedea55.