### PR TITLE
Fix config typo in regress tests

### DIFF
--- a/test/regress/conf/router.yaml
+++ b/test/regress/conf/router.yaml
@@ -28,10 +28,14 @@ frontend_rules:
   - db: regress
     usr: regress
     pool_mode: TRANSACTION
+    pool_discard: true
+    pool_rollback: true
     auth_rule:
       auth_method: ok
   - pool_mode: TRANSACTION
     pool_default: true
+    pool_discard: true
+    pool_rollback: true
     pool_prepared_statement: false
     auth_rule:
       auth_method: ok
@@ -73,8 +77,6 @@ backend_rules:
   - db: regress
     usr: regress
     connection_limit: 50
-    pool_discard: true
-    pool_rollback: true
     auth_rules:
       sh1:
         auth_method: md5


### PR DESCRIPTION
Move pool_discard and pool_rollback options to `frontend_rules` in router.yaml

https://github.com/pg-sharding/spqr/blob/master/pkg/config/rules.go

possible fix of https://github.com/pg-sharding/spqr/actions/runs/32032326095/job/95399980197?pr=2893