### PR TITLE
Do not list task group ids in STOP TASK GROUP.

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1086,7 +1086,7 @@ func ProcMetadataCommand(ctx context.Context,
 			Desc: engine.GetVPHeader("stop trace messages"),
 			Raw: [][][]byte{
 				{
-					[]byte("STOP TRASCE MESSAGES"),
+					[]byte("STOP TRACE MESSAGES"),
 				},
 			},
 		}
@@ -1272,15 +1272,15 @@ func ProcMetadataCommand(ctx context.Context,
 				return nil, err
 			}
 		}
-		acknowledgement := "STOP TASK GROUP"
+		cmdTag := "STOP TASK GROUP"
 		if stmt.ID == "*" {
-			acknowledgement += " ALL"
+			cmdTag += " ALL"
 		}
 
 		return &tupleslot.TupleTableSlot{
 			Desc: engine.GetVPHeader("task group"),
 			Raw: [][][]byte{{
-				[]byte(acknowledgement),
+				[]byte(cmdTag),
 			}},
 		}, nil
 	case *spqrparser.RetryMoveTaskGroup:

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1272,11 +1272,15 @@ func ProcMetadataCommand(ctx context.Context,
 				return nil, err
 			}
 		}
+		acknowledgement := "STOP TASK GROUP"
+		if stmt.ID == "*" {
+			acknowledgement += " ALL"
+		}
 
 		return &tupleslot.TupleTableSlot{
 			Desc: engine.GetVPHeader("task group"),
 			Raw: [][][]byte{{
-				[]byte("STOP TASK GROUP"),
+				[]byte(acknowledgement),
 			}},
 		}, nil
 	case *spqrparser.RetryMoveTaskGroup:

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1267,18 +1267,18 @@ func ProcMetadataCommand(ctx context.Context,
 			return nil, err
 		}
 
-		tts := &tupleslot.TupleTableSlot{
-			Desc: engine.GetVPHeader("Move task group ID"),
-		}
-
 		for id := range tgs {
 			if err := mgr.StopMoveTaskGroup(ctx, id, stmt.Immediate); err != nil {
 				return nil, err
 			}
-			tts.WriteDataRow(id)
 		}
 
-		return tts, nil
+		return &tupleslot.TupleTableSlot{
+			Desc: engine.GetVPHeader("task group"),
+			Raw: [][][]byte{{
+				[]byte("STOP TASK GROUP"),
+			}},
+		}, nil
 	case *spqrparser.RetryMoveTaskGroup:
 		tgs, err := listMoveTaskGroupsBySelector(ctx, mgr, stmt.ID)
 		if err != nil {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/models/kr"
 	"github.com/pg-sharding/spqr/pkg/models/rrelation"
 	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
+	"github.com/pg-sharding/spqr/pkg/models/tasks"
 	"github.com/pg-sharding/spqr/pkg/models/topology"
 	"github.com/pg-sharding/spqr/pkg/tupleslot"
 	"github.com/pg-sharding/spqr/qdb"
@@ -262,6 +263,44 @@ func TestMoveKeyRangeReplyIncludesHint(t *testing.T) {
 
 	assert.Contains(t, rows, "move key range krid3 to shard sh2")
 	assert.Contains(t, rows, "HINT: MOVE KEY RANGE only updates metadata. Use REDISTRIBUTE KEY RANGE to also migrate data.")
+}
+
+func TestStopMoveTaskGroupReply(t *testing.T) {
+	t.Run("all returns command acknowledgement instead of task group IDs", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		mmgr := mockmgr.NewMockEntityMgr(ctrl)
+		groups := map[string]*tasks.MoveTaskGroup{
+			"tg1": {ID: "tg1"},
+			"tg2": {ID: "tg2"},
+		}
+
+		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(groups, nil)
+		mmgr.EXPECT().StopMoveTaskGroup(ctx, "tg1", false).Return(nil)
+		mmgr.EXPECT().StopMoveTaskGroup(ctx, "tg2", false).Return(nil)
+
+		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, tupleslot.TupleDesc(engine.GetVPHeader("task group")), tts.Desc)
+		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP")}}, tts.Raw)
+	})
+
+	t.Run("all returns command acknowledgement when there are no task groups", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		mmgr := mockmgr.NewMockEntityMgr(ctrl)
+
+		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(map[string]*tasks.MoveTaskGroup{}, nil)
+
+		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, tupleslot.TupleDesc(engine.GetVPHeader("task group")), tts.Desc)
+		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP")}}, tts.Raw)
+	})
 }
 
 func TestCreateReferenceRelation(t *testing.T) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pg-sharding/spqr/pkg/models/kr"
 	"github.com/pg-sharding/spqr/pkg/models/rrelation"
 	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
-	"github.com/pg-sharding/spqr/pkg/models/tasks"
 	"github.com/pg-sharding/spqr/pkg/models/topology"
 	"github.com/pg-sharding/spqr/pkg/tupleslot"
 	"github.com/pg-sharding/spqr/qdb"
