### PR TITLE
add validation for empty shard on client connection

### DIFF
--- a/router/route/route.go
+++ b/router/route/route.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/client"
 	"github.com/pg-sharding/spqr/pkg/config"
 	"github.com/pg-sharding/spqr/pkg/models/kr"
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	"github.com/pg-sharding/spqr/pkg/models/topology"
 	"github.com/pg-sharding/spqr/pkg/pool"
 	"github.com/pg-sharding/spqr/pkg/shard"
@@ -105,8 +106,15 @@ func (r *Route) Params() (shard.ParameterSet, error) {
 		return r.params, nil
 	}
 
+	shardSnap := r.mShardPool.ShardMapping().Snap()
+	if len(shardSnap) == 0 {
+		return shard.ParameterSet{}, spqrerror.New(spqrerror.SPQR_NO_DATASHARD,
+			"no shards configured in the cluster: cannot serve client requests").
+			Hint("Add at least one shard using 'ADD SHARD' or configure shards in the router config file. Run 'SHOW shards' to verify.")
+	}
+
 	var anyK kr.ShardKey
-	for k := range r.mShardPool.ShardMapping().Snap() {
+	for k := range shardSnap {
 		anyK.Name = k
 		break
 	}

--- a/router/route/route_test.go
+++ b/router/route/route_test.go
@@ -4,8 +4,12 @@ import (
 	"sync"
 	"testing"
 
+	mock "github.com/pg-sharding/spqr/pkg/mock/pool"
+	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
+	"github.com/pg-sharding/spqr/pkg/models/topology"
 	"github.com/pg-sharding/spqr/pkg/shard"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestSetParams(t *testing.T) {
@@ -46,4 +50,25 @@ func TestSetParams(t *testing.T) {
 		assert.True(t, r.cachedParams, "cachedParams must be true even for an empty parameter")
 		assert.Empty(t, r.params, "params must be empty")
 	})
+}
+
+func TestParams_EmptyShardMapping(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPool := mock.NewMockMultiShardTSAPool(ctrl)
+	// ShardMapping returns an empty topology — no ConnectionWithTSA call should occur.
+	mockPool.EXPECT().ShardMapping().Return(topology.TopMgrFromMap(map[string]*topology.DataShard{}))
+
+	r := &Route{
+		mShardPool: mockPool,
+	}
+
+	ps, err := r.Params()
+
+	assert.Empty(t, ps)
+	assert.Error(t, err)
+	var spqrErr *spqrerror.SpqrError
+	assert.ErrorAs(t, err, &spqrErr)
+	assert.Equal(t, spqrerror.SPQR_NO_DATASHARD, spqrErr.ErrorCode)
 }


### PR DESCRIPTION
Instead of

```
ERROR: shard with name "" not found
```

the user will see

```
ERROR: no shards configured in the cluster: cannot serve client requests 
HINT: Add at least one shard using 'ADD SHARD' or configure shards in the router config file. Run 'SHOW shards' to verify.` when no shards are configured in the router.
```