### PR TITLE
Fix comment parsing for external use.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
-	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,6 @@ golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
-golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=

--- a/router/qparser/comment.go
+++ b/router/qparser/comment.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"unicode"
 
-	"golang.org/x/xerrors"
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 )
 
 /*
@@ -29,13 +29,13 @@ func ParseComment(comm string) (map[string]string, error) {
 
 		// colon symbol not found
 		if j == len(comm) {
-			return nil, xerrors.New("invalid comment format")
+			return nil, spqrerror.Newf(spqrerror.SPQR_UNEXPECTED, "invalid comment format")
 		}
 		optargLen := optargEnd - i + 1
 
 		if optargLen == 0 {
 			// empty opt name
-			return nil, xerrors.New("invalid comment format: empty option name")
+			return nil, spqrerror.Newf(spqrerror.SPQR_UNEXPECTED, "invalid comment format: empty option name")
 		}
 
 		// skip spaces after colon
@@ -43,7 +43,7 @@ func ParseComment(comm string) (map[string]string, error) {
 		}
 
 		if j == len(comm) || comm[j] != ':' {
-			return nil, xerrors.New("invalid comment format: expected colon after option name")
+			return nil, spqrerror.Newf(spqrerror.SPQR_UNEXPECTED, "invalid comment format: expected colon after option name")
 		}
 		// skip colon symbol
 		j++
@@ -54,7 +54,7 @@ func ParseComment(comm string) (map[string]string, error) {
 
 		if j == len(comm) {
 			// empty opt name
-			return nil, xerrors.New("invalid comment format: empty option values")
+			return nil, spqrerror.Newf(spqrerror.SPQR_UNEXPECTED, "invalid comment format: empty option values")
 		}
 
 		// now we are looking at first char of opt value
@@ -78,7 +78,7 @@ func ParseComment(comm string) (map[string]string, error) {
 		}
 		if j < len(comm) && comm[j] != ',' {
 			// empty opt name
-			return nil, xerrors.New("invalid comment format: expected comma after not-last key-value pair")
+			return nil, spqrerror.Newf(spqrerror.SPQR_UNEXPECTED, "invalid comment format: expected comma after not-last key-value pair")
 		}
 		// skip comma
 		j++

--- a/router/qparser/comment_test.go
+++ b/router/qparser/comment_test.go
@@ -77,10 +77,8 @@ func TestParseComment(t *testing.T) {
 		},
 		{
 			sample: "random comment in random format , __spqr__execute_on: sh3 ",
-			exp: map[string]string{
-				"__spqr__execute_on": "sh3",
-			},
-			err: nil,
+			exp:    nil,
+			err:    nil,
 		},
 	} {
 

--- a/router/qparser/comment_test.go
+++ b/router/qparser/comment_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -78,7 +79,7 @@ func TestParseComment(t *testing.T) {
 		{
 			sample: "random comment in random format , __spqr__execute_on: sh3 ",
 			exp:    nil,
-			err:    nil,
+			err:    spqrerror.Newf(spqrerror.SPQR_UNEXPECTED, "invalid comment format: expected colon after option name"),
 		},
 	} {
 

--- a/router/qparser/comment_test.go
+++ b/router/qparser/comment_test.go
@@ -75,6 +75,13 @@ func TestParseComment(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			sample: "random comment in random format , __spqr__execute_on: sh3 ",
+			exp: map[string]string{
+				"__spqr__execute_on": "sh3",
+			},
+			err: nil,
+		},
 	} {
 
 		mp, err := ParseComment(tt.sample)
@@ -85,6 +92,5 @@ func TestParseComment(t *testing.T) {
 			assert.NoError(err)
 			assert.Equal(tt.exp, mp)
 		}
-
 	}
 }

--- a/router/qparser/qparser.go
+++ b/router/qparser/qparser.go
@@ -28,10 +28,10 @@ func (qp *QParser) SetStmt(stmt lyx.Node) {
 }
 
 // TODO : unit tests
-func (qp *QParser) Parse(query string) ([]lyx.Node, string, error) {
+func (qp *QParser) Parse(query string) ([]lyx.Node, []string, error) {
 	qp.query = query
 
-	comment := ""
+	comments := []string{}
 	for i := 0; i < len(query)-4; {
 
 		if query[i] != '/' || query[i+1] != '*' {
@@ -50,11 +50,7 @@ func (qp *QParser) Parse(query string) ([]lyx.Node, string, error) {
 			break
 		}
 
-		if len(comment) == 0 {
-			comment = query[i+2 : j]
-		} else {
-			comment = comment + "," + query[i+2:j]
-		}
+		comments = append(comments, query[i+2:j])
 		i = j + 3
 	}
 
@@ -62,7 +58,7 @@ func (qp *QParser) Parse(query string) ([]lyx.Node, string, error) {
 
 	routerStmts, pos, err := lyx.Parse(query)
 	if err != nil {
-		return nil, comment, &spqrerror.SpqrError{
+		return nil, comments, &spqrerror.SpqrError{
 			Err:       err,
 			Position:  int32(pos),
 			ErrorCode: spqrerror.PG_SYNTAX_ERROR,
@@ -71,5 +67,5 @@ func (qp *QParser) Parse(query string) ([]lyx.Node, string, error) {
 
 	qp.stmt = routerStmts[0]
 
-	return routerStmts, comment, nil
+	return routerStmts, comments, nil
 }

--- a/router/qparser/qparser_test.go
+++ b/router/qparser/qparser_test.go
@@ -1,0 +1,49 @@
+package qparser_test
+
+import (
+	"testing"
+
+	"github.com/pg-sharding/spqr/router/qparser"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQParser(t *testing.T) {
+
+	assert := assert.New(t)
+
+	type tmp struct {
+		sample string
+		exp    []string
+		err    error
+	}
+
+	for _, tt := range []tmp{
+		{
+			sample: "select /* random comment in random format */ 6 + 7",
+			exp:    []string{" random comment in random format "},
+			err:    nil,
+		},
+		{
+			sample: "select /* random comment in random format */ 6 + 7  /* __spqr__execute_on: sh3 */",
+			exp:    []string{" random comment in random format ", " __spqr__execute_on: sh3 "},
+			err:    nil,
+		},
+
+		{
+			sample: "select /* __spqr__engine_v2: false  */ 6 + 7  /* __spqr__execute_on: sh3 */",
+			exp:    []string{" __spqr__engine_v2: false  ", " __spqr__execute_on: sh3 "},
+			err:    nil,
+		},
+	} {
+
+		qp := &qparser.QParser{}
+
+		_, comments, err := qp.Parse(tt.sample)
+		if tt.err != nil {
+			assert.Error(err)
+		} else {
+			assert.NoError(err)
+			assert.Equal(tt.exp, comments)
+		}
+	}
+}

