### PR TITLE
Pass origin value to generic GUC set function

### DIFF
--- a/router/relay/qstate.go
+++ b/router/relay/qstate.go
@@ -709,7 +709,7 @@ func (rst *RelayStateImpl) processSpqrHint(_ context.Context,
 				return err
 			}
 
-			guc.Set(rst.Client(), lvl, value)
+			guc.Set(rst.Client(), lvl, hintVal)
 		} else {
 
 			switch name {

--- a/test/regress/tests/router/expected/pg_advisory_lock.out
+++ b/test/regress/tests/router/expected/pg_advisory_lock.out
@@ -3,7 +3,7 @@ SET __spqr__advisory_lock_behaviour TO SCATTER;
 SHOW __spqr__advisory_lock_behaviour;
  advisory lock behaviour 
 -------------------------
- scatter
+ SCATTER
 (1 row)
 
 SET __spqr__engine_v2 TO off;
@@ -17,7 +17,7 @@ SET __spqr__advisory_lock_behaviour TO BLOCK;
 SHOW __spqr__advisory_lock_behaviour;
  advisory lock behaviour 
 -------------------------
- block
+ BLOCK
 (1 row)
 
 SELECT pg_advisory_lock(11);


### PR DESCRIPTION
Generally speaking its GUC's assign hook business to deal with upper-lower case etc.