### PR TITLE
Reset spqrguard state after flux regression test

### DIFF
--- a/test/regress/tests/router/expected/flux.out
+++ b/test/regress/tests/router/expected/flux.out
@@ -88,3 +88,10 @@ SELECT __spqr__console_execute('UNLOCK KEY RANGE k0; DROP DISTRIBUTION ALL CASCA
  d
 (1 row)
 
+SELECT set_config('spqrguard.prevent_distributed_table_modify', 'off', false) /* __spqr__execute_on: sh1 */;
+NOTICE: send query to shard(s) : sh1
+ set_config 
+------------
+ off
+(1 row)
+

--- a/test/regress/tests/router/sql/flux.sql
+++ b/test/regress/tests/router/sql/flux.sql
@@ -30,3 +30,5 @@ DROP TABLE flux_access_t1;
 DELETE FROM spqr_metadata.spqr_local_key_ranges  /* __spqr__execute_on: sh1 */;
 
 SELECT __spqr__console_execute('UNLOCK KEY RANGE k0; DROP DISTRIBUTION ALL CASCADE');
+
+SELECT set_config('spqrguard.prevent_distributed_table_modify', 'off', false) /* __spqr__execute_on: sh1 */;


### PR DESCRIPTION
Adds an explicit shard-side teardown to `flux` so its session-level spqrguard override does not leak into `autoprotect_2pc` under transaction pooling. Docker regression confirmed that `autoprotect_2pc` passes after the reset, and the `flux` expected output is updated accordingly. Fixes #2696. Fixes #2701.