### PR TITLE
feat(coordinator): add run subcommand

### DIFF
--- a/cmd/coordinator/init_test.go
+++ b/cmd/coordinator/init_test.go
@@ -33,3 +33,12 @@ func TestGetMaxTxnBatchSize(t *testing.T) {
 		is.Equal(uint16(qdb.DefaultMaxTxnSize), actual)
 	})
 }
+
+func TestCoordinatorRunCommand(t *testing.T) {
+	command, args, err := rootCmd.Find([]string{"run"})
+
+	assert.NoError(t, err)
+	assert.Same(t, runCmd, command)
+	assert.Empty(t, args)
+	assert.NotNil(t, rootCmd.RunE, "the root command should keep supporting direct startup")
+}

--- a/cmd/coordinator/main.go
+++ b/cmd/coordinator/main.go
@@ -43,7 +43,7 @@ func getMaxTxnBatchSize(configCoord *config.Coordinator) uint16 {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "spqr-coordinator run --config `path-to-config`",
+	Use:   "spqr-coordinator --config `path-to-config`",
 	Short: "spqr-coordinator",
 	Long:  "spqr-coordinator",
 	CompletionOptions: cobra.CompletionOptions{
@@ -132,6 +132,12 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "run coordinator",
+	RunE:  rootCmd.RunE,
+}
+
 var testCmd = &cobra.Command{
 	Use:   "test-config {path-to-config | -c path-to-config}",
 	Short: "Load, validate and print the given config file",
@@ -155,7 +161,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "l", "", "overload for `log_level` option in router config")
 	rootCmd.PersistentFlags().BoolVarP(&prettyLogging, "pretty-log", "P", false, "enables pretty logging")
 
-	rootCmd.AddCommand(testCmd)
+	rootCmd.AddCommand(runCmd, testCmd)
 }
 
 func main() {


### PR DESCRIPTION
## What changed

- add a proper `run` subcommand to `spqr-coordinator`
- reuse the existing startup handler to preserve direct-start compatibility
- add a test covering command resolution and backward compatibility

## Validation

- `go test ./cmd/coordinator`
- Linux build with Go 1.26
- root and `run --help` CLI smoke tests

Closes #1715