### PR TITLE
Reset stmtDef and stmtDesc on discard

### DIFF
--- a/pkg/datashard/datashard.go
+++ b/pkg/datashard/datashard.go
@@ -577,6 +577,8 @@ func (sh *Conn) Cleanup(rule *config.FrontendRule) error {
 		if err := sh.fire("DISCARD ALL"); err != nil {
 			return err
 		}
+        sh.stmtDef = map[uint64]*prepstatement.PreparedStatementDefinition{}
+        sh.stmtDesc = map[uint64]*prepstatement.PreparedStatementDescriptor{}
 	}
 
 	return nil


### PR DESCRIPTION
Initialize stmtDef and stmtDesc maps when PoolDiscard is true.