### PR TITLE
Create issues for repeated test failure candidates

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -12,6 +12,7 @@ adipiscing
 adminpassword
 AExpr
 afe
+Aflake
 aliasname
 aliqua
 aliquip
@@ -42,6 +43,7 @@ bootstraping
 Bootstrapper
 buildpackage
 cachedchecker
+Cagent
 caio
 CANCELREQ
 canreq

--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -138,6 +138,9 @@ Dzz
 ebff
 eda
 edabaf
+ededed
+eedb
+eedba
 efef
 eiusmod
 elephantsql

--- a/.github/workflows/test-history.yaml
+++ b/.github/workflows/test-history.yaml
@@ -11,12 +11,17 @@ on:
         description: Minimum failures with the same fingerprint before emitting a candidate
         required: false
         default: "3"
+      sync_issues:
+        description: Create or update GitHub issues for emitted failure candidates
+        required: false
+        default: "false"
   schedule:
     - cron: "17 3 * * *"
 
 permissions:
   actions: read
   contents: read
+  issues: write
 
 jobs:
   test-history:
@@ -75,6 +80,16 @@ jobs:
           if [ -f test-history/failure-candidates.md ]; then
             cat test-history/failure-candidates.md >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Create or update failure candidate issues
+        if: github.ref == 'refs/heads/master' && (github.event_name == 'schedule' || inputs.sync_issues == 'true')
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          go run ./test/tools/test_history_issues \
+            --candidates-input test-history/failure-candidates.json \
+            --repo "$GITHUB_REPOSITORY"
 
       - name: Upload test history artifacts
         if: always()

--- a/test/tools/test_history/main.go
+++ b/test/tools/test_history/main.go
@@ -865,6 +865,8 @@ func deriveMatrix(rel string) string {
 			return strings.TrimPrefix(part, "test-reports-regress-")
 		case strings.HasPrefix(part, "test-reports-feature-"):
 			return strings.TrimPrefix(part, "test-reports-feature-")
+		case part == "test-reports-isolation":
+			return "isolation"
 		case part == "regress-coord" && i+1 < len(parts)-1:
 			return parts[i+1]
 		case part == "regress" && i+1 < len(parts)-1:

--- a/test/tools/test_history/main_test.go
+++ b/test/tools/test_history/main_test.go
@@ -222,6 +222,21 @@ func TestTimestampFromReportPathOnlyAcceptsRFC3339(t *testing.T) {
 	}
 }
 
