### PR TITLE
Replace plain-text log output with structured JSON logging in `cmd/`

### DIFF
--- a/cmd/balancer/main.go
+++ b/cmd/balancer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/pg-sharding/spqr/balancer/app"
 	"github.com/pg-sharding/spqr/balancer/provider"
@@ -24,14 +23,14 @@ var rootCmd = &cobra.Command{
 		DisableDefaultCmd: true,
 	},
 	Version:       pkg.SpqrVersionRevision,
-	SilenceUsage:  false,
-	SilenceErrors: false,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		cfgStr, err := config.LoadBalancerCfg(cfgPath)
 		if err != nil {
 			return err
 		}
-		log.Println("Running config:", cfgStr)
+		spqrlog.Zero.Info().Str("config", cfgStr).Msg("running config")
 
 		// TODO add config.BalancerConfig().LogFileName
 		spqrlog.ReloadLogger("", config.BalancerConfig().LogLevel, false, false)

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"net/http"
 	"os"
@@ -50,14 +49,14 @@ var rootCmd = &cobra.Command{
 		DisableDefaultCmd: true,
 	},
 	Version:       pkg.SpqrVersionRevision,
-	SilenceUsage:  false,
-	SilenceErrors: false,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cfgStr, err := config.LoadCoordinatorCfg(cfgPath)
 		if err != nil {
 			return err
 		}