--- a/router/relay/qstate.go
+++ b/router/relay/qstate.go
@@ -149,12 +149,14 @@ l:
 	return pd, err
 }
 
-func (rst *RelayStateImpl) queryProc(comment string, binderQ func() error) error {
-	mp, err := qparser.ParseComment(comment)
+func (rst *RelayStateImpl) queryProc(comments []string, binderQ func() error) error {
+	for _, comment := range comments {
+		mp, err := qparser.ParseComment(comment)
 
-	if err == nil {
-		if err := rst.processSpqrHint(context.TODO(), mp, false, true); err != nil {
-			return err
+		if err == nil {
+			if err := rst.processSpqrHint(context.TODO(), mp, false, true); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -173,7 +175,7 @@ var (
 // So, we need to process SETs, BEGINs, ROLLBACKs etc ourselves.
 // QueryStateExecutor provides set of function for either simple of extended protoc interactions
 // query param is either plain query from simple proto or bind query from x proto
-func (rst *RelayStateImpl) ProcQueryAdvanced(query string, stmt lyx.Node, comment string, binderQ func() error, _ bool) (*PortalDesc, error) {
+func (rst *RelayStateImpl) ProcQueryAdvanced(query string, stmt lyx.Node, comments []string, binderQ func() error, _ bool) (*PortalDesc, error) {
 
 	/* !!! Do not complete relay here (no TX status management) !!! */
 
@@ -205,18 +207,20 @@ func (rst *RelayStateImpl) ProcQueryAdvanced(query string, stmt lyx.Node, commen
 			return noDataPd, err
 
 		case lyx.TRANS_STMT_COMMIT:
-			if mp, err := qparser.ParseComment(comment); err == nil {
+			for _, comment := range comments {
+				if mp, err := qparser.ParseComment(comment); err == nil {
 
-				if val, ok := mp[session.SPQR_COMMIT_STRATEGY]; ok {
-					switch val {
-					case twopc.CommitStrategy2pc:
-						fallthrough
-					case twopc.CommitStrategy1pc:
-						fallthrough
-					case twopc.CommitStrategyBestEffort:
-						rst.Client().SetCommitStrategy(val)
-					default:
-						/*should error-out*/
+					if val, ok := mp[session.SPQR_COMMIT_STRATEGY]; ok {
+						switch val {
+						case twopc.CommitStrategy2pc:
+							fallthrough
+						case twopc.CommitStrategy1pc:
+							fallthrough
+						case twopc.CommitStrategyBestEffort:
+							rst.Client().SetCommitStrategy(val)
+						default:
+							/*should error-out*/
+						}
 					}
 				}
 			}
@@ -514,7 +518,7 @@ func (rst *RelayStateImpl) ProcQueryAdvanced(query string, stmt lyx.Node, commen
 				} else {
 					/* If router does dot have any info about param, fire query to random shard. */
 					if _, ok := rst.Client().Params()[param]; !ok {
-						err := rst.queryProc(comment, binderQ)
+						err := rst.queryProc(comments, binderQ)
 						return pd, err
 					}
 
@@ -612,7 +616,7 @@ func (rst *RelayStateImpl) ProcQueryAdvanced(query string, stmt lyx.Node, commen
 			return nil, nil
 		} else {
 			// process like regular query
-			err := rst.queryProc(comment, binderQ)
+			err := rst.queryProc(comments, binderQ)
 			return nil, err
 		}
 	case *lyx.ExecuteStmt:
@@ -654,11 +658,11 @@ func (rst *RelayStateImpl) ProcQueryAdvanced(query string, stmt lyx.Node, commen
 			return nil, nil
 		} else {
 			// process like regular query
-			err := rst.queryProc(comment, binderQ)
+			err := rst.queryProc(comments, binderQ)
 			return nil, err
 		}
 	default:
-		err := rst.queryProc(comment, binderQ)
+		err := rst.queryProc(comments, binderQ)
 		return nil, err
 	}
 }

--- a/router/relay/relay.go
+++ b/router/relay/relay.go
@@ -49,7 +49,7 @@ type RelayStateMgr interface {
 	Reset() error
 	ResetWithError(err error) error
 
-	Parse(query string, doCaching bool) ([]lyx.Node, string, error)
+	Parse(query string, doCaching bool) ([]lyx.Node, []string, error)
 
 	Cache() *rmeta.MetadataCache
 	Parser() *qparser.QParser
@@ -84,7 +84,7 @@ type PortalDesc struct {
 
 type ParseCacheEntry struct {
 	ps   []lyx.Node
-	comm string
+	comm []string
 	stmt lyx.Node
 }
 
@@ -1135,7 +1135,7 @@ func (rst *RelayStateImpl) ProcessOneMsgCarefully(ctx context.Context, msg pgpro
 }
 
 // TODO : unit tests
-func (rst *RelayStateImpl) Parse(query string, doCaching bool) ([]lyx.Node, string, error) {
+func (rst *RelayStateImpl) Parse(query string, doCaching bool) ([]lyx.Node, []string, error) {
 	if cache, ok := rst.parseCache[query]; ok {
 		rst.qp.SetStmt(cache.stmt)
 		rst.qp.SetOriginQuery(query)
@@ -1145,7 +1145,7 @@ func (rst *RelayStateImpl) Parse(query string, doCaching bool) ([]lyx.Node, stri
 	stmts, comm, err := rst.qp.Parse(query)
 
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	/* XXX remove from here */

--- a/test/regress/tests/router/expected/routing_hint.out
+++ b/test/regress/tests/router/expected/routing_hint.out
@@ -285,7 +285,6 @@ NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 
 CREATE TABLE test_unmatch(i int) /* __spqr__scatter_query: true */;
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
-NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 SET __spqr__default_route_behaviour to 'sh2';
 SHOW __spqr__default_route_behaviour;
  default route behaviour 

--- a/test/regress/tests/router/expected/routing_hint.out
+++ b/test/regress/tests/router/expected/routing_hint.out
@@ -52,6 +52,7 @@ CREATE DISTRIBUTED RELATION test_h DISTRIBUTION KEY id HASH FUNCTION MURMUR IN d
 \c regress
 CREATE TABLE test(id int, age int);
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 -- TODO: specify distribution as well as sharding_key
 INSERT INTO test(id, age) VALUES (1210, 16) /*__spqr__sharding_key: 1, __spqr__distribution: ds1  */;
 NOTICE: send query to shard(s) : sh1

--- a/test/regress/tests/router/expected/routing_hint.out
+++ b/test/regress/tests/router/expected/routing_hint.out
@@ -52,7 +52,6 @@ CREATE DISTRIBUTED RELATION test_h DISTRIBUTION KEY id HASH FUNCTION MURMUR IN d
 \c regress
 CREATE TABLE test(id int, age int);
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
-NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 -- TODO: specify distribution as well as sharding_key
 INSERT INTO test(id, age) VALUES (1210, 16) /*__spqr__sharding_key: 1, __spqr__distribution: ds1  */;
 NOTICE: send query to shard(s) : sh1
@@ -71,6 +70,26 @@ NOTICE: send query to shard(s) : sh1
 -------+-----
  a1210 |  16
 (1 row)
+
+SELECT /* random comment */ * FROM test_h /*__spqr__sharding_key: a1210, __spqr__distribution: ds2  */;
+NOTICE: send query to shard(s) : sh1
+  id   | age 
+-------+-----
+ a1210 |  16
+(1 row)
+
+SELECT /* random: comment */ * FROM test_h /*__spqr__sharding_key: a1210, __spqr__distribution: ds2  */;
+NOTICE: send query to shard(s) : sh1
+  id   | age 
+-------+-----
+ a1210 |  16
+(1 row)
+
+SELECT /* random: comment */ * FROM test_h /* __spqr__execute_on: sh2  */;
+NOTICE: send query to shard(s) : sh2
+ id | age 
+----+-----
+(0 rows)
 
 INSERT INTO test_h(id, age) VALUES ('a12101', 16) /*__spqr__sharding_key: a12101, __spqr__distribution: ds2  */;
 NOTICE: send query to shard(s) : sh2
@@ -264,6 +283,7 @@ NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 (2 rows)
 
 CREATE TABLE test_unmatch(i int) /* __spqr__scatter_query: true */;
+NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 NOTICE: send query to shard(s) : sh1,sh2,sh3,sh4
 SET __spqr__default_route_behaviour to 'sh2';
 SHOW __spqr__default_route_behaviour;

--- a/test/regress/tests/router/expected/target_list_routing.out
+++ b/test/regress/tests/router/expected/target_list_routing.out
@@ -77,7 +77,9 @@ NOTICE: send query to shard(s) : sh1
 (1 row)
 
 /* test quoted sconsts. XXX: find a better place for that */
+SELECT 'a=b, "a=b", '' c '' '' '' ', 'a=b, "a=b", '' c ''''''';
 SELECT 'a=b, "a=b", '' c '' '' '' ', 'a=b, "a=b", '' c ''''''' /* __spqr__.execute_on: sh3 */;
+NOTICE: send query to shard(s) : sh3
         ?column?        |      ?column?       
 ------------------------+---------------------
  a=b, "a=b", ' c ' ' '  | a=b, "a=b", ' c '''

--- a/test/regress/tests/router/expected/target_list_routing.out
+++ b/test/regress/tests/router/expected/target_list_routing.out
@@ -78,7 +78,6 @@ NOTICE: send query to shard(s) : sh1
 
 /* test quoted sconsts. XXX: find a better place for that */
 SELECT 'a=b, "a=b", '' c '' '' '' ', 'a=b, "a=b", '' c ''''''';
-NOTICE: send query to shard(s) : sh3
         ?column?        |      ?column?       
 ------------------------+---------------------
  a=b, "a=b", ' c ' ' '  | a=b, "a=b", ' c '''

--- a/test/regress/tests/router/expected/target_list_routing.out
+++ b/test/regress/tests/router/expected/target_list_routing.out
@@ -78,6 +78,12 @@ NOTICE: send query to shard(s) : sh1
 
 /* test quoted sconsts. XXX: find a better place for that */
 SELECT 'a=b, "a=b", '' c '' '' '' ', 'a=b, "a=b", '' c ''''''';
+NOTICE: send query to shard(s) : sh3
+        ?column?        |      ?column?       
+------------------------+---------------------
+ a=b, "a=b", ' c ' ' '  | a=b, "a=b", ' c '''
+(1 row)
+
 SELECT 'a=b, "a=b", '' c '' '' '' ', 'a=b, "a=b", '' c ''''''' /* __spqr__.execute_on: sh3 */;
 NOTICE: send query to shard(s) : sh3
         ?column?        |      ?column?       

--- a/test/regress/tests/router/sql/routing_hint.sql
+++ b/test/regress/tests/router/sql/routing_hint.sql
@@ -21,6 +21,9 @@ INSERT INTO test(id, age) VALUES (10, 16) /*__spqr__sharding_key: 3000, __spqr__
 CREATE TABLE test_h(id TEXT, age int);
 INSERT INTO test_h(id, age) VALUES ('a1210', 16) /*__spqr__sharding_key: a1210, __spqr__distribution: ds2  */;
 SELECT * FROM test_h /*__spqr__sharding_key: a1210, __spqr__distribution: ds2  */;
+SELECT /* random comment */ * FROM test_h /*__spqr__sharding_key: a1210, __spqr__distribution: ds2  */;
+SELECT /* random: comment */ * FROM test_h /*__spqr__sharding_key: a1210, __spqr__distribution: ds2  */;
+SELECT /* random: comment */ * FROM test_h /* __spqr__execute_on: sh2  */;
 
 INSERT INTO test_h(id, age) VALUES ('a12101', 16) /*__spqr__sharding_key: a12101, __spqr__distribution: ds2  */;
 SELECT * FROM test_h /*__spqr__sharding_key: a12101, __spqr__distribution: ds2  */;

--- a/test/regress/tests/router/sql/target_list_routing.sql
+++ b/test/regress/tests/router/sql/target_list_routing.sql
@@ -28,6 +28,7 @@ select  coalesce((select sum(j) from sh2.tlt1 where i = 1), 0), coalesce((select
 
 /* test quoted sconsts. XXX: find a better place for that */
 
+SELECT 'a=b, "a=b", '' c '' '' '' ', 'a=b, "a=b", '' c ''''''';
 SELECT 'a=b, "a=b", '' c '' '' '' ', 'a=b, "a=b", '' c ''''''' /* __spqr__.execute_on: sh3 */;
 
 DROP SCHEMA sh2 CASCADE;


### PR DESCRIPTION
Some in-query comments may arise from third party application and have thier own semantics. So, do not raize errors or drop spqr-specific hint when meet such comments.