### PR TITLE
Add `total non-virtual queries` counter

### DIFF
--- a/pkg/engine/virtual_relation.go
+++ b/pkg/engine/virtual_relation.go
@@ -355,9 +355,8 @@ func InstanceVirtualRelationScan(ci connmgr.ConnectionMgr) *tupleslot.TupleTable
 			"failed_auth",
 			"failed_init",
 			"total_requests",
+			"_requests",
 		)}
-
-	stats := statistics.GetTotalRequests()
 
 	tts.WriteDataRow(
 		fmt.Sprintf("%v", ci.StartTime()),
@@ -367,7 +366,8 @@ func InstanceVirtualRelationScan(ci connmgr.ConnectionMgr) *tupleslot.TupleTable
 		fmt.Sprintf("%v", ci.ActiveTCPCount()),
 		fmt.Sprintf("%v", ci.FailedAuthCount()),
 		fmt.Sprintf("%v", ci.FailedInitCount()),
-		fmt.Sprintf("%d", stats),
+		fmt.Sprintf("%d", statistics.GetTotalRequests()),
+		fmt.Sprintf("%d", statistics.GetTotalNonVirtualRequests()),
 	)
 
 	return tts

--- a/pkg/engine/virtual_relation.go
+++ b/pkg/engine/virtual_relation.go
@@ -355,7 +355,7 @@ func InstanceVirtualRelationScan(ci connmgr.ConnectionMgr) *tupleslot.TupleTable
 			"failed_auth",
 			"failed_init",
 			"total_requests",
-			"_requests",
+			"non_virtual_requests",
 		)}
 
 	tts.WriteDataRow(

--- a/router/relay/executor.go
+++ b/router/relay/executor.go
@@ -129,6 +129,8 @@ func (s *QueryStateExecutorImpl) InitPlan(p plan.Plan) error {
 		return ErrMatchShardError
 	}
 
+	statistics.IncTotalNonVirtualRequest()
+
 	if len(s.ActiveShards()) != 0 {
 		spqrlog.Zero.Debug().
 			Uint("relay state", spqrlog.GetPointer(s)).

--- a/router/statistics/query_time_statistics.go
+++ b/router/statistics/query_time_statistics.go
@@ -24,7 +24,8 @@ type StartTimes struct {
 }
 
 type Statistics struct {
-	totalRequests uint64 // lifetime request count (atomic, monotonically increasing)
+	totalRequests           uint64 // lifetime request count (atomic, monotonically increasing)
+	totalNonVirtualRequests uint64 // queries that are executed without shards
 
 	RouterTime        map[uint]*tdigest.TDigest
 	ShardTime         map[uint]*tdigest.TDigest
@@ -115,6 +116,14 @@ func IncTotalRequest() {
 
 func GetTotalRequests() uint64 {
 	return atomic.LoadUint64(&QueryStatistics.totalRequests)
+}
+
+func IncTotalNonVirtualRequest() {
+	atomic.AddUint64(&QueryStatistics.totalNonVirtualRequests, 1)
+}
+
+func GetTotalNonVirtualRequests() uint64 {
+	return atomic.LoadUint64(&QueryStatistics.totalNonVirtualRequests)
 }
 
 func RecordStartTime(statType StatisticsType, t time.Time, clientH StatHolder) {


### PR DESCRIPTION
Useful to count real client rps, excluding `begin`, `commit`, `select 1` et cetera