-		log.Println("Running config:", cfgStr)
+		spqrlog.Zero.Info().Str("config", cfgStr).Msg("running config")
 
 		if config.CoordinatorConfig().EnableRoleSystem {
 			if config.CoordinatorConfig().RolesFile == "" {
@@ -67,7 +66,7 @@ var rootCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			log.Println("Running roles config:", rolesCfgStr)
+			spqrlog.Zero.Info().Str("config", rolesCfgStr).Msg("running roles config")
 		}
 
 		if logLevel != "" {
@@ -124,7 +123,9 @@ var rootCmd = &cobra.Command{
 		app := app.NewApp(coordinator)
 		// run pprof without wait group
 		go func() {
-			log.Println(http.ListenAndServe("localhost:6060", nil))
+			if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+				spqrlog.Zero.Error().Err(err).Msg("pprof server failed")
+			}
 		}()
 		return app.Run(true)
 	},

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"slices"
 	"strings"
@@ -40,8 +39,8 @@ var (
 			DisableDefaultCmd: true,
 		},
 		Version:       pkg.SpqrVersionRevision,
-		SilenceUsage:  false,
-		SilenceErrors: false,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	checkCmd = &cobra.Command{
@@ -203,7 +202,7 @@ var (
 			if err := checkUnlockKeyRange(ctx, db, keyRange, ds, shardToConn, shardFromConn); err != nil {
 				return err
 			}
-			log.Printf("key range \"%s\" is safe to unlock\n", keyRangeId)
+			spqrlog.Zero.Info().Str("key_range_id", keyRangeId).Msg("key range is safe to unlock")
 			return nil
 		},
 	}
@@ -482,15 +481,15 @@ func processKeyRange(ctx context.Context, db *qdb.EtcdQDB, keyRangeService proto
 		return fmt.Errorf("distribution \"%s\" not found in map", keyRange.Distribution)
 	}
 	if err := checkUnlockKeyRange(ctx, db, keyRange, ds, toConnCfg, fromConnCfg); err != nil {
-		log.Printf("key range not safe to unlock: %s", err)
+		spqrlog.Zero.Warn().Err(err).Msg("key range not safe to unlock")
 		return nil
 	}
 	if dryRun {
-		log.Printf("key range to unlock: \"%s\"", keyRange.ID)
+		spqrlog.Zero.Info().Str("key_range_id", keyRange.ID).Msg("key range to unlock (dry run)")
 		return nil
 	}
 	if err := db.TryTaskGroupLock(ctx, taskGroupId, "spqr-monitor recover"); err != nil {
-		log.Printf("failed to lock task group \"%s\", skipping...\n", taskGroupId)
+		spqrlog.Zero.Warn().Str("task_group_id", taskGroupId).Msg("failed to lock task group, skipping")
 		return nil
 	}
 	if _, err := keyRangeService.UnlockKeyRange(ctx, &protos.UnlockKeyRangeRequest{Id: []string{keyRange.ID}}); err != nil {
@@ -528,6 +527,12 @@ func processKeyRange(ctx context.Context, db *qdb.EtcdQDB, keyRangeService proto
 		return err
 	}
 
-	log.Printf("deleting task group \"%s\". source key range: \"%s\", dest key range: \"%s\", state: \"%s\", error msg: \"%s\"", taskGroupId, taskGroup.KrIdFrom, taskGroup.KrIdTo, status.State, status.Message)
+	spqrlog.Zero.Info().
+		Str("task_group_id", taskGroupId).
+		Str("source_key_range", taskGroup.KrIdFrom).
+		Str("dest_key_range", taskGroup.KrIdTo).
+		Str("state", status.State).
+		Str("error_msg", status.Message).
+		Msg("deleting task group")
 	return db.DropMoveTaskGroup(ctx, taskGroupId)
 }

--- a/cmd/redistributor/main.go
+++ b/cmd/redistributor/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/datatransfers"
 	"github.com/pg-sharding/spqr/pkg/models/kr"
 	protos "github.com/pg-sharding/spqr/pkg/protos"
+	"github.com/pg-sharding/spqr/pkg/spqrlog"
 	"github.com/pg-sharding/spqr/qdb"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -39,8 +39,8 @@ var (
 			DisableDefaultCmd: true,
 		},
 		Version:       pkg.SpqrVersionRevision,
-		SilenceUsage:  false,
-		SilenceErrors: false,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	generateTaskCmd = &cobra.Command{
@@ -49,7 +49,7 @@ var (
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := generateTask(nil, nil); err != nil {
 				if errors.Is(err, AlreadyDoneError{}) {
-					log.Printf("%s\n", err)
+					spqrlog.Zero.Info().Err(err).Msg("task already done")
 					return nil
 				}
 				return err
@@ -68,10 +68,10 @@ var (
 			for range ticker.C {
 				if err := generateTask(nil, nil); err != nil {
 					if errors.Is(err, AlreadyDoneError{}) {
-						log.Printf("%s\n", err)
+						spqrlog.Zero.Info().Err(err).Msg("task already done")
 						return nil
 					}
-					log.Printf("error generating task, exiting: %s\n", err)
+					spqrlog.Zero.Error().Err(err).Msg("error generating task, exiting")
 					return err
 				}
 			}
@@ -148,7 +148,7 @@ func generateTask(_ *cobra.Command, _ []string) error {
 	taskCount := 0
 	for _, task := range tasks {
 		if task.KeyRangeID == keyRangeID {
-			log.Printf("key range \"%s\" is already being redistributed, not doing anything\n", keyRangeID)
+			spqrlog.Zero.Info().Str("key_range_id", keyRangeID).Msg("key range is already being redistributed, not doing anything")
 			return nil
 		}
 		if task.ShardID == shardToID {
@@ -156,7 +156,7 @@ func generateTask(_ *cobra.Command, _ []string) error {
 		}
 	}
 	if taskCount >= maxRedistributeTasks {
-		log.Println("redistribute tasks limit reached, not doing anything")
+		spqrlog.Zero.Info().Msg("redistribute tasks limit reached, not doing anything")
 		return nil
 	}
 	nextBound, err := datatransfers.ResolveNextBound(ctx, keyRange, &c)
@@ -169,7 +169,7 @@ func generateTask(_ *cobra.Command, _ []string) error {
 	keyRangeToRedistribute := keyRange.ID
 	newBound := max(nextBoundInt-int64(chunkSize), curBound)
 	if dryRun {
-		log.Printf("redistribute key range with bound %d\n", newBound)
+		spqrlog.Zero.Info().Int64("bound", newBound).Msg("redistribute key range (dry run)")
 		return nil
 	}
 
@@ -179,7 +179,7 @@ func generateTask(_ *cobra.Command, _ []string) error {
 		buf := make([]byte, binary.MaxVarintLen64)
 		binary.PutVarint(buf, newBound)
 		newKeyRangeID := uuid.NewString()
-		log.Printf("splitting key range \"%s\" by %d\n", newKeyRangeID, newBound)
+		spqrlog.Zero.Info().Str("key_range_id", newKeyRangeID).Int64("bound", newBound).Msg("splitting key range")
 		if _, err := krService.SplitKeyRange(ctx, &protos.SplitKeyRangeRequest{
 			NewId:    newKeyRangeID,
 			SourceId: keyRange.ID,
@@ -189,7 +189,7 @@ func generateTask(_ *cobra.Command, _ []string) error {
 		}
 		keyRangeToRedistribute = newKeyRangeID
 	}
-	log.Printf("redistributing key range \"%s\"\n", keyRangeToRedistribute)
+	spqrlog.Zero.Info().Str("key_range_id", keyRangeToRedistribute).Msg("redistributing key range")
 	_, err = krService.RedistributeKeyRange(ctx, &protos.RedistributeKeyRangeRequest{
 		Krid:      keyRangeToRedistribute,
 		BatchSize: int64(batchSize),

--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
 	"math"
 	"net/http"
 	_ "net/http/pprof"
@@ -73,8 +72,8 @@ var (
 			DisableDefaultCmd: true,
 		},
 		Version:       pkg.SpqrVersionRevision,
-		SilenceUsage:  false,
-		SilenceErrors: false,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	startupOverrides Overrides
@@ -177,7 +176,7 @@ var runCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			log.Println("Running roles config:", rolesCfgStr)
+			spqrlog.Zero.Info().Str("config", rolesCfgStr).Msg("running roles config")
 		}
 
 		startupOverrides = collectOverrides(rootCmd)
@@ -206,7 +205,7 @@ var runCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			log.Println("Running coordinator config:", cfgStr)
+			spqrlog.Zero.Info().Str("config", cfgStr).Msg("running coordinator config")
 		}
 
 		if console && daemonize {
@@ -224,7 +223,7 @@ var runCmd = &cobra.Command{
 
 			d, err := ctx.Reborn()
 			if err != nil {
-				log.Fatal("Unable to run: ", err)
+				spqrlog.Zero.Fatal().Err(err).Msg("unable to run")
 			}
 			if d != nil {
 				return nil
@@ -491,7 +490,9 @@ var runCmd = &cobra.Command{
 
 		// run pprof without wait group
 		go func() {
-			log.Println(http.ListenAndServe("localhost:6060", nil))
+			if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+				spqrlog.Zero.Error().Err(err).Msg("pprof server failed")
+			}
 		}()
 
 		wg.Wait()

--- a/cmd/router/override.go
+++ b/cmd/router/override.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"os"
 	"strconv"
 	"strings"
 
 	"github.com/pg-sharding/spqr/pkg/config"
+	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
 
@@ -153,10 +154,17 @@ func ApplyOverrides(cfg *config.Router, ov Overrides, qdbImpl string) error {
 }
 
 func logEffectiveConfig(cfg *config.Router) error {
-	configBytes, err := json.MarshalIndent(cfg, "", "  ")
+	configBytes, err := json.Marshal(cfg)
 	if err != nil {
 		return err
 	}
-	log.Println("Running config:", string(configBytes))
+	// Write synchronously to os.Stderr, bypassing the global spqrlog.Zero logger.
+	// After SIGHUP, spqrlog.Zero uses an async diode writer that may delay output
+	// indefinitely, breaking tools that watch the log for this message.
+	var w = zerolog.New(os.Stderr).With().Timestamp().Logger()
+	if cfg.PrettyLogging {
+		w = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().Timestamp().Logger()
+	}
+	w.Info().RawJSON("config", configBytes).Msg("running config")
 	return nil
 }

--- a/test/cli/override.sh
+++ b/test/cli/override.sh
@@ -44,16 +44,16 @@ echo "[i] Logs:          $LOG"
 
 # --- Helpers ---
 
-# Count how many times the log contains the "Running config:" marker
+# Count how many times the log contains the "running config" marker
 count_configs() {
   if [[ -f "$LOG" ]]; then
-    grep -c 'Running config:' "$LOG" || echo 0
+    grep -c 'running config' "$LOG" || echo 0
   else
     echo 0
   fi
 }
 
-# Wait until the number of "Running config:" occurrences reaches target_count
+# Wait until the number of "running config" occurrences reaches target_count
 # Arguments:
 #   $1 target_count
 #   $2 timeout_s (optional, default 10s)
@@ -73,33 +73,24 @@ wait_for_new_config() {
     fi
     sleep 0.2
   done
-  echo "[!] Timeout waiting for Running config (#$target_count)" >&2
+  echo "[!] Timeout waiting for running config (#$target_count)" >&2
   cat $LOG
   return 1
 }
 
-# Extract the JSON blob printed after the latest "Running config:" entry.
+# Extract the config JSON from the latest "running config" structured log entry.
+# Handles both JSON log format and pretty-log (console) format.
+# Strips ANSI escape codes before parsing.
 extract_last_config_json() {
-    awk '
-    /Running config:/ {
-    # стартуем с первой "{" в этой строке
-    p = index($0, "{")
-    if (p) {
-        out = 1; depth = 0
-        s = substr($0, p)
-        print s
-        depth += gsub(/\{/, "&", s)
-        depth -= gsub(/\}/, "&", s)
-        next
-    }
-    }
-    out {
-    print
-    depth += gsub(/\{/, "&")
-    depth -= gsub(/\}/, "&")
-    if (depth == 0) exit
-    }
-    ' "$LOG"
+    local line
+    line="$(grep 'running config' "$LOG" | tail -1 | sed 's/\x1b\[[0-9;]*m//g')"
+    if echo "$line" | jq -e '.config' >/dev/null 2>&1; then
+        # JSON log format: {"level":"info","config":{...},"message":"running config"}
+        echo "$line" | jq -r '.config'
+    else
+        # Pretty-log format: 5:09PM INF running config config={...}
+        echo "$line" | sed 's/.*config=//'
+    fi
 }
 
 assert_eq() {
@@ -154,9 +145,9 @@ PID=$!
 set -e
 echo "$PID" >"$PID_FILE"
 
-# 1) Wait for the first "Running config" occurrence (startup)
+# 1) Wait for the first "running config" occurrence (startup)
 target=1
-echo "[i] Waiting for Running config #$target..."
+echo "[i] Waiting for running config #$target..."
 wait_for_new_config "$target" 15
 
 # Parse and assert startup effective config
@@ -168,12 +159,12 @@ fi
 echo "[i] Asserting startup effective config..."
 check_effective_config "$JSON"
 
-# 2) Send SIGHUP and expect another "Running config" (reload)
+# 2) Send SIGHUP and expect another "running config" (reload)
 echo "[i] Sending SIGHUP..."
 kill -HUP "$PID" 2>/dev/null || true
 
 target=$((target+1))
-wait_for_new_config "$target" 10
+wait_for_new_config "$target" 15
 
 # Parse and assert post-SIGHUP effective config (overrides should persist)
 JSON2="$(extract_last_config_json)"


### PR DESCRIPTION
When a config file has invalid YAML, the router log output looks like this:

```
"identity_range_size": 0,2026/08/05 15:41:20 Running config: {
  ...
}
Error: yaml: line 15: could not find expected ':'
Usage:
  spqr-router run [flags]
...
{"level":"fatal","error":"yaml: line 15: could not find expected ':'","time":"..."}
```

Plain-text lines from `log.Println` and cobra's default error/usage printing
break downstream JSON log parsers in production.
