### PR TITLE
Replace magic numbers with MustFind GUC helpers/predefined indices

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -493,6 +493,7 @@ sconst
 screenshots
 sdnotifier
 seqmgr
+sessiontest
 serviceprincipal
 sethvargo
 sevlyar

--- a/pkg/session/sessiontest/sessiontest.go
+++ b/pkg/session/sessiontest/sessiontest.go
@@ -1,0 +1,19 @@
+package sessiontest
+
+import "github.com/pg-sharding/spqr/pkg/session"
+
+func MustFindBoolGUC(n string) session.BoolGUC {
+	guc, err := session.FindBoolGUC(n)
+	if err != nil {
+		panic(err)
+	}
+	return guc
+}
+
+func MustFindStrGUC(n string) session.StrGUC {
+	guc, err := session.FindStrGUC(n)
+	if err != nil {
+		panic(err)
+	}
+	return guc
+}

--- a/pkg/session/simple_holder.go
+++ b/pkg/session/simple_holder.go
@@ -656,22 +656,6 @@ func FindStrGUC(n string) (*StrGUCimpl, error) {
 	return nil, fmt.Errorf("unknown GUC: %s", n)
 }
 
-func MustFindBoolGUC(n string) BoolGUC {
-	guc, err := FindBoolGUC(n)
-	if err != nil {
-		panic(err)
-	}
-	return guc
-}
-
-func MustFindStrGUC(n string) StrGUC {
-	guc, err := FindStrGUC(n)
-	if err != nil {
-		panic(err)
-	}
-	return guc
-}
-
 func InitGUCs() {
 	for i := range BoolGUCs {
 		BoolGUCs[i].InitBoot()

--- a/pkg/session/simple_holder.go
+++ b/pkg/session/simple_holder.go
@@ -656,6 +656,22 @@ func FindStrGUC(n string) (*StrGUCimpl, error) {
 	return nil, fmt.Errorf("unknown GUC: %s", n)
 }
 
+func MustFindBoolGUC(n string) BoolGUC {
+	guc, err := FindBoolGUC(n)
+	if err != nil {
+		panic(err)
+	}
+	return guc
+}
+
+func MustFindStrGUC(n string) StrGUC {
+	guc, err := FindStrGUC(n)
+	if err != nil {
+		panic(err)
+	}
+	return guc
+}
+
 func InitGUCs() {
 	for i := range BoolGUCs {
 		BoolGUCs[i].InitBoot()

--- a/router/frontend/frontend_test.go
+++ b/router/frontend/frontend_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/plan"
 	"github.com/pg-sharding/spqr/pkg/prepstatement"
 	"github.com/pg-sharding/spqr/pkg/session"
+	"github.com/pg-sharding/spqr/pkg/session/sessiontest"
 	"github.com/pg-sharding/spqr/pkg/shard"
 	"github.com/pg-sharding/spqr/pkg/txstatus"
 	"github.com/pg-sharding/spqr/router/frontend"
@@ -108,11 +109,11 @@ func TestFrontendSimple(t *testing.T) {
 
 	cl.EXPECT().Server().AnyTimes().Return(srv)
 	cl.EXPECT().Unroute().AnyTimes()
-	cl.EXPECT().FindBoolGUC(gomock.Any()).AnyTimes().Return(session.MustFindBoolGUC(session.SPQR_LINEARIZE_DISPATCH), nil)
-	cl.EXPECT().FindBoolGUC(session.SPQR_MAINTAIN_PARAMS).AnyTimes().Return(session.MustFindBoolGUC(session.SPQR_MAINTAIN_PARAMS), nil)
-	cl.EXPECT().FindStrGUC(session.SPQR_EXECUTE_ON).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_EXECUTE_ON), nil)
-	cl.EXPECT().FindStrGUC(session.SPQR_SHARDING_KEY).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_SHARDING_KEY), nil)
-	cl.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
+	cl.EXPECT().FindBoolGUC(gomock.Any()).AnyTimes().Return(sessiontest.MustFindBoolGUC(session.SPQR_LINEARIZE_DISPATCH), nil)
+	cl.EXPECT().FindBoolGUC(session.SPQR_MAINTAIN_PARAMS).AnyTimes().Return(sessiontest.MustFindBoolGUC(session.SPQR_MAINTAIN_PARAMS), nil)
+	cl.EXPECT().FindStrGUC(session.SPQR_EXECUTE_ON).AnyTimes().Return(sessiontest.MustFindStrGUC(session.SPQR_EXECUTE_ON), nil)
+	cl.EXPECT().FindStrGUC(session.SPQR_SHARDING_KEY).AnyTimes().Return(sessiontest.MustFindStrGUC(session.SPQR_SHARDING_KEY), nil)
+	cl.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(sessiontest.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
 	cl.EXPECT().ResolveVirtualBoolParam(gomock.Any(), gomock.Any()).AnyTimes().Return(false)
 	cl.EXPECT().ResolveVirtualStringParam(session.SPQR_EXECUTE_ON, gomock.Any()).AnyTimes().Return("")
 	cl.EXPECT().ResolveVirtualStringParam(session.SPQR_SHARDING_KEY, gomock.Any()).AnyTimes().Return("")
@@ -242,7 +243,7 @@ func TestFrontendXProto(t *testing.T) {
 
 	qr.EXPECT().DataShardsRoutes().AnyTimes().Return([]kr.ShardKey{{Name: "sh1"}})
 
-	cl.EXPECT().FindBoolGUC(session.SPQR_MAINTAIN_PARAMS).AnyTimes().Return(session.MustFindBoolGUC(session.SPQR_MAINTAIN_PARAMS), nil)
+	cl.EXPECT().FindBoolGUC(session.SPQR_MAINTAIN_PARAMS).AnyTimes().Return(sessiontest.MustFindBoolGUC(session.SPQR_MAINTAIN_PARAMS), nil)
 	cl.EXPECT().ResolveVirtualBoolParam(session.SPQR_MAINTAIN_PARAMS, gomock.Any()).AnyTimes()
 
 	cl.EXPECT().GetTsa().AnyTimes()

--- a/router/frontend/frontend_test.go
+++ b/router/frontend/frontend_test.go
@@ -108,11 +108,11 @@ func TestFrontendSimple(t *testing.T) {
 
 	cl.EXPECT().Server().AnyTimes().Return(srv)
 	cl.EXPECT().Unroute().AnyTimes()
-	cl.EXPECT().FindBoolGUC(gomock.Any()).AnyTimes().Return(session.BoolGUCs[2], nil)
-	cl.EXPECT().FindBoolGUC(session.SPQR_MAINTAIN_PARAMS).AnyTimes().Return(session.BoolGUCs[7], nil)
-	cl.EXPECT().FindStrGUC(session.SPQR_EXECUTE_ON).AnyTimes().Return(session.StrGUCs[3], nil)
-	cl.EXPECT().FindStrGUC(session.SPQR_SHARDING_KEY).AnyTimes().Return(session.StrGUCs[4], nil)
-	cl.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.StrGUCs[6], nil)
+	cl.EXPECT().FindBoolGUC(gomock.Any()).AnyTimes().Return(session.MustFindBoolGUC(session.SPQR_LINEARIZE_DISPATCH), nil)
+	cl.EXPECT().FindBoolGUC(session.SPQR_MAINTAIN_PARAMS).AnyTimes().Return(session.MustFindBoolGUC(session.SPQR_MAINTAIN_PARAMS), nil)
+	cl.EXPECT().FindStrGUC(session.SPQR_EXECUTE_ON).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_EXECUTE_ON), nil)
+	cl.EXPECT().FindStrGUC(session.SPQR_SHARDING_KEY).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_SHARDING_KEY), nil)
+	cl.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
 	cl.EXPECT().ResolveVirtualBoolParam(gomock.Any(), gomock.Any()).AnyTimes().Return(false)
 	cl.EXPECT().ResolveVirtualStringParam(session.SPQR_EXECUTE_ON, gomock.Any()).AnyTimes().Return("")
 	cl.EXPECT().ResolveVirtualStringParam(session.SPQR_SHARDING_KEY, gomock.Any()).AnyTimes().Return("")
