### PR TITLE
Fix index out of range panic when parsing shard host address

### DIFF
--- a/pkg/config/data_transfers.go
+++ b/pkg/config/data_transfers.go
@@ -49,11 +49,20 @@ func LoadShardDataCfg(cfgPath string) (*DatatransferConnections, error) {
 	return s, nil
 }
 
+// SplitHostPort splits a "host:port" string into host and port components.
+// If no port is provided, defaults to "5432".
+func SplitHostPort(hostPort string) (host, port string) {
+	parts := strings.SplitN(hostPort, ":", 2)
+	if len(parts) < 2 || parts[1] == "" {
+		return parts[0], "5432"
+	}
+	return parts[0], parts[1]
+}
+
 func (sc *ShardConnect) GetConnStrings() []string {
 	res := make([]string, len(sc.Hosts))
 	for i, h := range sc.Hosts {
-		hostname := strings.Split(h, ":")[0]
-		port := strings.Split(h, ":")[1]
+		hostname, port := SplitHostPort(h)
 		res[i] = fmt.Sprintf("user=%s host=%s port=%s dbname=%s password=%s", sc.User, hostname, port, sc.DB, sc.Password)
 	}
 	return res
@@ -63,8 +72,9 @@ func (sc *ShardConnect) GetCombinedConnString() string {
 	hosts := make([]string, len(sc.Hosts))
 	ports := make([]string, len(sc.Hosts))
 	for i, h := range sc.Hosts {
-		hosts[i] = strings.Split(h, ":")[0]
-		ports[i] = strings.Split(h, ":")[1]
+		hostname, port := SplitHostPort(h)
+		hosts[i] = hostname
+		ports[i] = port
 	}
 	return fmt.Sprintf("user=%s host=%s port=%s dbname=%s password=%s", sc.User, strings.Join(hosts, ","), strings.Join(ports, ","), sc.DB, sc.Password)
 }

--- a/pkg/datatransfers/util.go
+++ b/pkg/datatransfers/util.go
@@ -3,7 +3,6 @@ package datatransfers
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	pgx "github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/tracelog"
@@ -26,8 +25,7 @@ func GetConnStrings(s *config.ShardConnect, applicationName string) map[string]s
 	}
 	res := make(map[string]string)
 	for _, host := range s.Hosts {
-		address := strings.Split(host, ":")[0]
-		port := strings.Split(host, ":")[1]
+		address, port := config.SplitHostPort(host)
 		res[host] = fmt.Sprintf("user=%s host=%s port=%s dbname=%s password=%s application_name=%s", s.User, address, port, s.DB, s.Password, applicationName)
 	}
 	return res
@@ -81,11 +79,8 @@ func GetMasterHost(ctx context.Context, s *config.ShardConnect) (string, error) 
 			return "", err
 		}
 		if isMaster {
-			parts := strings.Split(host, ":")
-			if len(parts) == 0 {
-				return "", fmt.Errorf("malformed host address: missing port")
-			}
-			return parts[0], nil
+			host, _ := config.SplitHostPort(host)
+			return host, nil
 		}
 	}
 	return "", spqrerror.New(spqrerror.SPQR_TRANSFER_ERROR, "unable to find master")


### PR DESCRIPTION
```
panic: runtime error: index out of range [1] with length 1                                       
                                                                                                   
  goroutine 22 [running]:                                                                          
  github.com/pg-sharding/spqr/pkg/datatransfers.GetConnStrings(0x17096fe7ce10, {0x17096fd80880,    
  0x1d})                                                                                           
          /root/build/spqr/pkg/datatransfers/util.go:30 +0x4cd                                     
  github.com/pg-sharding/spqr/pkg/datatransfers.GetMasterConnection({0x1dbb7f0, 0x297f5e0},        
  0x17096fe7ce10, {0x1cfb818, 0xf})                                                                
          /root/build/spqr/pkg/datatransfers/util.go:51 +0xbf                                      
  github.com/pg-sharding/spqr/pkg/datatransfers.TraverseShards.func1({0x1dbb7f0, 0x297f5e0})       
          /root/build/spqr/pkg/datatransfers/data_transfers.go:1016 +0x6f                          
  github.com/sethvargo/go-retry.DoValue[...]({0x1dbb7f0, 0x297f5e0}, {0x1da7aa0, 0x17096fe77cb0},  
  0x17096fde9640)                                                                                  
          /root/build/spqr/vendor/github.com/sethvargo/go-retry/retry.go:61 +0x103                 
  github.com/pg-sharding/spqr/pkg/datatransfers.TraverseShards({0x1dbb7f0, 0x297f5e0},             
  0x17096fc25c00)                                                                                  
          /root/build/spqr/pkg/datatransfers/data_transfers.go:1015 +0x22c                         
  github.com/pg-sharding/spqr/coordinator/pkg.(*ClusteredCoordinator).setUpSPQRGuard(0x17096fd7e64 
  0, {0x1dbb7f0, 0x297f5e0})                                                                       
          /root/build/spqr/coordinator/pkg/clustered_coord.go:773 +0x574                           
  github.com/pg-sharding/spqr/coordinator/pkg.(*ClusteredCoordinator).RunCoordinator(0x17096fd7e64 
  0, {0x1dbb7f0, 0x297f5e0}, 0x0)                                                                  
          /root/build/spqr/coordinator/pkg/clustered_coord.go:675 +0xbd4                           
  created by github.com/pg-sharding/spqr/coordinator/app.(*App).Run in goroutine 1                 
          /root/build/spqr/coordinator/app/app.go:72 +0x411 
```