@@ -263,61 +262,6 @@ func TestMoveKeyRangeReplyIncludesHint(t *testing.T) {
 
 	assert.Contains(t, rows, "move key range krid3 to shard sh2")
 	assert.Contains(t, rows, "HINT: MOVE KEY RANGE only updates metadata. Use REDISTRIBUTE KEY RANGE to also migrate data.")
-}
-
-func TestStopMoveTaskGroupReply(t *testing.T) {
-	t.Run("all returns command acknowledgement instead of task group IDs", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ctx := context.Background()
-		mmgr := mockmgr.NewMockEntityMgr(ctrl)
-		groups := map[string]*tasks.MoveTaskGroup{
-			"tg1": {ID: "tg1"},
-			"tg2": {ID: "tg2"},
-		}
-
-		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(groups, nil)
-		mmgr.EXPECT().StopMoveTaskGroup(ctx, "tg1", false).Return(nil)
-		mmgr.EXPECT().StopMoveTaskGroup(ctx, "tg2", false).Return(nil)
-
-		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, tupleslot.TupleDesc(engine.GetVPHeader("task group")), tts.Desc)
-		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP ALL")}}, tts.Raw)
-	})
-
-	t.Run("all returns command acknowledgement when there are no task groups", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ctx := context.Background()
-		mmgr := mockmgr.NewMockEntityMgr(ctrl)
-
-		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(map[string]*tasks.MoveTaskGroup{}, nil)
-
-		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, tupleslot.TupleDesc(engine.GetVPHeader("task group")), tts.Desc)
-		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP ALL")}}, tts.Raw)
-	})
-
-	t.Run("explicit selector returns command acknowledgement without all", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		ctx := context.Background()
-		mmgr := mockmgr.NewMockEntityMgr(ctrl)
-		group := &tasks.MoveTaskGroup{ID: "tg1"}
-
-		mmgr.EXPECT().GetMoveTaskGroup(ctx, "tg1").Return(group, nil)
-		mmgr.EXPECT().StopMoveTaskGroup(ctx, "tg1", false).Return(nil)
-
-		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "tg1"}, mmgr, nil, nil, nil, false, nil)
-		assert.NoError(t, err)
-		assert.Equal(t, tupleslot.TupleDesc(engine.GetVPHeader("task group")), tts.Desc)
-		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP")}}, tts.Raw)
-	})
 }
 
 func TestCreateReferenceRelation(t *testing.T) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -284,7 +284,7 @@ func TestStopMoveTaskGroupReply(t *testing.T) {
 		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, tupleslot.TupleDesc(engine.GetVPHeader("task group")), tts.Desc)
-		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP")}}, tts.Raw)
+		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP ALL")}}, tts.Raw)
 	})
 
 	t.Run("all returns command acknowledgement when there are no task groups", func(t *testing.T) {
@@ -297,6 +297,23 @@ func TestStopMoveTaskGroupReply(t *testing.T) {
 		mmgr.EXPECT().ListMoveTaskGroups(ctx).Return(map[string]*tasks.MoveTaskGroup{}, nil)
 
 		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "*"}, mmgr, nil, nil, nil, false, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, tupleslot.TupleDesc(engine.GetVPHeader("task group")), tts.Desc)
+		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP ALL")}}, tts.Raw)
+	})
+
+	t.Run("explicit selector returns command acknowledgement without all", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		mmgr := mockmgr.NewMockEntityMgr(ctrl)
+		group := &tasks.MoveTaskGroup{ID: "tg1"}
+
+		mmgr.EXPECT().GetMoveTaskGroup(ctx, "tg1").Return(group, nil)
+		mmgr.EXPECT().StopMoveTaskGroup(ctx, "tg1", false).Return(nil)
+
+		tts, err := meta.ProcMetadataCommand(ctx, &spqrparser.StopMoveTaskGroup{ID: "tg1"}, mmgr, nil, nil, nil, false, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, tupleslot.TupleDesc(engine.GetVPHeader("task group")), tts.Desc)
 		assert.Equal(t, [][][]byte{{[]byte("STOP TASK GROUP")}}, tts.Raw)

--- a/test/isolation/expected/move_cancel.out
+++ b/test/isolation/expected/move_cancel.out
@@ -76,9 +76,9 @@ shard sh1   |11|1
 (2 rows)
 
 step s4_cancel: select __spqr__console_execute('STOP TASK GROUP zid immediate') /*__spqr__preferred_engine: v2 */;
-Move task group ID
-------------------
-zid               
+task group     
+---------------
+STOP TASK GROUP
 (1 row)
 
 step s2_await_task: SELECT __spqr__await_task('zid') /* __spqr__preferred_engine: v2 */;

--- a/test/regress/tests/coordinator/expected/redistribute.out
+++ b/test/regress/tests/coordinator/expected/redistribute.out
@@ -77,19 +77,22 @@ RETRY TASK GROUP tgid;
 (0 rows)
 
 STOP MOVE TASK GROUP tgid;
- Move task group ID 
---------------------
-(0 rows)
+   task group    
+-----------------
+ STOP TASK GROUP
+(1 row)
 
 STOP TASK GROUP tgid;
- Move task group ID 
---------------------
-(0 rows)
+   task group    
+-----------------
+ STOP TASK GROUP
+(1 row)
 
 STOP TASK GROUP ALL;
- Move task group ID 
---------------------
-(0 rows)
+   task group    
+-----------------
+ STOP TASK GROUP
+(1 row)
 
 DROP DISTRIBUTION ALL CASCADE;
  distribution_id 

--- a/test/regress/tests/coordinator/expected/redistribute.out
+++ b/test/regress/tests/coordinator/expected/redistribute.out
@@ -89,9 +89,9 @@ STOP TASK GROUP tgid;
 (1 row)
 
 STOP TASK GROUP ALL;
-   task group    
------------------
- STOP TASK GROUP
+     task group      
+---------------------
+ STOP TASK GROUP ALL
 (1 row)
 
 DROP DISTRIBUTION ALL CASCADE;


### PR DESCRIPTION
For consistency, I based this output format on the existing ATTACH/DETACH CONTROL POINT output: [control_point.out](https://github.com/pg-sharding/spqr/blob/master/test/regress/tests/console/expected/control_point.out).