### PR TITLE
Remove pg_advisory_lock test from schedule

### DIFF
--- a/test/isolation/schedule
+++ b/test/isolation/schedule
@@ -5,7 +5,6 @@ test: simple_move_subsequent
 test: move_schema_qualify
 test: move_fqn_relations
 test: move_guard_check
-test: pg_advisory_lock
 test: 2pc
 test: 2pc_happy_path_recovery
 test: move_cancel


### PR DESCRIPTION
Removed 'pg_advisory_lock' test from the schedule.

Will be restored https://github.com/pg-sharding/spqr/issues/2757