### PR TITLE
Add `log_query` router config option

### DIFF
--- a/pkg/config/router.go
+++ b/pkg/config/router.go
@@ -37,6 +37,7 @@ var cfgRouter Router
 
 type Router struct {
 	LogLevel      string `json:"log_level" toml:"log_level" yaml:"log_level"`
+	LogQuery      bool   `json:"log_query" toml:"log_query" yaml:"log_query"`
 	PrettyLogging bool   `json:"pretty_logging" toml:"pretty_logging" yaml:"pretty_logging"`
 
 	// TimeQuantiles is an array of quantiles to show in "SHOW time_quantiles" query. Each quantile is set as a string containing float64 representation

--- a/router/frontend/frontend.go
+++ b/router/frontend/frontend.go
@@ -193,14 +193,19 @@ func ProcessMessage(rst relay.RelayStateMgr, msg pgproto3.FrontendMessage) error
 		} else {
 			if sErr, ok := err.(*spqrerror.SpqrError); ok {
 				/* For simple query, set explicit query string in error message */
-				_ = sErr.Query(q.String)
+				sErr = sErr.Query(q.String)
 			}
 		}
 
-		spqrlog.Zero.Info().
-			Uint("client", rst.Client().ID()).Str("query", q.String).TimeDiff("time", time.Now(), tm).Msg("executed query")
-
 		rst.Client().ClosePreparedStatement("")
+
+		if config.RouterConfig().LogQuery {
+			spqrlog.Zero.Info().
+				Uint("client", rst.Client().ID()).Str("query", q.String).TimeDiff("time", time.Now(), tm).Msg("executed query")
+		} else {
+			spqrlog.Zero.Info().
+				Uint("client", rst.Client().ID()).TimeDiff("time", time.Now(), tm).Msg("executed query")
+		}
 
 		return teardownPipeline(rst, err)
 	/* These messages do not trigger immediate processing */

--- a/router/frontend/frontend.go
+++ b/router/frontend/frontend.go
@@ -193,7 +193,7 @@ func ProcessMessage(rst relay.RelayStateMgr, msg pgproto3.FrontendMessage) error
 		} else {
 			if sErr, ok := err.(*spqrerror.SpqrError); ok {
 				/* For simple query, set explicit query string in error message */
-				sErr = sErr.Query(q.String)
+				err = sErr.Query(q.String)
 			}
 		}
 


### PR DESCRIPTION
Full query logging is SPQR router is done on INFO severity log level. But logging full query SQL is sometimes unneeded, while log become messy. So, add a new config option to regulate this, with default being false