### PR TITLE
Stabilize await-pids timeout assertion without accepting legacy errors

### DIFF
--- a/test/feature/features/redistribute.feature
+++ b/test/feature/features/redistribute.feature
@@ -1879,7 +1879,7 @@ Feature: Redistribution test
     Then command return code should be "1"
     And SQL error on host "coordinator" should match regexp
     """
-    ERROR: failed to await virtual transactions to exit: timeout: context already done: context deadline exceeded \(SQLSTATE SPQRt\)
+    ERROR: failed to await virtual transactions to exit: .*context deadline exceeded \(SQLSTATE SPQRt\)
     """
     When I run SQL on host "coordinator"
     """


### PR DESCRIPTION
## Summary

- relax only the unstable pgx diagnostic text in the await-pids timeout assertion
- continue requiring the direct `failed to await virtual transactions to exit` error
- continue requiring `context deadline exceeded` and the recoverable `SPQRt` SQLSTATE
- do not accept the legacy `failed to move keys` wrapper, generic recoverable message, or `SPQRT`

## Root cause

The three failures grouped by #2804 occurred on three consecutive master revisions while move-key error handling and its test expectation were changing:

- `89c245f` introduced a malformed regexp with unescaped literal parentheses
- `e870b93` changed the recoverable error representation without updating the assertion
- `7da3d71` ran with the same stale assertion

Those historical outputs are not nondeterministic variants of the current contract. PRs #2792 and #2797 subsequently aligned the assertion and made the coordinator return the original recoverable `SPQRt` error without the outer `failed to move keys` wrapper.

The current assertion still overfits the pgx wording `timeout: context already done:`. This change ignores only that unstable diagnostic prefix while preserving the semantic timeout cause and error classification. It is intentionally narrower than #2870 so a regression to the legacy wrapper or `SPQRT` remains visible.

## Impact

The scenario remains strict about the behavior under test: await-pids must fail because its context deadline is exceeded, and the failure must remain recoverable. Only incidental wording between the operation name and timeout cause may vary.

## Validation

- `go test ./test/feature/testutil/matchers`
- `git diff --check`
- exercised the regexp with Go's regexp engine:
  - accepted both observed `context already done: context deadline exceeded` and direct `context deadline exceeded` forms
  - rejected the legacy wrapper, generic recoverable message, and uppercase `SPQRT` forms

Fixes #2804
