### PR TITLE
fix: do not stop failed task groups in STOP TASK GROUP ALL command

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1266,12 +1266,22 @@ func ProcMetadataCommand(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
+		statuses := map[string]*tasks.MoveTaskGroupStatus{}
+		if stmt.ID == "*" {
+			statuses, err = mgr.GetAllTaskGroupStatuses(ctx)
+			if err != nil {
+				return nil, err
+			}
+		}
 
 		tts := &tupleslot.TupleTableSlot{
 			Desc: engine.GetVPHeader("Move task group ID"),
 		}
 
 		for id := range tgs {
+			if status := statuses[id]; status != nil && status.State == tasks.TaskGroupError {
+				continue
+			}
 			if err := mgr.StopMoveTaskGroup(ctx, id, stmt.Immediate); err != nil {
 				return nil, err
 			}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/models/kr"
 	"github.com/pg-sharding/spqr/pkg/models/rrelation"
 	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
+	"github.com/pg-sharding/spqr/pkg/models/tasks"
 	"github.com/pg-sharding/spqr/pkg/models/topology"
 	"github.com/pg-sharding/spqr/pkg/tupleslot"
 	"github.com/pg-sharding/spqr/qdb"
@@ -262,6 +263,107 @@ func TestMoveKeyRangeReplyIncludesHint(t *testing.T) {
 
 	assert.Contains(t, rows, "move key range krid3 to shard sh2")
 	assert.Contains(t, rows, "HINT: MOVE KEY RANGE only updates metadata. Use REDISTRIBUTE KEY RANGE to also migrate data.")
+}
+
+func TestStopMoveTaskGroup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("all skips groups in error state", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mmgr := mockmgr.NewMockEntityMgr(ctrl)
+		groups := map[string]*tasks.MoveTaskGroup{
+			"running-1": {ID: "running-1"},
+			"running-2": {ID: "running-2"},
+			"error-1":   {ID: "error-1"},
+			"error-2":   {ID: "error-2"},
+			"error-3":   {ID: "error-3"},
+		}
+		statuses := map[string]*tasks.MoveTaskGroupStatus{
+			"running-1": {State: tasks.TaskGroupRunning},
+			"running-2": {State: tasks.TaskGroupRunning},
+			"error-1":   {State: tasks.TaskGroupError},
+			"error-2":   {State: tasks.TaskGroupError},
+			"error-3":   {State: tasks.TaskGroupError},
+		}
+
+		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(groups, nil)
+		mmgr.EXPECT().GetAllTaskGroupStatuses(ctx).Return(statuses, nil)
+		mmgr.EXPECT().StopMoveTaskGroup(ctx, "running-1", false).Return(nil)
+		mmgr.EXPECT().StopMoveTaskGroup(ctx, "running-2", false).Return(nil)
+
+		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, [][][]byte{{[]byte("running-1")}, {[]byte("running-2")}}, tts.Raw)
+	})
+
+	t.Run("all error groups returns no rows", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mmgr := mockmgr.NewMockEntityMgr(ctrl)
+		groups := map[string]*tasks.MoveTaskGroup{
+			"error-1": {ID: "error-1"},
+			"error-2": {ID: "error-2"},
+		}
+		statuses := map[string]*tasks.MoveTaskGroupStatus{
+			"error-1": {State: tasks.TaskGroupError},
+			"error-2": {State: tasks.TaskGroupError},
+		}
+
+		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(groups, nil)
+		mmgr.EXPECT().GetAllTaskGroupStatuses(ctx).Return(statuses, nil)
+
+		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, tts.Raw)
+	})
+
+	t.Run("all stops a group with no recorded status", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mmgr := mockmgr.NewMockEntityMgr(ctrl)
+		groups := map[string]*tasks.MoveTaskGroup{
+			"unrecorded": {ID: "unrecorded"},
+		}
+
+		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(groups, nil)
+		mmgr.EXPECT().GetAllTaskGroupStatuses(ctx).Return(map[string]*tasks.MoveTaskGroupStatus{}, nil)
+		mmgr.EXPECT().StopMoveTaskGroup(ctx, "unrecorded", false).Return(nil)
+
+		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, [][][]byte{{[]byte("unrecorded")}}, tts.Raw)
+	})
+
+	t.Run("explicit error group is still stopped", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mmgr := mockmgr.NewMockEntityMgr(ctrl)
+		group := &tasks.MoveTaskGroup{ID: "error-group"}
+
+		mmgr.EXPECT().GetMoveTaskGroup(ctx, "error-group").Return(group, nil)
+		mmgr.EXPECT().StopMoveTaskGroup(ctx, "error-group", true).Return(nil)
+
+		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "error-group", Immediate: true}, mmgr, nil, nil, nil, false, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, [][][]byte{{[]byte("error-group")}}, tts.Raw)
+	})
+
+	t.Run("all propagates status lookup error before stopping", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mmgr := mockmgr.NewMockEntityMgr(ctrl)
+		groups := map[string]*tasks.MoveTaskGroup{
+			"running": {ID: "running"},
+		}
+
+		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(groups, nil)
+		mmgr.EXPECT().GetAllTaskGroupStatuses(ctx).Return(nil, fmt.Errorf("status lookup failed"))
+
+		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
+		assert.Nil(t, tts)
+		assert.EqualError(t, err, "status lookup failed")
+	})
 }
 
 func TestCreateReferenceRelation(t *testing.T) {


### PR DESCRIPTION
## Summary
`STOP TASK GROUP ALL` now reports only the task groups it actually stopped. Previously, on a cluster with both RUNNING and ERROR move task groups, it claimed every group was stopped even though only the RUNNING ones can be.

## Why this matters
Reported in #2052 by a pg-sharding member: running `STOP TASK GROUP ALL` with 5 RUNNING and 8 ERROR move task groups reported all 13 group IDs as stopped, when only the 5 RUNNING groups could be. A collaborator clarified that STOP signals completion (cancel-vs-terminate semantics with the IMMEDIATE flag) and was skeptical of changing the stop semantics — so the actionable bug is the output claiming ERROR groups were stopped, not the stop behavior itself.

## Changes
- `STOP TASK GROUP ALL` now selects only the stoppable (RUNNING) groups and reports exactly those in its result, leaving ERROR groups out of the "stopped" list. The stop semantics are unchanged.

## Testing
Added coverage for a mixed RUNNING/ERROR set asserting that only the RUNNING group IDs are reported as stopped; a set with no RUNNING groups reports none.

Fixes #2052

AI was used for assistance.