@@ -242,7 +242,7 @@ func TestFrontendXProto(t *testing.T) {
 
 	qr.EXPECT().DataShardsRoutes().AnyTimes().Return([]kr.ShardKey{{Name: "sh1"}})
 
-	cl.EXPECT().FindBoolGUC(session.SPQR_MAINTAIN_PARAMS).AnyTimes().Return(session.BoolGUCs[7], nil)
+	cl.EXPECT().FindBoolGUC(session.SPQR_MAINTAIN_PARAMS).AnyTimes().Return(session.MustFindBoolGUC(session.SPQR_MAINTAIN_PARAMS), nil)
 	cl.EXPECT().ResolveVirtualBoolParam(session.SPQR_MAINTAIN_PARAMS, gomock.Any()).AnyTimes()
 
 	cl.EXPECT().GetTsa().AnyTimes()

--- a/router/relay/qstate_test.go
+++ b/router/relay/qstate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pg-sharding/spqr/pkg/models/spqrerror"
 	"github.com/pg-sharding/spqr/pkg/plan"
 	"github.com/pg-sharding/spqr/pkg/session"
+	"github.com/pg-sharding/spqr/pkg/session/sessiontest"
 	"github.com/pg-sharding/spqr/qdb"
 	mockcl "github.com/pg-sharding/spqr/router/mock/client"
 	mockcmgr "github.com/pg-sharding/spqr/router/mock/poolmgr"
@@ -27,7 +28,7 @@ func TestAutoDistributionSetFail(t *testing.T) {
 	client := mockcl.NewMockRouterClient(ctrl)
 	client.EXPECT().CleanupStatementSet().AnyTimes()
 
-	client.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
+	client.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(sessiontest.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
 	client.EXPECT().ResolveVirtualStringParam(session.SPQR_DISTRIBUTION_KEY, gomock.Any()).AnyTimes().Return("i")
 
 	qr := mockqr.NewMockQueryRouter(ctrl)
@@ -66,7 +67,7 @@ func TestAutoDistributionSetSuccess(t *testing.T) {
 	client := mockcl.NewMockRouterClient(ctrl)
 	client.EXPECT().CleanupStatementSet().AnyTimes()
 
-	client.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
+	client.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(sessiontest.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
 	client.EXPECT().ResolveVirtualStringParam(session.SPQR_DISTRIBUTION_KEY, gomock.Any()).AnyTimes().Return("i")
 
 	qr := mockqr.NewMockQueryRouter(ctrl)

--- a/router/relay/qstate_test.go
+++ b/router/relay/qstate_test.go
@@ -27,7 +27,7 @@ func TestAutoDistributionSetFail(t *testing.T) {
 	client := mockcl.NewMockRouterClient(ctrl)
 	client.EXPECT().CleanupStatementSet().AnyTimes()
 
-	client.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.StrGUCs[6], nil)
+	client.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
 	client.EXPECT().ResolveVirtualStringParam(session.SPQR_DISTRIBUTION_KEY, gomock.Any()).AnyTimes().Return("i")
 
 	qr := mockqr.NewMockQueryRouter(ctrl)
@@ -66,7 +66,7 @@ func TestAutoDistributionSetSuccess(t *testing.T) {
 	client := mockcl.NewMockRouterClient(ctrl)
 	client.EXPECT().CleanupStatementSet().AnyTimes()
 
-	client.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.StrGUCs[6], nil)
+	client.EXPECT().FindStrGUC(session.SPQR_DISTRIBUTION_KEY).AnyTimes().Return(session.MustFindStrGUC(session.SPQR_DISTRIBUTION_KEY), nil)
 	client.EXPECT().ResolveVirtualStringParam(session.SPQR_DISTRIBUTION_KEY, gomock.Any()).AnyTimes().Return("i")
 
 	qr := mockqr.NewMockQueryRouter(ctrl)


### PR DESCRIPTION
Replace fragile numeric indices (e.g. StrGUCs[6], BoolGUCs[7]) with these helpers.