### PR TITLE
Security: Insecure gRPC Connection Using Without TLS

### DIFF
--- a/pkg/coord/d_proxy.go
+++ b/pkg/coord/d_proxy.go
@@ -2,12 +2,13 @@ package coord
 
 import (
 	"context"
+	"crypto/tls"
 
 	"github.com/pg-sharding/spqr/pkg/config"
 	"github.com/pg-sharding/spqr/pkg/meta"
 	"github.com/pg-sharding/spqr/pkg/spqrlog"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 func DistributedMgr(ctx context.Context, localCoordinator meta.EntityMgr) (meta.EntityMgr, func(), error) {
@@ -21,7 +22,7 @@ func DistributedMgr(ctx context.Context, localCoordinator meta.EntityMgr) (meta.
 		return nil, nil, err
 	}
 
-	conn, err := grpc.NewClient(coordAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(coordAddr, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary

Security: Insecure gRPC Connection Using Without TLS

## Problem

**Severity**: `High` | **File**: `pkg/coord/d_proxy.go:L20`

The `DistributedMgr` function in `pkg/coord/d_proxy.go` creates a gRPC client connection using `grpc.WithTransportCredentials(insecure.NewCredentials())`, which disables TLS entirely. This allows for man-in-the-middle attacks on coordinator-to-router communication. The code fetches a coordinator address and connects without any authentication or encryption.

## Solution

Use proper TLS credentials with certificate verification instead of insecure credentials. Consider adding configuration options for CA certificates, client certificates, and enabling/disabling TLS verification.

## Changes

- `pkg/coord/d_proxy.go` (modified)