+func TestDeriveMatrixFromDownloadedIsolationReportPath(t *testing.T) {
+	tests := map[string]string{
+		"29030391367/test-reports-isolation/isolation-regress.xml":     "isolation",
+		"test-reports/isolation/isolation-regress.xml":                 "isolation",
+		"29030391367/test-reports-regress-jammy-16/jammy-16/test.xml":  "jammy-16",
+		"29030391367/test-reports-feature-feature-0/feature-0/out.xml": "feature-0",
+	}
+
+	for path, want := range tests {
+		if got := deriveMatrix(path); got != want {
+			t.Fatalf("deriveMatrix(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
 func TestTimestampLessSortsUnknownLast(t *testing.T) {
 	if timestampLess("", "2026-07-07T10:00:00Z") {
 		t.Fatal("empty timestamp sorted before a real timestamp")

--- a/test/tools/test_history_issues/main.go
+++ b/test/tools/test_history_issues/main.go
@@ -1,0 +1,551 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+type stringList []string
+
+func (s *stringList) String() string {
+	return strings.Join(*s, ",")
+}
+
+func (s *stringList) Set(value string) error {
+	for _, part := range strings.Split(value, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			*s = append(*s, part)
+		}
+	}
+	return nil
+}
+
+type candidateReport struct {
+	Candidates []failureCandidate `json:"candidates"`
+}
+
+type failureCandidate struct {
+	ID               string        `json:"id"`
+	Scope            string        `json:"scope"`
+	Suite            string        `json:"suite"`
+	Name             string        `json:"name"`
+	Matrix           string        `json:"matrix,omitempty"`
+	AffectedMatrices []string      `json:"affected_matrices,omitempty"`
+	Fingerprint      string        `json:"fingerprint"`
+	Failures         int           `json:"failures"`
+	TestRuns         int           `json:"test_runs"`
+	FailureRate      float64       `json:"failure_rate"`
+	FirstObserved    string        `json:"first_observed,omitempty"`
+	LastObserved     string        `json:"last_observed,omitempty"`
+	LastKnownPass    string        `json:"last_known_pass,omitempty"`
+	TraceExcerpt     string        `json:"trace_excerpt,omitempty"`
+	Evidence         []runEvidence `json:"evidence"`
+	AgentTaskTitle   string        `json:"agent_task_title"`
+}
+
+type runEvidence struct {
+	RunID      string `json:"run_id,omitempty"`
+	RunURL     string `json:"run_url,omitempty"`
+	CommitSHA  string `json:"commit_sha,omitempty"`
+	Branch     string `json:"branch,omitempty"`
+	Timestamp  string `json:"timestamp,omitempty"`
+	Matrix     string `json:"matrix,omitempty"`
+	ReportPath string `json:"report_path,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+type issueSpec struct {
+	CandidateID string
+	Title       string
+	Body        string
+}
+
+type githubIssue struct {
+	Number      int    `json:"number"`
+	Title       string `json:"title"`
+	Body        string `json:"body"`
+	PullRequest any    `json:"pull_request,omitempty"`
+}
+
+type githubLabel struct {
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description,omitempty"`
+}
+
+type githubClient struct {
+	apiURL     string
+	owner      string
+	repo       string
+	token      string
+	httpClient *http.Client
+}
+
+type options struct {
+	candidatesInput string
+	repo            string
+	token           string
+	apiURL          string
+	labels          stringList
+	dryRun          bool
+}
+
+const markerPrefix = "<!-- spqr-test-failure-candidate:"
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout io.Writer) error {
+	opts := options{}
+	fs := flag.NewFlagSet("test_history_issues", flag.ContinueOnError)
+	fs.StringVar(&opts.candidatesInput, "candidates-input", "", "path to failure-candidates.json")
+	fs.StringVar(&opts.repo, "repo", "", "GitHub repository in owner/name form")
+	fs.StringVar(&opts.token, "github-token", firstNonEmpty(os.Getenv("GITHUB_TOKEN"), os.Getenv("GH_TOKEN")), "GitHub token; defaults to GITHUB_TOKEN or GH_TOKEN")
+	fs.StringVar(&opts.apiURL, "github-api-url", "https://api.github.com", "GitHub API base URL")
+	fs.Var(&opts.labels, "label", "label to add to created/updated issues; can be repeated or comma-separated")
+	fs.BoolVar(&opts.dryRun, "dry-run", false, "render planned issue changes without writing to GitHub")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if opts.candidatesInput == "" {
+		return errors.New("--candidates-input is required")
+	}
+	if len(opts.labels) == 0 {
+		opts.labels = stringList{"ci-flaky", "agent:flake-fix"}
+	}
+
+	report, err := readCandidateReport(opts.candidatesInput)
+	if err != nil {
+		return err
+	}
+	candidates := filterIssueCandidates(report.Candidates)
+	specs := make([]issueSpec, 0, len(candidates))
+	for _, candidate := range candidates {
+		specs = append(specs, issueSpecFromCandidate(candidate))
+	}
+
+	if opts.dryRun {
+		for _, spec := range specs {
+			if _, err := fmt.Fprintf(stdout, "would sync candidate %s: %s\n", spec.CandidateID, spec.Title); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if opts.repo == "" {
+		return errors.New("--repo is required unless --dry-run is set")
+	}
+	if opts.token == "" {
+		return errors.New("--github-token or GITHUB_TOKEN is required unless --dry-run is set")
+	}
+
+	owner, repo, err := parseRepo(opts.repo)
+	if err != nil {
+		return err
+	}
+	client := githubClient{
+		apiURL: strings.TrimRight(opts.apiURL, "/"),
+		owner:  owner,
+		repo:   repo,
+		token:  opts.token,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+	return syncIssues(client, specs, []string(opts.labels), stdout)
+}
+
+func readCandidateReport(path string) (candidateReport, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return candidateReport{}, err
+	}
+	var report candidateReport
+	if err := json.Unmarshal(content, &report); err != nil {
+		return candidateReport{}, err
+	}
+	return report, nil
+}
+
+func filterIssueCandidates(candidates []failureCandidate) []failureCandidate {
+	crossMatrixKeys := make(map[string]struct{})
+	for _, candidate := range candidates {
+		if candidate.Scope == "cross_matrix" {
+			crossMatrixKeys[candidate.issueGroupKey()] = struct{}{}
+		}
+	}
+
+	filtered := make([]failureCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.Scope == "matrix" {
+			if _, ok := crossMatrixKeys[candidate.issueGroupKey()]; ok {
+				continue
+			}
+		}
+		filtered = append(filtered, candidate)
+	}
+	return filtered
+}
+
+func (candidate failureCandidate) issueGroupKey() string {
+	return candidate.Suite + "\x00" + candidate.Name + "\x00" + candidate.Fingerprint
+}
+
+func syncIssues(client githubClient, specs []issueSpec, labels []string, stdout io.Writer) error {
+	if len(specs) == 0 {
+		if _, err := fmt.Fprintln(stdout, "no failure candidates to sync"); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	for _, label := range defaultLabelDefinitions(labels) {
+		if err := client.ensureLabel(label); err != nil {
+			return err
+		}
+	}
+
+	existingIssues, err := client.listCandidateIssues(labels)
+	if err != nil {
+		return err
+	}
+
+	for _, spec := range specs {
+		existing := findIssueByCandidateID(existingIssues, spec.CandidateID)
+		if existing == nil {
+			created, err := client.createIssue(spec, labels)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(stdout, "created issue #%d for candidate %s\n", created.Number, spec.CandidateID); err != nil {
+				return err
+			}
+			continue
+		}
+		if existing.Title == spec.Title && existing.Body == spec.Body {
+			if _, err := fmt.Fprintf(stdout, "issue #%d already up to date for candidate %s\n", existing.Number, spec.CandidateID); err != nil {
+				return err
+			}
+			continue
+		}
+		updated, err := client.updateIssue(existing.Number, spec, labels)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(stdout, "updated issue #%d for candidate %s\n", updated.Number, spec.CandidateID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func issueSpecFromCandidate(candidate failureCandidate) issueSpec {
+	title := candidateTitle(candidate)
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "%s%s -->\n\n", markerPrefix, candidate.ID)
+	builder.WriteString("## Test Failure Candidate\n\n")
+	builder.WriteString("This issue is generated from `test-history` and is intended to be an agent-ready investigation task.\n\n")
+	builder.WriteString("## Candidate\n\n")
+	fmt.Fprintf(&builder, "- Scope: `%s`\n", candidate.Scope)
+	fmt.Fprintf(&builder, "- Suite: `%s`\n", candidate.Suite)
+	fmt.Fprintf(&builder, "- Test: `%s`\n", candidate.Name)
+	if candidate.Matrix != "" {
+		fmt.Fprintf(&builder, "- Matrix: `%s`\n", candidate.Matrix)
+	}
+	if len(candidate.AffectedMatrices) > 0 {
+		fmt.Fprintf(&builder, "- Affected matrices: %s\n", strings.Join(candidate.AffectedMatrices, ", "))
+	}
+	fmt.Fprintf(&builder, "- Fingerprint: `%s`\n", candidate.Fingerprint)
+	fmt.Fprintf(&builder, "- Failures: %d / %d collected runs\n", candidate.Failures, candidate.TestRuns)
+	fmt.Fprintf(&builder, "- Failure rate in collected history: %.2f\n", candidate.FailureRate)
+	if candidate.FirstObserved != "" {
+		fmt.Fprintf(&builder, "- First observed: %s\n", candidate.FirstObserved)
+	}
+	if candidate.LastObserved != "" {
+		fmt.Fprintf(&builder, "- Last observed: %s\n", candidate.LastObserved)
+	}
+	if candidate.LastKnownPass != "" {
+		fmt.Fprintf(&builder, "- Last known pass before first observed failure: %s\n", candidate.LastKnownPass)
+	}
+
+	if len(candidate.Evidence) > 0 {
+		builder.WriteString("\n## Evidence\n\n")
+		for _, evidence := range candidate.Evidence {
+			builder.WriteString("- ")
+			label := firstNonEmpty(evidence.RunID, evidence.Timestamp, "run")
+			if evidence.RunURL != "" {
+				fmt.Fprintf(&builder, "[%s](%s)", label, evidence.RunURL)
+			} else {
+				builder.WriteString(label)
+			}
+			if evidence.CommitSHA != "" {
+				fmt.Fprintf(&builder, " `%s`", shortSHA(evidence.CommitSHA))
+			}
+			if evidence.Matrix != "" {
+				fmt.Fprintf(&builder, " `%s`", evidence.Matrix)
+			}
+			if evidence.ReportPath != "" {
+				fmt.Fprintf(&builder, " `%s`", evidence.ReportPath)
+			}
+			builder.WriteByte('\n')
+		}
+	}
+
+	builder.WriteString("\n## Agent Task\n\n")
+	if candidate.AgentTaskTitle != "" {
+		fmt.Fprintf(&builder, "%s.\n\n", candidate.AgentTaskTitle)
+	}
+	builder.WriteString("Find the root cause, explain when the failure was first observed, and open a focused draft PR with validation evidence.\n")
+
+	if candidate.TraceExcerpt != "" {
+		fence := markdownCodeFence(candidate.TraceExcerpt)
+		builder.WriteString("\n## Failure Excerpt\n\n")
+		builder.WriteString(fence)
+		builder.WriteString("text\n")
+		builder.WriteString(candidate.TraceExcerpt)
+		if !strings.HasSuffix(candidate.TraceExcerpt, "\n") {
+			builder.WriteByte('\n')
+		}
+		builder.WriteString(fence)
+		builder.WriteByte('\n')
+	}
+
+	return issueSpec{
+		CandidateID: candidate.ID,
+		Title:       title,
+		Body:        builder.String(),
+	}
+}
+
+func candidateTitle(candidate failureCandidate) string {
+	switch {
+	case candidate.Scope == "cross_matrix":
+		return fmt.Sprintf("[ci-flaky] %s / %s (cross-matrix)", candidate.Suite, candidate.Name)
+	case candidate.Matrix != "":
+		return fmt.Sprintf("[ci-flaky] %s / %s [%s]", candidate.Suite, candidate.Name, candidate.Matrix)
+	default:
+		return fmt.Sprintf("[ci-flaky] %s / %s", candidate.Suite, candidate.Name)
+	}
+}
+
+func findIssueByCandidateID(issues []githubIssue, candidateID string) *githubIssue {
+	marker := markerPrefix + candidateID + " -->"
+	for i := range issues {
+		if issues[i].PullRequest != nil {
+			continue
+		}
+		if strings.Contains(issues[i].Body, marker) {
+			return &issues[i]
+		}
+	}
+	return nil
+}
+
+func parseRepo(value string) (string, string, error) {
+	parts := strings.Split(value, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("--repo must use owner/name form, got %q", value)
+	}
+	return parts[0], parts[1], nil
+}
+
+func defaultLabelDefinitions(labels []string) []githubLabel {
+	definitions := make([]githubLabel, 0, len(labels))
+	for _, label := range labels {
+		switch label {
+		case "ci-flaky":
+			definitions = append(definitions, githubLabel{Name: label, Color: "d73a4a", Description: "Recurring CI test failure"})
+		case "agent:flake-fix":
+			definitions = append(definitions, githubLabel{Name: label, Color: "5319e7", Description: "Agent-ready flaky test fix task"})
+		default:
+			definitions = append(definitions, githubLabel{Name: label, Color: "ededed"})
+		}
+	}
+	return definitions
+}
+
+func (client githubClient) ensureLabel(label githubLabel) error {
+	path := fmt.Sprintf("/repos/%s/%s/labels/%s", client.owner, client.repo, url.PathEscape(label.Name))
+	response, err := client.do("GET", path, nil)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode == http.StatusOK {
+		return nil
+	}
+	if response.StatusCode != http.StatusNotFound {
+		return githubError(response)
+	}
+
+	payload := map[string]string{
+		"name":        label.Name,
+		"color":       label.Color,
+		"description": label.Description,
+	}
+	response, err = client.do("POST", fmt.Sprintf("/repos/%s/%s/labels", client.owner, client.repo), payload)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusOK {
+		return githubError(response)
+	}
+	return nil
+}
+
+func (client githubClient) listCandidateIssues(labels []string) ([]githubIssue, error) {
+	query := url.Values{}
+	query.Set("state", "open")
+	query.Set("per_page", "100")
+	if len(labels) > 0 {
+		query.Set("labels", labels[0])
+	}
+	path := fmt.Sprintf("/repos/%s/%s/issues?%s", client.owner, client.repo, query.Encode())
+	response, err := client.do("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode != http.StatusOK {
+		return nil, githubError(response)
+	}
+	var issues []githubIssue
+	if err := json.NewDecoder(response.Body).Decode(&issues); err != nil {
+		return nil, err
+	}
+	return issues, nil
+}
+
+func (client githubClient) createIssue(spec issueSpec, labels []string) (githubIssue, error) {
+	payload := map[string]any{
+		"title":  spec.Title,
+		"body":   spec.Body,
+		"labels": labels,
+	}
+	response, err := client.do("POST", fmt.Sprintf("/repos/%s/%s/issues", client.owner, client.repo), payload)
+	if err != nil {
+		return githubIssue{}, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode != http.StatusCreated {
+		return githubIssue{}, githubError(response)
+	}
+	var issue githubIssue
+	if err := json.NewDecoder(response.Body).Decode(&issue); err != nil {
+		return githubIssue{}, err
+	}
+	return issue, nil
+}
+
+func (client githubClient) updateIssue(number int, spec issueSpec, labels []string) (githubIssue, error) {
+	payload := map[string]any{
+		"title":  spec.Title,
+		"body":   spec.Body,
+		"labels": labels,
+	}
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d", client.owner, client.repo, number)
+	response, err := client.do("PATCH", path, payload)
+	if err != nil {
+		return githubIssue{}, err
+	}
+	defer func() {
+		_ = response.Body.Close()
+	}()
+	if response.StatusCode != http.StatusOK {
+		return githubIssue{}, githubError(response)
+	}
+	var issue githubIssue
+	if err := json.NewDecoder(response.Body).Decode(&issue); err != nil {
+		return githubIssue{}, err
+	}
+	return issue, nil
+}
+
+func (client githubClient) do(method, path string, payload any) (*http.Response, error) {
+	var body io.Reader
+	if payload != nil {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		body = bytes.NewReader(encoded)
+	}
+	request, err := http.NewRequest(method, client.apiURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if payload != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if client.token != "" {
+		request.Header.Set("Authorization", "Bearer "+client.token)
+	}
+	return client.httpClient.Do(request)
+}
+
+func githubError(response *http.Response) error {
+	content, _ := io.ReadAll(response.Body)
+	return fmt.Errorf("github API %s failed with %s: %s", response.Request.URL.Path, response.Status, strings.TrimSpace(string(content)))
+}
+
+func markdownCodeFence(value string) string {
+	longestRun := 0
+	currentRun := 0
+	for _, char := range value {
+		if char == '`' {
+			currentRun++
+			if currentRun > longestRun {
+				longestRun = currentRun
+			}
+			continue
+		}
+		currentRun = 0
+	}
+	if longestRun < 3 {
+		longestRun = 3
+	} else {
+		longestRun++
+	}
+	return strings.Repeat("`", longestRun)
+}
+
+func shortSHA(value string) string {
+	if len(value) <= 12 {
+		return value
+	}
+	return value[:12]
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/test/tools/test_history_issues/main.go
+++ b/test/tools/test_history_issues/main.go
@@ -414,27 +414,75 @@ func (client githubClient) ensureLabel(label githubLabel) error {
 
 func (client githubClient) listCandidateIssues(labels []string) ([]githubIssue, error) {
 	query := url.Values{}
-	query.Set("state", "open")
+	query.Set("state", "all")
 	query.Set("per_page", "100")
+	query.Set("page", "1")
 	if len(labels) > 0 {
-		query.Set("labels", labels[0])
+		query.Set("labels", strings.Join(labels, ","))
 	}
 	path := fmt.Sprintf("/repos/%s/%s/issues?%s", client.owner, client.repo, query.Encode())
-	response, err := client.do("GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = response.Body.Close()
-	}()
-	if response.StatusCode != http.StatusOK {
-		return nil, githubError(response)
-	}
+
 	var issues []githubIssue
-	if err := json.NewDecoder(response.Body).Decode(&issues); err != nil {
-		return nil, err
+	for {
+		response, err := client.do("GET", path, nil)
+		if err != nil {
+			return nil, err
+		}
+		if response.StatusCode != http.StatusOK {
+			err := githubError(response)
+			_ = response.Body.Close()
+			return nil, err
+		}
+
+		var pageIssues []githubIssue
+		if err := json.NewDecoder(response.Body).Decode(&pageIssues); err != nil {
+			_ = response.Body.Close()
+			return nil, err
+		}
+		issues = append(issues, pageIssues...)
+
+		nextPath, hasNext := nextLinkPath(response.Header.Get("Link"))
+		if err := response.Body.Close(); err != nil {
+			return nil, err
+		}
+		if !hasNext {
+			break
+		}
+		path = nextPath
 	}
 	return issues, nil
+}
+
+func nextLinkPath(header string) (string, bool) {
+	for _, link := range strings.Split(header, ",") {
+		sections := strings.Split(link, ";")
+		if len(sections) < 2 {
+			continue
+		}
+
+		isNext := false
+		for _, section := range sections[1:] {
+			if strings.TrimSpace(section) == `rel="next"` {
+				isNext = true
+				break
+			}
+		}
+		if !isNext {
+			continue
+		}
+
+		target := strings.TrimSpace(sections[0])
+		target = strings.TrimPrefix(strings.TrimSuffix(target, ">"), "<")
+		parsed, err := url.Parse(target)
+		if err != nil {
+			continue
+		}
+		if parsed.IsAbs() {
+			return parsed.RequestURI(), true
+		}
+		return target, true
+	}
+	return "", false
 }
 
 func (client githubClient) createIssue(spec issueSpec, labels []string) (githubIssue, error) {

--- a/test/tools/test_history_issues/main_test.go
+++ b/test/tools/test_history_issues/main_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIssueSpecFromCrossMatrixCandidate(t *testing.T) {
+	spec := issueSpecFromCandidate(failureCandidate{
+		ID:               "abc123",
+		Scope:            "cross_matrix",
+		Suite:            "router-regress_router-6432",
+		Name:             "autoprotect_2pc",
+		AffectedMatrices: []string{"jammy-14", "noble-15"},
+		Fingerprint:      "1d269da6e7c2840e",
+		Failures:         3,
+		TestRuns:         4,
+		FailureRate:      0.75,
+		FirstObserved:    "2026-07-07T10:10:06Z",
+		LastObserved:     "2026-07-09T15:39:34Z",
+		AgentTaskTitle:   "Investigate recurring cross-matrix failure in router-regress_router-6432 / autoprotect_2pc",
+		TraceExcerpt:     "diff line\n```sql\nselect 1;\n```",
+		Evidence: []runEvidence{
+			{
+				RunID:      "29030391367",
+				RunURL:     "https://github.test/runs/29030391367",
+				CommitSHA:  "733275a6eedba6f17469954ad4e14db9bf543b43",
+				Matrix:     "jammy-14",
+				ReportPath: "29030391367/test-reports-regress-jammy-14/report.xml",
+			},
+		},
+	})
+
+	if spec.CandidateID != "abc123" {
+		t.Fatalf("unexpected candidate id: %#v", spec)
+	}
+	if spec.Title != "[ci-flaky] router-regress_router-6432 / autoprotect_2pc (cross-matrix)" {
+		t.Fatalf("unexpected title: %q", spec.Title)
+	}
+	for _, want := range []string{
+		"<!-- spqr-test-failure-candidate:abc123 -->",
+		"- Affected matrices: jammy-14, noble-15",
+		"- Fingerprint: `1d269da6e7c2840e`",
+		"[29030391367](https://github.test/runs/29030391367)",
+		"`733275a6eedb`",
+		"````text\n",
+		"Find the root cause",
+	} {
+		if !strings.Contains(spec.Body, want) {
+			t.Fatalf("body missing %q:\n%s", want, spec.Body)
+		}
+	}
+}
+
+func TestIssueSpecFromMatrixCandidate(t *testing.T) {
+	spec := issueSpecFromCandidate(failureCandidate{
+		ID:          "matrix123",
+		Scope:       "matrix",
+		Suite:       "isolation-regress",
+		Name:        "pg_advisory_lock",
+		Matrix:      "isolation",
+		Fingerprint: "d3c2af5c34d33d30",
+		Failures:    4,
+		TestRuns:    4,
+	})
+
+	if spec.Title != "[ci-flaky] isolation-regress / pg_advisory_lock [isolation]" {
+		t.Fatalf("unexpected title: %q", spec.Title)
+	}
+	if !strings.Contains(spec.Body, "- Matrix: `isolation`") {
+		t.Fatalf("body missing matrix:\n%s", spec.Body)
+	}
+}
+
+func TestFindIssueByCandidateID(t *testing.T) {
+	issues := []githubIssue{
+		{Number: 1, Body: "<!-- spqr-test-failure-candidate:other -->"},
+		{Number: 2, Body: "<!-- spqr-test-failure-candidate:target -->"},
+		{Number: 3, Body: "<!-- spqr-test-failure-candidate:target -->", PullRequest: map[string]any{}},
+	}
+
+	issue := findIssueByCandidateID(issues, "target")
+	if issue == nil || issue.Number != 2 {
+		t.Fatalf("unexpected issue match: %#v", issue)
+	}
+	if issue := findIssueByCandidateID(issues, "missing"); issue != nil {
+		t.Fatalf("unexpected issue match: %#v", issue)
+	}
+}
+
+func TestFilterIssueCandidatesDropsMatrixCandidateCoveredByCrossMatrix(t *testing.T) {
+	candidates := []failureCandidate{
+		{
+			ID:          "cross",
+			Scope:       "cross_matrix",
+			Suite:       "router",
+			Name:        "autoprotect_2pc",
+			Fingerprint: "same",
+		},
+		{
+			ID:          "matrix",
+			Scope:       "matrix",
+			Suite:       "router",
+			Name:        "autoprotect_2pc",
+			Matrix:      "jammy-14",
+			Fingerprint: "same",
+		},
+		{
+			ID:          "other",
+			Scope:       "matrix",
+			Suite:       "isolation",
+			Name:        "pg_advisory_lock",
+			Matrix:      "isolation",
+			Fingerprint: "other",
+		},
+	}
+
+	filtered := filterIssueCandidates(candidates)
+	if len(filtered) != 2 {
+		t.Fatalf("unexpected filtered candidates: %#v", filtered)
+	}
+	if filtered[0].ID != "cross" || filtered[1].ID != "other" {
+		t.Fatalf("unexpected filtered order: %#v", filtered)
+	}
+}
+
+func TestSyncIssuesSkipsEmptyCandidates(t *testing.T) {
+	var output strings.Builder
+	err := syncIssues(githubClient{}, nil, []string{"ci-flaky"}, &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); got != "no failure candidates to sync\n" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestRunDryRun(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "failure-candidates.json")
+	content := `{
+  "candidates": [
+    {
+      "id": "abc123",
+      "scope": "cross_matrix",
+      "suite": "router",
+      "name": "autoprotect_2pc",
+      "fingerprint": "fp",
+      "failures": 3,
+      "test_runs": 3
+    }
+  ]
+}`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var output strings.Builder
+	err := run([]string{"--candidates-input", path, "--dry-run"}, &output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); !strings.Contains(got, "would sync candidate abc123") {
+		t.Fatalf("unexpected dry-run output: %q", got)
+	}
+}
+
+func TestParseRepo(t *testing.T) {
+	owner, repo, err := parseRepo("pg-sharding/spqr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owner != "pg-sharding" || repo != "spqr" {
+		t.Fatalf("unexpected repo parse: %q/%q", owner, repo)
+	}
+	if _, _, err := parseRepo("spqr"); err == nil {
+		t.Fatal("expected invalid repo error")
+	}
+}

--- a/test/tools/test_history_issues/main_test.go
+++ b/test/tools/test_history_issues/main_test.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -137,6 +142,60 @@ func TestSyncIssuesSkipsEmptyCandidates(t *testing.T) {
 	}
 }
 
+func TestListCandidateIssuesUsesAllStateLabelsAndPagination(t *testing.T) {
+	var pages []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/repos/pg-sharding/spqr/issues" {
+			t.Errorf("unexpected path: %s", request.URL.Path)
+		}
+		query := request.URL.Query()
+		if query.Get("state") != "all" {
+			t.Errorf("unexpected state query: %q", query.Get("state"))
+		}
+		if query.Get("labels") != "ci-flaky,agent:flake-fix" {
+			t.Errorf("unexpected labels query: %q", query.Get("labels"))
+		}
+		if query.Get("per_page") != "100" {
+			t.Errorf("unexpected per_page query: %q", query.Get("per_page"))
+		}
+
+		page := query.Get("page")
+		pages = append(pages, page)
+		switch page {
+		case "1":
+			writer.Header().Set("Link", fmt.Sprintf(
+				`<%s/repos/pg-sharding/spqr/issues?labels=ci-flaky%%2Cagent%%3Aflake-fix&page=2&per_page=100&state=all>; rel="next"`,
+				server.URL,
+			))
+			writeJSONResponse(t, writer, []githubIssue{{Number: 1, Body: "first"}})
+		case "2":
+			writeJSONResponse(t, writer, []githubIssue{{Number: 2, Body: "second"}})
+		default:
+			t.Errorf("unexpected page: %q", page)
+			writeJSONResponse(t, writer, []githubIssue{})
+		}
+	}))
+	defer server.Close()
+
+	client := githubClient{
+		apiURL:     server.URL,
+		owner:      "pg-sharding",
+		repo:       "spqr",
+		httpClient: server.Client(),
+	}
+	issues, err := client.listCandidateIssues([]string{"ci-flaky", "agent:flake-fix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(pages, []string{"1", "2"}) {
+		t.Fatalf("unexpected requested pages: %#v", pages)
+	}
+	if len(issues) != 2 || issues[0].Number != 1 || issues[1].Number != 2 {
+		t.Fatalf("unexpected issues: %#v", issues)
+	}
+}
+
 func TestRunDryRun(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "failure-candidates.json")
@@ -177,5 +236,13 @@ func TestParseRepo(t *testing.T) {
 	}
 	if _, _, err := parseRepo("spqr"); err == nil {
 		t.Fatal("expected invalid repo error")
+	}
+}
+
+func writeJSONResponse(t *testing.T, writer http.ResponseWriter, value any) {
+	t.Helper()
+	writer.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(writer).Encode(value); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This PR is a part of https://github.com/pg-sharding/spqr/issues/2605
## Summary

Add an issue-sync layer for repeated test failure candidates produced by `test-history`.

This turns `failure-candidates.json` into GitHub issues that can be used as agent-ready tasks. The sync is deduplicated by a hidden `candidate.id` marker in the issue body and updates existing issues instead of creating duplicates.

## Details

- Add `test/tools/test_history_issues`, a small Go tool that:
  - reads `failure-candidates.json`;
  - renders an agent-ready issue body with candidate metadata, evidence links, and failure excerpt;
  - creates or updates GitHub issues through the REST API;
  - ensures the default labels `ci-flaky` and `agent:flake-fix` exist;
  - skips per-matrix candidates when they are already covered by a cross-matrix candidate with the same suite/test/fingerprint.
- Wire issue sync into `.github/workflows/test-history.yaml`:
  - scheduled runs sync issues automatically;
  - manual runs can opt in with `sync_issues=true`;
  - normal manual runs remain report-only by default.
- Fix isolation report matrix extraction so downloaded paths like `RUN_ID/test-reports-isolation/isolation-regress.xml` produce `matrix=isolation` instead of the run id.

## Why

After #2687, a manual `test-history` run on `master` produced real repeated candidates. It also exposed that isolation artifacts were using the run id as the matrix value, which would create noisy agent tasks. This PR fixes that before enabling issue creation.

## Validation

- Manually ran `test-history` on `master`: run `29070934966` succeeded.
- Inspected its artifact:
  - `records=3715`
  - `candidates_count=3`
  - `autoprotect_2pc` cross-matrix candidate found across `jammy-14`, `jammy-16`, `jammy-17`, `noble-14`, `noble-15`, `noble-16`.
- Verified the isolation matrix fix against a real downloaded `test-reports-isolation` artifact: failed records now get `matrix=isolation`.
- `go test -mod=readonly ./test/tools/...`
- `env GOFLAGS=-mod=readonly golangci-lint run --color=always --build-tags=all`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test-history.yaml")'`
- Dry-run issue sync on the fresh artifact produced 2 planned issues after deduping the covered per-matrix candidate.
