### PR TITLE
fix: fixed test docker composer linter issue

### DIFF
--- a/test/feature/testutil/docker_composer.go
+++ b/test/feature/testutil/docker_composer.go
@@ -345,8 +345,7 @@ func (dc *DockerComposer) RunAsyncCommand(service string, cmd string) error {
 		return fmt.Errorf("no such service: %s", service)
 	}
 	execCfg := container.ExecOptions{
-		Detach: true,
-		Cmd:    []string{shell, "-c", cmd},
+		Cmd: []string{shell, "-c", cmd},
 	}
 	execResp, err := dc.api.ContainerExecCreate(context.Background(), cont.ID, execCfg)
 	if err != nil {


### PR DESCRIPTION
https://github.com/pg-sharding/spqr/actions/runs/32357251314/job/96388976404?pr=2742
```
  test/feature/testutil/docker_composer.go:348:3: SA1019: (github.com/docker/docker/api/types/container.ExecOptions).Detach is deprecated: the Detach field is not used, and will be removed in a future release. (staticcheck)
  		Detach: true,

```